### PR TITLE
Set DSTROOT to TEMPORARY_FOLDER in XCODEFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-XCODEFLAGS=-workspace 'Carthage.xcworkspace' -scheme 'carthage'
-
-TEMPORARY_FOLDER=/tmp/Carthage.dst
+TEMPORARY_FOLDER?=/tmp/Carthage.dst
 PREFIX?=/usr/local
 BUILD_TOOL?=xcodebuild
+
+XCODEFLAGS=-workspace 'Carthage.xcworkspace' -scheme 'carthage' DSTROOT=$(TEMPORARY_FOLDER)
 
 BUILT_BUNDLE=$(TEMPORARY_FOLDER)/Applications/carthage.app
 CARTHAGEKIT_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/CarthageKit.framework


### PR DESCRIPTION
Without this, overriding `TEMPORARY_FOLDER` will only partially work since Xcode always uses `/tmp/Carthage.dst` as its intermediate built products location (see https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW22).

Supporting overriding `TEMPORARY_FOLDER` also means that a failed homebrew installation can still clean up temporary artifacts (see https://github.com/Homebrew/homebrew/pull/35926#discussion_r23104627).

I've confirmed this also works with `xctool`.