### PR TITLE
We're a dependency manager, not a package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Carthage
 
-A simple package manager for Cocoa.
+A simple dependency manager for Cocoa.
 
 The goal of Carthage is straightforward: to resolve complex dependency graphs in the simplest way possible, without supplanting or duplicating the existing Cocoa toolchain.
 
 ### Process
 
-The package management process looks like this:
+The dependency management process looks like this:
 
 1. Your project specifies its dependencies, and which versions it will accept
 1. Those dependencies specify their own dependencies in the same way


### PR DESCRIPTION
I think “package manager” is way grander in scope, and not really what we're aspiring to. It'd be great if we never have to maintain a centralized database of packages, for example.

Even if we go down that route eventually, I think “dependency management” is a more accurate description of what we're trying to address.
