### PR TITLE
Xcode.swift: Don't unwrap non-optional

### DIFF
--- a/CarthageKit/Xcode.swift
+++ b/CarthageKit/Xcode.swift
@@ -79,7 +79,7 @@ public func <(lhs: ProjectLocator, rhs: ProjectLocator) -> Bool {
 
 extension ProjectLocator: Printable {
 	public var description: String {
-		return fileURL.lastPathComponent!
+		return fileURL.lastPathComponent
 	}
 }
 


### PR DESCRIPTION
Currently, the build fails with the following error: `Operand of postfix '!' should have optional type; type is 'String'`. The cause is a line in Xcode.swift that attempts to "unwrap" `fileURL.lastPathComponent`. However, the return type of `-[NSURL lastPathComponent]` is `String`, not `String?`, so it cannot be unwrapped.

Remove the unwrapping in order to fix the build.

---

Not sure if it matters, but I'm running Xcode 6.1 (6A1052d) on OS X 10.10 (14A379a).
