### PR TITLE
Quick typo fix in readme for Run Script commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
   and add the paths to the frameworks you want to use under “Input Files”, e.g.:
 
   ```
-  $(SRCROOT)/Carthage/Build/iOS/LlamaKit.framework
-  $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
+  "$SRCROOT/Carthage/Build/iOS/LlamaKit.framework"
+  "$SRCROOT/Carthage/Build/iOS/ReactiveCocoa.framework"
   ```
   
   This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries.


### PR DESCRIPTION
The default shell /bin/sh uses $VAR and not $(VAR) for variable substitution – the latter will actually error but Xcode won't notify you unless you go looking for it, so it could easily cause problems for people.

(Also added double quotes for good measure, though they aren't likely needed since hopefully no one has spaces in their framework names.)