### PR TITLE
Build Option: --verbose 

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -31,6 +31,12 @@ public struct BuildCommand: CommandType {
 
 				let (stdoutSignal, schemeSignals) = self.buildProjectInDirectoryURL(directoryURL, options: options)
 				stdoutSignal.observe { data in
+					if options.verbose {
+						if let outString = NSString(data: data, encoding: NSUTF8StringEncoding) {
+							carthage.print(outString)
+						}
+					}
+
 					stdoutHandle.writeData(data)
 					stdoutHandle.synchronizeFile()
 				}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -116,16 +116,18 @@ public struct BuildCommand: CommandType {
 public struct BuildOptions: OptionsType {
 	public let configuration: String
 	public let skipCurrent: Bool
+	public let verbose: Bool
 	public let directoryPath: String
 
-	public static func create(configuration: String)(skipCurrent: Bool)(directoryPath: String) -> BuildOptions {
-		return self(configuration: configuration, skipCurrent: skipCurrent, directoryPath: directoryPath)
+	public static func create(configuration: String)(skipCurrent: Bool)(verbose: Bool)(directoryPath: String) -> BuildOptions {
+		return self(configuration: configuration, skipCurrent: skipCurrent, verbose: verbose, directoryPath: directoryPath)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<BuildOptions> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build")
 			<*> m <| Option(key: "skip-current", defaultValue: true, usage: "don't skip building the Carthage project (in addition to its dependencies)")
+			<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline")
 			<*> m <| Option(defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")
 	}
 }

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -36,7 +36,7 @@ public struct UpdateOptions: OptionsType {
 
 	/// The build options corresponding to these options.
 	public var buildOptions: BuildOptions {
-		return BuildOptions(configuration: configuration, skipCurrent: true, directoryPath: checkoutOptions.directoryPath)
+		return BuildOptions(configuration: configuration, skipCurrent: true, verbose: false, directoryPath: checkoutOptions.directoryPath)
 	}
 
 	/// If `buildAfterUpdate` is true, this will be a signal representing the


### PR DESCRIPTION
Per #273, the `--verbose` option will print out the xcodebuild log as each build progresses.

 - This doesn't (yet) offer a `--verbose` option for `carthage bootstrap` or `carthage update`. I suspect we'll want that option, since a desired use case for verbose output is with `carthage bootstrap` on a non-interactive Travis CI session, but a verbose option on those commands might also print verbose output from the git clone/checkout stage of the process, so I've left it out for the moment.

 - My solution for tailing the build log was simply to print each line of data from `stdoutSignal` as it's written to the log file. This appears to correctly interleave the build logs with the non-verbose printing from `schemeSignals`. I have only a beginner's understanding of ReactiveCocoa, so if there's a more idiomatic approach I'd love to know what it might be.