### PR TITLE
Explain why the Run Script phase is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
   $(SRCROOT)/Carthage/Build/iOS/LlamaKit.framework
   $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
   ```
+  
+  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries.
 
 ##### For both platforms
 


### PR DESCRIPTION
Without a link to [the radar](http://www.openradar.me/radar?id=6409498411401216), it might not be clear that we're working around an Xcode issue. I want to be clear that it's not a restriction inherent to Carthage itself.
