### PR TITLE
Join build signals using concat(), not then()

### DIFF
--- a/carthage/Build.swift
+++ b/carthage/Build.swift
@@ -80,7 +80,7 @@ public struct BuildCommand: CommandType {
 			let (currentOutput, currentSignals) = buildInDirectory(directoryURL, withConfiguration: options.configuration)
 			currentOutput.observe(stdoutSink)
 
-			buildSignal = buildSignal.then(currentSignals)
+			buildSignal = buildSignal.concat(currentSignals)
 		}
 
 		return (stdoutSignal, buildSignal)


### PR DESCRIPTION
What a dumb mistake.

Resolves #147.
