### PR TITLE
Add note on dependencies requiring an Xcode project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The goal of CocoaPods is listed in its [README](https://github.com/CocoaPods/Coc
 
 By contrast, Carthage has been created as a _decentralized_ dependency manager. There is no central list of projects, which reduces maintenance work and avoids any central point of failure. However, project discovery is more difficult—users must resort to GitHub’s [Trending](https://github.com/trending?l=swift) pages or similar.
 
-CocoaPods projects must also have what’s known as a [podspec](http://guides.cocoapods.org/syntax/podspec.html) file, which includes metadata about the project and specifies how it should be built. Because Carthage uses `xcodebuild` to build dependencies, instead of integrating them into a single workspace, it doesn’t have a similar specification file.
+CocoaPods projects must also have what’s known as a [podspec](http://guides.cocoapods.org/syntax/podspec.html) file, which includes metadata about the project and specifies how it should be built. Carthage uses `xcodebuild` to build dependencies, instead of integrating them into a single workspace, it doesn’t have a similar specification file but your dependencies must include their own Xcode project that describes how to build their products.
 
 Ultimately, we created Carthage because we wanted the simplest tool possible—a dependency manager that gets the job done without taking over the responsibility of Xcode, and without creating extra work for framework authors. CocoaPods offers many amazing features that Carthage will never have, at the expense of additional complexity.
 


### PR DESCRIPTION
In comparison to CocoaPods, users aren’t used to having to provide an Xcode project which encodes their build settings and produces a build product. When attempting to build such a pod brought in as a dependency, the build fails.

Although “uses `xcodebuild`” does strongly imply that your dependency must include an Xcode project, it might be worth spelling this out.
