### PR TITLE
Fix copy-frameworks help bug

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -38,11 +38,9 @@ public struct CopyFrameworksCommand: CommandType {
 				.concat(identity)
 				.wait()
 
-		default:
-			break
+		case .Usage:
+			return success(())
 		}
-
-		return success(())
 	}
 }
 


### PR DESCRIPTION
Fixes #277:
A bug occurred when calling `carthage help copy-frameworks`. Previously, the CopyFrameworksCommand would ignore the mode argument passed to run() and would attempt to execute the command. This change fixes run() to only execute in Arguments mode.