### PR TITLE
PrettyColors — Take advantage of the terminal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "Carthage/Checkouts/Argo"]
 	path = Carthage/Checkouts/Argo
 	url = https://github.com/thoughtbot/Argo.git
+[submodule "Carthage/Checkouts/PrettyColors"]
+	path = Carthage/Checkouts/PrettyColors
+	url = https://github.com/jdhealy/PrettyColors.git

--- a/Cartfile
+++ b/Cartfile
@@ -4,4 +4,4 @@ github "jspahrsummers/xcconfigs" >= 0.6
 github "Carthage/Commandant" "master"
 github "Carthage/ReactiveTask" "master"
 github "thoughtbot/Argo" ~> 0.2
-github "jdhealy/PrettyColors" "edf8291df2"
+github "jdhealy/PrettyColors" ~> 1.0.0

--- a/Cartfile
+++ b/Cartfile
@@ -4,3 +4,4 @@ github "jspahrsummers/xcconfigs" >= 0.6
 github "Carthage/Commandant" "master"
 github "Carthage/ReactiveTask" "master"
 github "thoughtbot/Argo" ~> 0.2
+github "jdhealy/PrettyColors" "edf8291df2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "thoughtbot/Argo" "v0.2"
 github "Carthage/LlamaKit" "carthage-0.1.1"
 github "Quick/Nimble" "v0.2.0"
-github "jdhealy/PrettyColors" "edf8291df2f524ed62dcfa60227b988535ccf6eb"
+github "jdhealy/PrettyColors" "v1.0.0"
 github "Quick/Quick" "v0.2.0"
 github "jspahrsummers/xcconfigs" "0.7"
 github "Carthage/Commandant" "2c0384bfa4d0c66ab0ebf5bc48739f9236ea2e0c"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,7 @@
 github "thoughtbot/Argo" "v0.2"
 github "Carthage/LlamaKit" "carthage-0.1.1"
 github "Quick/Nimble" "v0.2.0"
+github "jdhealy/PrettyColors" "edf8291df2f524ed62dcfa60227b988535ccf6eb"
 github "Quick/Quick" "v0.2.0"
 github "jspahrsummers/xcconfigs" "0.7"
 github "Carthage/Commandant" "2c0384bfa4d0c66ab0ebf5bc48739f9236ea2e0c"

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		5482DAF11A3849D700197FB8 /* CopyFrameworks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5482DAF01A3849D700197FB8 /* CopyFrameworks.swift */; };
 		54911EF31A1D34EC00FFAE5F /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54911EF21A1D34EC00FFAE5F /* Version.swift */; };
 		549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */; };
+		67AFA98A1A79430B00B7DA78 /* PrettyColors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67AFA9891A79430B00B7DA78 /* PrettyColors.framework */; };
+		67AFA98B1A79433900B7DA78 /* PrettyColors.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 67AFA9891A79430B00B7DA78 /* PrettyColors.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		88ED56D619ECE34900CBF5C4 /* Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88ED56D519ECE34900CBF5C4 /* Git.swift */; };
 		D00CCE321A20783A00109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; };
 		D00CCE331A20784800109F8C /* Commandant.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -84,6 +86,7 @@
 				D01F8A4519EA28E600643E7C /* ReactiveCocoa.framework in Copy Frameworks */,
 				D00CCE331A20784800109F8C /* Commandant.framework in Copy Frameworks */,
 				D0E0E1B11A2D28CB0097BE2B /* ReactiveTask.framework in Copy Frameworks */,
+				67AFA98B1A79433900B7DA78 /* PrettyColors.framework in Copy Frameworks */,
 				D0F648831A4DD3EA00BCF808 /* Argo.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -108,6 +111,7 @@
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectSpec.swift; sourceTree = "<group>"; };
+		67AFA9891A79430B00B7DA78 /* PrettyColors.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PrettyColors.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88ED56D519ECE34900CBF5C4 /* Git.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Git.swift; sourceTree = "<group>"; };
 		D00CCE311A20783A00109F8C /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D01D82D61A10160700F0DD94 /* Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 				D00CCE321A20783A00109F8C /* Commandant.framework in Frameworks */,
 				D01F8A4119EA28C600643E7C /* LlamaKit.framework in Frameworks */,
 				D01F8A3F19EA28C400643E7C /* ReactiveCocoa.framework in Frameworks */,
+				67AFA98A1A79430B00B7DA78 /* PrettyColors.framework in Frameworks */,
 				D0F648821A4DD3D900BCF808 /* Argo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -348,6 +353,7 @@
 				D0F648811A4DD3D900BCF808 /* Argo.framework */,
 				D00CCE311A20783A00109F8C /* Commandant.framework */,
 				D01F8A4019EA28C600643E7C /* LlamaKit.framework */,
+				67AFA9891A79430B00B7DA78 /* PrettyColors.framework */,
 				D01F8A3E19EA28C400643E7C /* ReactiveCocoa.framework */,
 				D0E0E1AF1A2D28AC0097BE2B /* ReactiveTask.framework */,
 				D0D1217019E87B05005E4BAA /* Info.plist */,

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */; };
 		67AFA98A1A79430B00B7DA78 /* PrettyColors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67AFA9891A79430B00B7DA78 /* PrettyColors.framework */; };
 		67AFA98B1A79433900B7DA78 /* PrettyColors.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 67AFA9891A79430B00B7DA78 /* PrettyColors.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		67C870081A7A04E100F6647C /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C870071A7A04E100F6647C /* Formatting.swift */; };
 		88ED56D619ECE34900CBF5C4 /* Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88ED56D519ECE34900CBF5C4 /* Git.swift */; };
 		D00CCE321A20783A00109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; };
 		D00CCE331A20784800109F8C /* Commandant.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -112,6 +113,7 @@
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectSpec.swift; sourceTree = "<group>"; };
 		67AFA9891A79430B00B7DA78 /* PrettyColors.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PrettyColors.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		67C870071A7A04E100F6647C /* Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatting.swift; sourceTree = "<group>"; };
 		88ED56D519ECE34900CBF5C4 /* Git.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Git.swift; sourceTree = "<group>"; };
 		D00CCE311A20783A00109F8C /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D01D82D61A10160700F0DD94 /* Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				F66685FB19E8F1EC00487A88 /* Checkout.swift */,
 				5482DAF01A3849D700197FB8 /* CopyFrameworks.swift */,
 				D05BD1981A26864F00A36A0E /* Extensions.swift */,
+				67C870071A7A04E100F6647C /* Formatting.swift */,
 				D02DB8DF1A4BC9B600097CDE /* Fetch.swift */,
 				D0D1211B19E87861005E4BAA /* main.swift */,
 				D0AAC23F1A14933100060F2E /* Update.swift */,
@@ -619,6 +622,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67C870081A7A04E100F6647C /* Formatting.swift in Sources */,
 				D02DB8E01A4BC9B600097CDE /* Fetch.swift in Sources */,
 				5482DAF11A3849D700197FB8 /* CopyFrameworks.swift in Sources */,
 				D095BA3C1A187D40007F15D6 /* Bootstrap.swift in Sources */,

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		5482DAF11A3849D700197FB8 /* CopyFrameworks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5482DAF01A3849D700197FB8 /* CopyFrameworks.swift */; };
 		54911EF31A1D34EC00FFAE5F /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54911EF21A1D34EC00FFAE5F /* Version.swift */; };
 		549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */; };
+		6724C86A1A850A4600E47F00 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6724C8691A850A4600E47F00 /* Environment.swift */; };
 		67AFA98A1A79430B00B7DA78 /* PrettyColors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67AFA9891A79430B00B7DA78 /* PrettyColors.framework */; };
 		67AFA98B1A79433900B7DA78 /* PrettyColors.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 67AFA9891A79430B00B7DA78 /* PrettyColors.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		67C870081A7A04E100F6647C /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C870071A7A04E100F6647C /* Formatting.swift */; };
@@ -112,6 +113,7 @@
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectSpec.swift; sourceTree = "<group>"; };
+		6724C8691A850A4600E47F00 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		67AFA9891A79430B00B7DA78 /* PrettyColors.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PrettyColors.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		67C870071A7A04E100F6647C /* Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatting.swift; sourceTree = "<group>"; };
 		88ED56D519ECE34900CBF5C4 /* Git.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Git.swift; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 				D03B32BE19EA49D8007788BE /* Build.swift */,
 				F66685FB19E8F1EC00487A88 /* Checkout.swift */,
 				5482DAF01A3849D700197FB8 /* CopyFrameworks.swift */,
+				6724C8691A850A4600E47F00 /* Environment.swift */,
 				D05BD1981A26864F00A36A0E /* Extensions.swift */,
 				67C870071A7A04E100F6647C /* Formatting.swift */,
 				D02DB8DF1A4BC9B600097CDE /* Fetch.swift */,
@@ -629,6 +632,7 @@
 				54911EF31A1D34EC00FFAE5F /* Version.swift in Sources */,
 				D0AAC2401A14933100060F2E /* Update.swift in Sources */,
 				D05BD1991A26864F00A36A0E /* Extensions.swift in Sources */,
+				6724C86A1A850A4600E47F00 /* Environment.swift in Sources */,
 				D03B32BF19EA49D8007788BE /* Build.swift in Sources */,
 				D0E7B65619E9C76900EDBA4D /* main.swift in Sources */,
 				F689C33619EA14D4006D1EFA /* Checkout.swift in Sources */,

--- a/Carthage.xcworkspace/contents.xcworkspacedata
+++ b/Carthage.xcworkspace/contents.xcworkspacedata
@@ -25,4 +25,7 @@
    <FileRef
       location = "group:Carthage/Checkouts/Argo/Argo.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Carthage/Checkouts/PrettyColors/PrettyColors.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -10,7 +10,6 @@ import CarthageKit
 import Commandant
 import Foundation
 import LlamaKit
-import PrettyColors
 import ReactiveCocoa
 
 public struct BootstrapCommand: CommandType {

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -28,7 +28,7 @@ public struct BootstrapCommand: CommandType {
 							if NSFileManager.defaultManager().fileExistsAtPath(project.resolvedCartfileURL.path!) {
 								return project.checkoutResolvedDependencies()
 							} else {
-								carthage.println(bullets + "No Cartfile.resolved found, updating dependencies")
+								carthage.println(Formatting.bullets + "No Cartfile.resolved found, updating dependencies")
 								return project.updateDependencies()
 							}
 						}

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -28,7 +28,8 @@ public struct BootstrapCommand: CommandType {
 							if NSFileManager.defaultManager().fileExistsAtPath(project.resolvedCartfileURL.path!) {
 								return project.checkoutResolvedDependencies()
 							} else {
-								carthage.println(Formatting.bullets + "No Cartfile.resolved found, updating dependencies")
+								let formatting = options.checkoutOptions.colorOptions.formatting
+								carthage.println(formatting.bullets + "No Cartfile.resolved found, updating dependencies")
 								return project.updateDependencies()
 							}
 						}

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -10,6 +10,7 @@ import CarthageKit
 import Commandant
 import Foundation
 import LlamaKit
+import PrettyColors
 import ReactiveCocoa
 
 public struct BootstrapCommand: CommandType {
@@ -27,7 +28,7 @@ public struct BootstrapCommand: CommandType {
 							if NSFileManager.defaultManager().fileExistsAtPath(project.resolvedCartfileURL.path!) {
 								return project.checkoutResolvedDependencies()
 							} else {
-								carthage.println("*** No Cartfile.resolved found, updating dependencies")
+								carthage.println(bullets + "No Cartfile.resolved found, updating dependencies")
 								return project.updateDependencies()
 							}
 						}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -10,7 +10,6 @@ import CarthageKit
 import Commandant
 import Foundation
 import LlamaKit
-import PrettyColors
 import ReactiveCocoa
 
 public struct BuildCommand: CommandType {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -39,9 +39,9 @@ public struct BuildCommand: CommandType {
 				return schemeSignals
 					.concat(identity)
 					.on(started: {
-						carthage.println(bullets + "xcodebuild output can be found in " + Color.Wrap(foreground: .Yellow).wrap(temporaryURL.path!))
+						carthage.println(Formatting.bullets + "xcodebuild output can be found in " + Formatting.path.autowrap(temporaryURL.path!))
 					}, next: { (project, scheme) in
-						carthage.println(bullets + "Building scheme " + Color.Wrap(foreground: .Green).wrap(quote(scheme)) + " in " + bold.wrap(project.description))
+						carthage.println(Formatting.bullets + "Building scheme " + Formatting.quote(scheme) + " in " + Formatting.projectName.autowrap(project.description))
 					})
 					.then(.empty())
 			}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -119,12 +119,13 @@ public struct BuildOptions: OptionsType {
 	public let skipCurrent: Bool
 	public let directoryPath: String
 
-	public static func create(configuration: String)(skipCurrent: Bool)(directoryPath: String) -> BuildOptions {
+	public static func create(color: ColorOptions)(configuration: String)(skipCurrent: Bool)(directoryPath: String) -> BuildOptions {
 		return self(configuration: configuration, skipCurrent: skipCurrent, directoryPath: directoryPath)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<BuildOptions> {
 		return create
+			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build")
 			<*> m <| Option(key: "skip-current", defaultValue: true, usage: "don't skip building the Carthage project (in addition to its dependencies)")
 			<*> m <| Option(defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -10,6 +10,7 @@ import CarthageKit
 import Commandant
 import Foundation
 import LlamaKit
+import PrettyColors
 import ReactiveCocoa
 
 public struct BuildCommand: CommandType {
@@ -38,9 +39,9 @@ public struct BuildCommand: CommandType {
 				return schemeSignals
 					.concat(identity)
 					.on(started: {
-						carthage.println("*** xcodebuild output can be found in \(temporaryURL.path!)")
+						carthage.println(bullets + "xcodebuild output can be found in " + Color.Wrap(foreground: .Yellow).wrap(temporaryURL.path!))
 					}, next: { (project, scheme) in
-						carthage.println("*** Building scheme \"\(scheme)\" in \(project)")
+						carthage.println(bullets + "Building scheme " + Color.Wrap(foreground: .Green).wrap(quote(scheme)) + " in " + bold.wrap(project.description))
 					})
 					.then(.empty())
 			}

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -36,9 +36,10 @@ public struct CheckoutOptions: OptionsType {
 	public let useSSH: Bool
 	public let useSubmodules: Bool
 	public let useBinaries: Bool
+	public let colorOptions: ColorOptions
 
-	public static func create(useSSH: Bool)(useSubmodules: Bool)(useBinaries: Bool)(color: ColorOptions)(directoryPath: String) -> CheckoutOptions {
-		return self(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: useBinaries)
+	public static func create(useSSH: Bool)(useSubmodules: Bool)(useBinaries: Bool)(colorOptions: ColorOptions)(directoryPath: String) -> CheckoutOptions {
+		return self(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: useBinaries, colorOptions: colorOptions)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<CheckoutOptions> {
@@ -62,10 +63,10 @@ public struct CheckoutOptions: OptionsType {
 			project.preferHTTPS = !self.useSSH
 			project.useSubmodules = self.useSubmodules
 			project.useBinaries = self.useBinaries
-			project.projectEvents.observe(ProjectEventSink())
+			project.projectEvents.observe(ProjectEventSink(colorOptions))
 
 			return project
-				.migrateIfNecessary()
+				.migrateIfNecessary(colorOptions)
 				.on(next: carthage.println)
 				.then(.single(project))
 		} else {

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -63,7 +63,7 @@ public struct CheckoutOptions: OptionsType {
 			project.preferHTTPS = !self.useSSH
 			project.useSubmodules = self.useSubmodules
 			project.useBinaries = self.useBinaries
-			project.projectEvents.observe(ProjectEventSink(colorOptions))
+			project.projectEvents.observe(ProjectEventSink(colorOptions: colorOptions))
 
 			return project
 				.migrateIfNecessary(colorOptions)

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -37,7 +37,7 @@ public struct CheckoutOptions: OptionsType {
 	public let useSubmodules: Bool
 	public let useBinaries: Bool
 
-	public static func create(useSSH: Bool)(useSubmodules: Bool)(useBinaries: Bool)(directoryPath: String) -> CheckoutOptions {
+	public static func create(useSSH: Bool)(useSubmodules: Bool)(useBinaries: Bool)(color: ColorOptions)(directoryPath: String) -> CheckoutOptions {
 		return self(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: useBinaries)
 	}
 
@@ -50,6 +50,7 @@ public struct CheckoutOptions: OptionsType {
 			<*> m <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 			<*> m <| Option(key: "use-submodules", defaultValue: false, usage: "add dependencies as Git submodules")
 			<*> m <| Option(key: "use-binaries", defaultValue: true, usage: "check out dependency repositories even when prebuilt frameworks exist" + useBinariesAddendum)
+			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")
 	}
 

--- a/Source/carthage/Components.plist
+++ b/Source/carthage/Components.plist
@@ -39,6 +39,12 @@
 				<key>RootRelativeBundlePath</key>
 				<string>Library/Frameworks/CarthageKit.framework/Versions/A/Frameworks/Argo.framework</string>
 			</dict>
+			<dict>
+				<key>BundleOverwriteAction</key>
+				<string></string>
+				<key>RootRelativeBundlePath</key>
+				<string>Library/Frameworks/CarthageKit.framework/Versions/A/Frameworks/PrettyColors.framework</string>
+			</dict>
 		</array>
 		<key>RootRelativeBundlePath</key>
 		<string>Library/Frameworks/CarthageKit.framework</string>

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -95,7 +95,7 @@ private func inputFiles() -> ColdSignal<String> {
 		}
 }
 
-private func getEnvironmentVariable(variable: String) -> Result<String> {
+internal func getEnvironmentVariable(variable: String) -> Result<String> {
 	let environment = NSProcessInfo.processInfo().environment
 
 	if let value = environment[variable] as String? {

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -94,13 +94,3 @@ private func inputFiles() -> ColdSignal<String> {
 			return ColdSignal.fromValues(variables).concat(identity)
 		}
 }
-
-internal func getEnvironmentVariable(variable: String) -> Result<String> {
-	let environment = NSProcessInfo.processInfo().environment
-
-	if let value = environment[variable] as String? {
-		return success(value)
-	} else {
-		return failure(CarthageError.MissingEnvironmentVariable(variable: variable).error)
-	}
-}

--- a/Source/carthage/Environment.swift
+++ b/Source/carthage/Environment.swift
@@ -1,0 +1,39 @@
+//
+//  Environment.swift
+//  Carthage
+//
+//  Created by J.D. Healy on 2/6/15.
+//  Copyright (c) 2015 Carthage. All rights reserved.
+//
+
+import CarthageKit
+import Foundation
+import LlamaKit
+
+internal func getEnvironmentVariable(variable: String) -> Result<String> {
+	let environment = NSProcessInfo.processInfo().environment
+
+	if let value = environment[variable] as String? {
+		return success(value)
+	} else {
+		return failure(CarthageError.MissingEnvironmentVariable(variable: variable).error)
+	}
+}
+
+/// Information about the possible parent terminal.
+internal struct Terminal {
+	/// Terminal type retrieved from `TERM` environment variable.
+	static var terminalType: String? {
+		return getEnvironmentVariable("TERM").value()
+	}
+	
+	/// Whether terminal type is `dumb`.
+	static var isDumb: Bool {
+		return terminalType?.caseInsensitiveCompare("dumb") == NSComparisonResult.OrderedSame ?? false
+	}
+	
+	/// Whether STDOUT is a TTY.
+	static var isTTY: Bool {
+		return isatty(STDOUT_FILENO) != 0
+	}
+}

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -13,6 +13,7 @@ import CarthageKit
 import Commandant
 import Foundation
 import LlamaKit
+import PrettyColors
 import ReactiveCocoa
 
 private let outputQueue = { () -> dispatch_queue_t in
@@ -55,21 +56,25 @@ extension GitURL: ArgumentType {
 	}
 }
 
+internal let bullets = Color.Wrap(foreground: .Blue, style: .Bold).wrap("***") + " "
+internal let bold = [StyleParameter.Bold] as Color.Wrap
+internal func quote(string: String) -> String { return "\u{0022}" + string + "\u{0022}" }
+
 /// Logs project events put into the sink.
 internal struct ProjectEventSink: SinkType {
 	mutating func put(event: ProjectEvent) {
 		switch event {
 		case let .Cloning(project):
-			carthage.println("*** Cloning \(project.name)")
+			carthage.println(bullets + "Cloning " + bold.wrap(project.name))
 
 		case let .Fetching(project):
-			carthage.println("*** Fetching \(project.name)")
+			carthage.println(bullets + "Fetching " + bold.wrap(project.name))
 
 		case let .CheckingOut(project, revision):
-			carthage.println("*** Checking out \(project.name) at \"\(revision)\"")
+			carthage.println(bullets + "Checking out " + bold.wrap(project.name) + " at " + Color.Wrap(foreground: .Green).wrap(quote(revision)))
 
 		case let .DownloadingBinaries(project, release):
-			carthage.println("*** Downloading \(project.name) release \"\(release)\"")
+			carthage.println(bullets + "Downloading " + bold.wrap(project.name) + " at " + Color.Wrap(foreground: .Green).wrap(quote(release)))
 		}
 	}
 }
@@ -90,7 +95,7 @@ extension Project {
 		let carthageBuild = "Carthage.build"
 		let carthageCheckout = "Carthage.checkout"
 
-		let migrationMessage = "*** MIGRATION WARNING ***\n\nThis project appears to be set up for an older (pre-0.4) version of Carthage. Unfortunately, the directory structure for Carthage projects has since changed, so this project will be migrated automatically.\n\nSpecifically, the following renames will occur:\n\n  \(cartfileLock) -> \(CarthageProjectResolvedCartfilePath)\n  \(carthageBuild) -> \(CarthageBinariesFolderPath)\n  \(carthageCheckout) -> \(CarthageProjectCheckoutsPath)\n\nFor more information, see https://github.com/Carthage/Carthage/pull/224.\n"
+		let migrationMessage = Color.Wrap(foreground: .Blue, style: .Bold).wrap("*** MIGRATION WARNING ***") + "\n\nThis project appears to be set up for an older (pre-0.4) version of Carthage. Unfortunately, the directory structure for Carthage projects has since changed, so this project will be migrated automatically.\n\nSpecifically, the following renames will occur:\n\n  \(cartfileLock) -> \(CarthageProjectResolvedCartfilePath)\n  \(carthageBuild) -> \(CarthageBinariesFolderPath)\n  \(carthageCheckout) -> \(CarthageProjectCheckoutsPath)\n\nFor more information, see " + ([StyleParameter.Underlined] as Color.Wrap).wrap("https://github.com/Carthage/Carthage/pull/224") + ".\n"
 		let signals = ColdSignal<ColdSignal<String>> { sink, disposable in
 			let checkFile: (String, String) -> () = { oldName, newName in
 				if fileManager.fileExistsAtPath(directoryPath.stringByAppendingPathComponent(oldName)) {

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -56,25 +56,50 @@ extension GitURL: ArgumentType {
 	}
 }
 
-internal let bullets = Color.Wrap(foreground: .Blue, style: .Bold).wrap("***") + " "
-internal let bold = [StyleParameter.Bold] as Color.Wrap
-internal func quote(string: String) -> String { return "\u{0022}" + string + "\u{0022}" }
+extension Color.Wrap {
+	func autowrap(string: String) -> String {
+		return Formatting.color ? self.wrap(string) : string
+	}
+}
+
+internal struct Formatting {
+	static let color = Terminal.isTTY && !Terminal.isDumb
+	
+	static let bulletin = Color.Wrap(foreground: .Blue, style: .Bold)
+	static let bullets: String = {
+		return bulletin.autowrap("***") + " "
+	}()
+	
+	static let URL = [StyleParameter.Underlined] as Color.Wrap
+	static let projectName = [StyleParameter.Bold] as Color.Wrap
+	static let path = Color.Wrap(foreground: .Yellow)
+	
+	static func quote(string: String) -> String {
+		return Color.Wrap(foreground: .Green).autowrap("\u{0022}" + string + "\u{0022}")
+	}
+}
+
+internal struct Terminal {
+	static let term: String? = NSProcessInfo().environment["TERM"] as? String
+	static let isDumb: Bool = (Terminal.term? as NSString?)?.isEqualToString("dumb") ?? false
+	static let isTTY: Bool = isatty(1) == 1
+}
 
 /// Logs project events put into the sink.
 internal struct ProjectEventSink: SinkType {
 	mutating func put(event: ProjectEvent) {
 		switch event {
 		case let .Cloning(project):
-			carthage.println(bullets + "Cloning " + bold.wrap(project.name))
+			carthage.println(Formatting.bullets + "Cloning " + Formatting.projectName.autowrap(project.name))
 
 		case let .Fetching(project):
-			carthage.println(bullets + "Fetching " + bold.wrap(project.name))
+			carthage.println(Formatting.bullets + "Fetching " + Formatting.projectName.autowrap(project.name))
 
 		case let .CheckingOut(project, revision):
-			carthage.println(bullets + "Checking out " + bold.wrap(project.name) + " at " + Color.Wrap(foreground: .Green).wrap(quote(revision)))
+			carthage.println(Formatting.bullets + "Checking out " + Formatting.projectName.autowrap(project.name) + " at " + Formatting.quote(revision))
 
 		case let .DownloadingBinaries(project, release):
-			carthage.println(bullets + "Downloading " + bold.wrap(project.name) + " at " + Color.Wrap(foreground: .Green).wrap(quote(release)))
+			carthage.println(Formatting.bullets + "Downloading " + Formatting.projectName.autowrap(project.name) + " at " + Formatting.quote(release))
 		}
 	}
 }
@@ -95,7 +120,7 @@ extension Project {
 		let carthageBuild = "Carthage.build"
 		let carthageCheckout = "Carthage.checkout"
 
-		let migrationMessage = Color.Wrap(foreground: .Blue, style: .Bold).wrap("*** MIGRATION WARNING ***") + "\n\nThis project appears to be set up for an older (pre-0.4) version of Carthage. Unfortunately, the directory structure for Carthage projects has since changed, so this project will be migrated automatically.\n\nSpecifically, the following renames will occur:\n\n  \(cartfileLock) -> \(CarthageProjectResolvedCartfilePath)\n  \(carthageBuild) -> \(CarthageBinariesFolderPath)\n  \(carthageCheckout) -> \(CarthageProjectCheckoutsPath)\n\nFor more information, see " + ([StyleParameter.Underlined] as Color.Wrap).wrap("https://github.com/Carthage/Carthage/pull/224") + ".\n"
+		let migrationMessage = Formatting.bulletin.autowrap("*** MIGRATION WARNING ***") + "\n\nThis project appears to be set up for an older (pre-0.4) version of Carthage. Unfortunately, the directory structure for Carthage projects has since changed, so this project will be migrated automatically.\n\nSpecifically, the following renames will occur:\n\n  \(cartfileLock) -> \(CarthageProjectResolvedCartfilePath)\n  \(carthageBuild) -> \(CarthageBinariesFolderPath)\n  \(carthageCheckout) -> \(CarthageProjectCheckoutsPath)\n\nFor more information, see " + Formatting.URL.autowrap("https://github.com/Carthage/Carthage/pull/224") + ".\n"
 		let signals = ColdSignal<ColdSignal<String>> { sink, disposable in
 			let checkFile: (String, String) -> () = { oldName, newName in
 				if fileManager.fileExistsAtPath(directoryPath.stringByAppendingPathComponent(oldName)) {

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -100,7 +100,7 @@ extension Project {
 		
 		let formatting = colorOptions.formatting
 		
-		let migrationMessage = formatting.bulletin(string: "*** MIGRATION WARNING ***") + "\n\nThis project appears to be set up for an older (pre-0.4) version of Carthage. Unfortunately, the directory structure for Carthage projects has since changed, so this project will be migrated automatically.\n\nSpecifically, the following renames will occur:\n\n  \(cartfileLock) -> \(CarthageProjectResolvedCartfilePath)\n  \(carthageBuild) -> \(CarthageBinariesFolderPath)\n  \(carthageCheckout) -> \(CarthageProjectCheckoutsPath)\n\nFor more information, see " + formatting.URL(string: "https://github.com/Carthage/Carthage/pull/224") + ".\n"
+		let migrationMessage = formatting.bulletinTitle("MIGRATION WARNING") + "\n\nThis project appears to be set up for an older (pre-0.4) version of Carthage. Unfortunately, the directory structure for Carthage projects has since changed, so this project will be migrated automatically.\n\nSpecifically, the following renames will occur:\n\n  \(cartfileLock) -> \(CarthageProjectResolvedCartfilePath)\n  \(carthageBuild) -> \(CarthageBinariesFolderPath)\n  \(carthageCheckout) -> \(CarthageProjectCheckoutsPath)\n\nFor more information, see " + formatting.URL(string: "https://github.com/Carthage/Carthage/pull/224") + ".\n"
 		let signals = ColdSignal<ColdSignal<String>> { sink, disposable in
 			let checkFile: (String, String) -> () = { oldName, newName in
 				if fileManager.fileExistsAtPath(directoryPath.stringByAppendingPathComponent(oldName)) {

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -59,7 +59,7 @@ extension GitURL: ArgumentType {
 internal struct ProjectEventSink: SinkType {
 	private let colorOptions: ColorOptions
 	
-	init(_ colorOptions: ColorOptions) {
+	init(colorOptions: ColorOptions) {
 		self.colorOptions = colorOptions
 	}
 	

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -57,7 +57,7 @@ extension GitURL: ArgumentType {
 
 /// Logs project events put into the sink.
 internal struct ProjectEventSink: SinkType {
-	let colorOptions: ColorOptions
+	private let colorOptions: ColorOptions
 	
 	init(_ colorOptions: ColorOptions) {
 		self.colorOptions = colorOptions

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -13,7 +13,6 @@ import CarthageKit
 import Commandant
 import Foundation
 import LlamaKit
-import PrettyColors
 import ReactiveCocoa
 
 private let outputQueue = { () -> dispatch_queue_t in

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -56,35 +56,6 @@ extension GitURL: ArgumentType {
 	}
 }
 
-extension Color.Wrap {
-	func autowrap(string: String) -> String {
-		return Formatting.color ? self.wrap(string) : string
-	}
-}
-
-internal struct Formatting {
-	static let color = Terminal.isTTY && !Terminal.isDumb
-	
-	static let bulletin = Color.Wrap(foreground: .Blue, style: .Bold)
-	static let bullets: String = {
-		return bulletin.autowrap("***") + " "
-	}()
-	
-	static let URL = [StyleParameter.Underlined] as Color.Wrap
-	static let projectName = [StyleParameter.Bold] as Color.Wrap
-	static let path = Color.Wrap(foreground: .Yellow)
-	
-	static func quote(string: String) -> String {
-		return Color.Wrap(foreground: .Green).autowrap("\u{0022}" + string + "\u{0022}")
-	}
-}
-
-internal struct Terminal {
-	static let term: String? = NSProcessInfo().environment["TERM"] as? String
-	static let isDumb: Bool = (Terminal.term? as NSString?)?.isEqualToString("dumb") ?? false
-	static let isTTY: Bool = isatty(1) == 1
-}
-
 /// Logs project events put into the sink.
 internal struct ProjectEventSink: SinkType {
 	mutating func put(event: ProjectEvent) {

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -64,7 +64,6 @@ internal struct ProjectEventSink: SinkType {
 	}
 	
 	mutating func put(event: ProjectEvent) {
-		
 		let formatting = colorOptions.formatting
 		
 		switch event {

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -20,7 +20,7 @@ public struct FetchCommand: CommandType {
 		return ColdSignal.fromResult(FetchOptions.evaluate(mode))
 			.mergeMap { options -> ColdSignal<()> in
 				let project = ProjectIdentifier.Git(options.repositoryURL)
-				var eventSink = ProjectEventSink(options.colorOptions)
+				var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
 
 				return cloneOrFetchProject(project, preferHTTPS: true)
 					.on(next: { event, _ in

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -35,12 +35,13 @@ public struct FetchCommand: CommandType {
 private struct FetchOptions: OptionsType {
 	let repositoryURL: GitURL
 
-	static func create(repositoryURL: GitURL) -> FetchOptions {
+	static func create(color: ColorOptions)(repositoryURL: GitURL) -> FetchOptions {
 		return self(repositoryURL: repositoryURL)
 	}
 
 	static func evaluate(m: CommandMode) -> Result<FetchOptions> {
 		return create
+			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(usage: "the Git repository that should be cloned or fetched")
 	}
 }

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -20,7 +20,7 @@ public struct FetchCommand: CommandType {
 		return ColdSignal.fromResult(FetchOptions.evaluate(mode))
 			.mergeMap { options -> ColdSignal<()> in
 				let project = ProjectIdentifier.Git(options.repositoryURL)
-				var eventSink = ProjectEventSink()
+				var eventSink = ProjectEventSink(options.colorOptions)
 
 				return cloneOrFetchProject(project, preferHTTPS: true)
 					.on(next: { event, _ in
@@ -33,10 +33,11 @@ public struct FetchCommand: CommandType {
 }
 
 private struct FetchOptions: OptionsType {
+	let colorOptions: ColorOptions
 	let repositoryURL: GitURL
 
-	static func create(color: ColorOptions)(repositoryURL: GitURL) -> FetchOptions {
-		return self(repositoryURL: repositoryURL)
+	static func create(colorOptions: ColorOptions)(repositoryURL: GitURL) -> FetchOptions {
+		return self(colorOptions: colorOptions, repositoryURL: repositoryURL)
 	}
 
 	static func evaluate(m: CommandMode) -> Result<FetchOptions> {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -36,7 +36,7 @@ internal struct Formatting {
 }
 
 internal struct Terminal {
-	static let term: String? = NSProcessInfo().environment["TERM"] as? String
-	static let isDumb: Bool = (Terminal.term? as NSString?)?.isEqualToString("dumb") ?? false
 	static let isTTY: Bool = isatty(1) == 1
+	static let term: String? = getEnvironmentVariable("TERM").value()
+	static let isDumb: Bool = (Terminal.term?.lowercaseString as NSString?)?.isEqualToString("dumb") ?? false
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -78,7 +78,7 @@ public struct ColorOptions: OptionsType {
 	}
 	
 	public static func create(argument: ColorArgument) -> ColorOptions {
-		dispatch_once(&Static.token, { Static.colorful = argument.isColorful })
+		dispatch_once(&Static.token) { Static.colorful = argument.isColorful }
 		return self(argument: argument)
 	}
 	

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -30,7 +30,7 @@ internal struct Terminal {
 	
 	/// Whether STDOUT is a TTY.
 	static var isTTY: Bool {
-		return isatty(STDOUT_FILENO) == 1
+		return isatty(STDOUT_FILENO) != 0
 	}
 }
 

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -45,7 +45,7 @@ public enum ColorArgument: String, ArgumentType, Printable {
 	}
 	
 	public var description: String {
-		return "‘auto’ || ‘always’ || ‘never’"
+		return self.rawValue
 	}
 	
 	public static let name = "color"
@@ -93,6 +93,6 @@ public struct ColorOptions: OptionsType {
 	
 	public static func evaluate(m: CommandMode) -> Result<ColorOptions> {
 		return create
-			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply formatting and colors to terminal messages")
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "apply Terminal colors and formatting — ‘auto’ || ‘always’ || ‘never’")
 	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -17,9 +17,15 @@ func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 }
 
 internal struct Terminal {
-	static let term: String? = getEnvironmentVariable("TERM").value()
-	static let isDumb: Bool = (Terminal.term?.lowercaseString as NSString?)?.isEqualToString("dumb") ?? false
-	static let isTTY: Bool = isatty(STDOUT_FILENO) == 1
+	static var term: String? {
+		return getEnvironmentVariable("TERM").value()
+	}
+	static var isDumb: Bool {
+		return (Terminal.term?.lowercaseString as NSString?)?.isEqualToString("dumb") ?? false
+	}
+	static var isTTY: Bool {
+		return isatty(STDOUT_FILENO) == 1
+	}
 }
 
 public enum ColorArgument: String, ArgumentType, Printable {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -90,7 +90,6 @@ public struct ColorOptions: OptionsType {
 		func quote(string: String, quotationMark: String = "\"") -> String {
 			return wrap(colorful)(wrap: Color.Wrap(foreground: .Green))(string: quotationMark + string + quotationMark)
 		}
-		
 	}
 	
 	static func create(argument: ColorArgument) -> ColorOptions {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -12,7 +12,7 @@ import LlamaKit
 import PrettyColors
 
 /// Wraps or passes through a string.
-func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
+private func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 	return colorful ? wrap.wrap(string) : string
 }
 

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -41,7 +41,7 @@ internal struct Terminal {
 	static let isTTY: Bool = isatty(STDOUT_FILENO) == 1
 }
 
-public enum ColorArgument: String, ArgumentType {
+public enum ColorArgument: String, ArgumentType, Printable {
 	case Auto = "auto"
 	case Never = "never"
 	case Always = "always"
@@ -56,6 +56,8 @@ public enum ColorArgument: String, ArgumentType {
 			return Terminal.isTTY && !Terminal.isDumb
 		}
 	}
+	
+	public var description: String { return "‘auto’ || ‘always’ || ‘never’" }
 	
 	public static let name = "color"
 	
@@ -104,6 +106,6 @@ public struct ColorOptions: OptionsType {
 	
 	public static func evaluate(m: CommandMode) -> Result<ColorOptions> {
 		return create
-			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "Terminal coloring and styling — values: ‘auto’ || ‘always’ || ‘never’")
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "Terminal coloring and styling")
 	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -69,8 +69,24 @@ public struct ColorOptions: OptionsType {
 	public let argument: ColorArgument
 	
 	static var colorful: Bool {
-		if Static.colorful == nil { fatalError("`ColorOptions.create` might not have been called…") }
-		return Static.colorful!
+
+		if let colorful = Static.colorful {
+			return colorful
+		} else {
+			var arguments = Process.arguments
+			assert(arguments.count >= 1)
+			
+			// Remove the executable name.
+			arguments.removeAtIndex(0)
+			
+			switch ColorOptions.evaluate(.Arguments(ArgumentParser(arguments))) {
+			case .Success(let options):
+				return options.unbox.argument.isColorful
+			case .Failure(let error):
+				fatalError(error.description)
+			}
+
+		}
 	}
 
 	private struct Static {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -19,11 +19,11 @@ func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 
 /// Information about the possible parent terminal.
 internal struct Terminal {
-	static var term: String? {
+	static var terminalType: String? {
 		return getEnvironmentVariable("TERM").value()
 	}
 	static var isDumb: Bool {
-		return (Terminal.term?.lowercaseString as NSString?)?.isEqualToString("dumb") ?? false
+		return terminalType?.caseInsensitiveCompare("dumb") == NSComparisonResult.OrderedSame ?? false
 	}
 	static var isTTY: Bool {
 		return isatty(STDOUT_FILENO) == 1

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -12,10 +12,12 @@ import LlamaKit
 import PrettyColors
 import ReactiveCocoa
 
+/// Wraps or passes through a string.
 func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 	return colorful ? wrap.wrap(string) : string
 }
 
+/// Information about the possible parent terminal.
 internal struct Terminal {
 	static var term: String? {
 		return getEnvironmentVariable("TERM").value()
@@ -33,6 +35,7 @@ public enum ColorArgument: String, ArgumentType, Printable {
 	case Never = "never"
 	case Always = "always"
 	
+	/// Whether to color and format.
 	public var isColorful: Bool {
 		switch self {
 		case .Always:
@@ -63,6 +66,7 @@ public struct ColorOptions: OptionsType {
 	struct Formatting {
 		let colorful: Bool
 		
+		/// Wraps or passes through a string.
 		typealias Wrap = (string: String) -> String
 		
 		init(_ colorful: Bool) {
@@ -81,6 +85,7 @@ public struct ColorOptions: OptionsType {
 		let projectName: Wrap
 		let path: Wrap
 		
+		/// Wraps a string in quotation marks and formatting.
 		func quote(string: String, quotationMark: String = "\"") -> String {
 			return wrap(colorful)(wrap: Color.Wrap(foreground: .Green))(string: quotationMark + string + quotationMark)
 		}

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -69,10 +69,8 @@ public struct ColorOptions: OptionsType {
 	public let argument: ColorArgument
 	
 	static var colorful: Bool {
-		get {
-			if Static.colorful == nil { fatalError("`ColorOptions.create` might not have been called…") }
-			return Static.colorful!
-		}
+		if Static.colorful == nil { fatalError("`ColorOptions.create` might not have been called…") }
+		return Static.colorful!
 	}
 
 	private struct Static {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -44,7 +44,9 @@ public enum ColorArgument: String, ArgumentType, Printable {
 		}
 	}
 	
-	public var description: String { return "‘auto’ || ‘always’ || ‘never’" }
+	public var description: String {
+		return "‘auto’ || ‘always’ || ‘never’"
+	}
 	
 	public static let name = "color"
 	

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -67,7 +67,7 @@ public struct ColorOptions: OptionsType {
 	let argument: ColorArgument
 	let formatting: Formatting
 	
-	struct Formatting {
+	public struct Formatting {
 		let colorful: Bool
 		
 		/// Wraps a string with terminal colors and formatting or passes it through.

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -14,18 +14,17 @@ import ReactiveCocoa
 
 extension Color.Wrap {
 	func autowrap(string: String) -> String {
-		return Formatting.color ? self.wrap(string) : string
+		return ColorOptions.colorful ? self.wrap(string) : string
 	}
 }
 
 internal struct Formatting {
-	static let color = Terminal.isTTY && !Terminal.isDumb
 
 	static let bulletin = Color.Wrap(foreground: .Blue, style: .Bold)
 	static let bullets: String = {
 		return bulletin.autowrap("***") + " "
 	}()
-
+	
 	static let URL = [StyleParameter.Underlined] as Color.Wrap
 	static let projectName = [StyleParameter.Bold] as Color.Wrap
 	static let path = Color.Wrap(foreground: .Yellow)
@@ -33,10 +32,58 @@ internal struct Formatting {
 	static func quote(string: String, quotationMark: String = "\u{0022}" /* double quote */) -> String {
 		return Color.Wrap(foreground: .Green).autowrap(quotationMark + string + quotationMark)
 	}
+	
 }
 
 internal struct Terminal {
 	static let term: String? = getEnvironmentVariable("TERM").value()
 	static let isDumb: Bool = (Terminal.term?.lowercaseString as NSString?)?.isEqualToString("dumb") ?? false
 	static let isTTY: Bool = isatty(STDOUT_FILENO) == 1
+}
+
+public enum ColorArgument: String, ArgumentType {
+	case Auto = "auto"
+	case Never = "never"
+	case Always = "always"
+	
+	public var isColorful: Bool {
+		switch self {
+		case .Always: return true
+		case .Never:  return false
+		case .Auto:   return Terminal.isTTY && !Terminal.isDumb
+		}
+	}
+	
+	public static let name = "color"
+	
+	public static func fromString(string: String) -> ColorArgument? {
+		return self(rawValue: string.lowercaseString)
+	}
+	
+}
+
+public struct ColorOptions: OptionsType {
+	public let argument: ColorArgument
+	
+	static var colorful: Bool {
+		get {
+			if Static.colorful == nil { fatalError("`ColorOptions.create` might not have been called…") }
+			return Static.colorful!
+		}
+	}
+
+	private struct Static {
+		static var colorful: Bool? = nil
+		static var token: dispatch_once_t = 0
+	}
+	
+	public static func create(argument: ColorArgument) -> ColorOptions {
+		dispatch_once(&Static.token, { Static.colorful = argument.isColorful })
+		return self(argument: argument)
+	}
+	
+	public static func evaluate(m: CommandMode) -> Result<ColorOptions> {
+		return create
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "Terminal coloring and styling — values: ‘auto’ || ‘always’ || ‘never’")
+	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -70,7 +70,7 @@ public struct ColorOptions: OptionsType {
 	
 	static var colorful: Bool {
 
-		if let colorful = Static.colorful {
+		if let colorful = Static.Colorful.singleton {
 			return colorful
 		} else {
 			var arguments = Process.arguments
@@ -91,12 +91,14 @@ public struct ColorOptions: OptionsType {
 	}
 
 	private struct Static {
-		static var colorful: Bool? = nil
-		static var token: dispatch_once_t = 0
+		struct Colorful {
+			static var singleton: Bool? = nil
+			static var token: dispatch_once_t = 0
+		}
 	}
 	
 	public static func create(argument: ColorArgument) -> ColorOptions {
-		dispatch_once(&Static.token) { Static.colorful = argument.isColorful }
+		dispatch_once(&Static.Colorful.token) { Static.Colorful.singleton = argument.isColorful }
 		return self(argument: argument)
 	}
 	

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -11,21 +11,24 @@ import Foundation
 import LlamaKit
 import PrettyColors
 
-/// Wraps or passes through a string.
+/// Wraps a string with terminal colors and formatting or passes it through, depending on `colorful`.
 private func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 	return colorful ? wrap.wrap(string) : string
 }
 
 /// Information about the possible parent terminal.
 internal struct Terminal {
+	/// Terminal type retrieved from `TERM` environment variable.
 	static var terminalType: String? {
 		return getEnvironmentVariable("TERM").value()
 	}
 	
+	/// Whether terminal type is `dumb`.
 	static var isDumb: Bool {
 		return terminalType?.caseInsensitiveCompare("dumb") == NSComparisonResult.OrderedSame ?? false
 	}
 	
+	/// Whether STDOUT is a TTY.
 	static var isTTY: Bool {
 		return isatty(STDOUT_FILENO) == 1
 	}
@@ -67,7 +70,7 @@ public struct ColorOptions: OptionsType {
 	struct Formatting {
 		let colorful: Bool
 		
-		/// Wraps or passes through a string.
+		/// Wraps a string with terminal colors and formatting or passes it through.
 		typealias Wrap = (string: String) -> String
 		
 		init(_ colorful: Bool) {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -10,7 +10,6 @@ import Commandant
 import Foundation
 import LlamaKit
 import PrettyColors
-import ReactiveCocoa
 
 /// Wraps or passes through a string.
 func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -16,24 +16,6 @@ private func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 	return colorful ? wrap.wrap(string) : string
 }
 
-/// Information about the possible parent terminal.
-internal struct Terminal {
-	/// Terminal type retrieved from `TERM` environment variable.
-	static var terminalType: String? {
-		return getEnvironmentVariable("TERM").value()
-	}
-	
-	/// Whether terminal type is `dumb`.
-	static var isDumb: Bool {
-		return terminalType?.caseInsensitiveCompare("dumb") == NSComparisonResult.OrderedSame ?? false
-	}
-	
-	/// Whether STDOUT is a TTY.
-	static var isTTY: Bool {
-		return isatty(STDOUT_FILENO) != 0
-	}
-}
-
 public enum ColorArgument: String, ArgumentType, Printable {
 	case Auto = "auto"
 	case Never = "never"

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -14,7 +14,7 @@ import ReactiveCocoa
 
 extension Color.Wrap {
 	func autowrap(string: String) -> String {
-		return ColorOptions.colorful ? self.wrap(string) : string
+		return ColorOptions.colorful ? wrap(string) : string
 	}
 }
 

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -84,6 +84,11 @@ public struct ColorOptions: OptionsType {
 		
 		let bulletin: Wrap
 		let bullets: String
+
+		/// Wraps a string in bullets, one space of padding, and formatting.
+		func bulletinTitle(string: String) -> String {
+			return bulletin(string: "*** " + string + " ***")
+		}
 		
 		let URL: Wrap
 		let projectName: Wrap

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -25,8 +25,8 @@ internal struct Formatting {
 		return bulletin.autowrap("***") + " "
 	}()
 	
-	static let URL = [StyleParameter.Underlined] as Color.Wrap
-	static let projectName = [StyleParameter.Bold] as Color.Wrap
+	static let URL = Color.Wrap(styles: .Underlined)
+	static let projectName = Color.Wrap(styles: .Bold)
 	static let path = Color.Wrap(foreground: .Yellow)
 	
 	static func quote(string: String, quotationMark: String = "\"") -> String {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -1,0 +1,42 @@
+//
+//  Formatting.swift
+//  Carthage
+//
+//  Created by J.D. Healy on 1/29/15.
+//  Copyright (c) 2015 Carthage. All rights reserved.
+//
+
+import Commandant
+import Foundation
+import LlamaKit
+import PrettyColors
+import ReactiveCocoa
+
+extension Color.Wrap {
+	func autowrap(string: String) -> String {
+		return Formatting.color ? self.wrap(string) : string
+	}
+}
+
+internal struct Formatting {
+	static let color = Terminal.isTTY && !Terminal.isDumb
+
+	static let bulletin = Color.Wrap(foreground: .Blue, style: .Bold)
+	static let bullets: String = {
+		return bulletin.autowrap("***") + " "
+	}()
+
+	static let URL = [StyleParameter.Underlined] as Color.Wrap
+	static let projectName = [StyleParameter.Bold] as Color.Wrap
+	static let path = Color.Wrap(foreground: .Yellow)
+
+	static func quote(string: String) -> String {
+		return Color.Wrap(foreground: .Green).autowrap("\u{0022}" + string + "\u{0022}")
+	}
+}
+
+internal struct Terminal {
+	static let term: String? = NSProcessInfo().environment["TERM"] as? String
+	static let isDumb: Bool = (Terminal.term? as NSString?)?.isEqualToString("dumb") ?? false
+	static let isTTY: Bool = isatty(1) == 1
+}

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -36,7 +36,7 @@ internal struct Formatting {
 }
 
 internal struct Terminal {
-	static let isTTY: Bool = isatty(1) == 1
 	static let term: String? = getEnvironmentVariable("TERM").value()
 	static let isDumb: Bool = (Terminal.term?.lowercaseString as NSString?)?.isEqualToString("dumb") ?? false
+	static let isTTY: Bool = isatty(STDOUT_FILENO) == 1
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -16,6 +16,7 @@ private func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
 	return colorful ? wrap.wrap(string) : string
 }
 
+/// Argument for whether to color and format terminal output.
 public enum ColorArgument: String, ArgumentType, Printable {
 	case Auto = "auto"
 	case Never = "never"
@@ -45,6 +46,7 @@ public enum ColorArgument: String, ArgumentType, Printable {
 	
 }
 
+/// Options for whether to color and format terminal output.
 public struct ColorOptions: OptionsType {
 	let argument: ColorArgument
 	let formatting: Formatting

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -29,9 +29,9 @@ internal struct Formatting {
 	static let URL = [StyleParameter.Underlined] as Color.Wrap
 	static let projectName = [StyleParameter.Bold] as Color.Wrap
 	static let path = Color.Wrap(foreground: .Yellow)
-
-	static func quote(string: String) -> String {
-		return Color.Wrap(foreground: .Green).autowrap("\u{0022}" + string + "\u{0022}")
+	
+	static func quote(string: String, quotationMark: String = "\u{0022}" /* double quote */) -> String {
+		return Color.Wrap(foreground: .Green).autowrap(quotationMark + string + quotationMark)
 	}
 }
 

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -21,9 +21,11 @@ internal struct Terminal {
 	static var terminalType: String? {
 		return getEnvironmentVariable("TERM").value()
 	}
+	
 	static var isDumb: Bool {
 		return terminalType?.caseInsensitiveCompare("dumb") == NSComparisonResult.OrderedSame ?? false
 	}
+	
 	static var isTTY: Bool {
 		return isatty(STDOUT_FILENO) == 1
 	}

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -74,12 +74,12 @@ public struct ColorOptions: OptionsType {
 		typealias Wrap = (string: String) -> String
 		
 		init(_ colorful: Bool) {
-			self.colorful    = colorful
-			self.bulletin    = wrap(colorful)(wrap: Color.Wrap(foreground: .Blue, style: .Bold))
-			self.bullets     = self.bulletin(string: "***") + " "
-			self.URL         = wrap(colorful)(wrap: Color.Wrap(styles: .Underlined))
-			self.projectName = wrap(colorful)(wrap: Color.Wrap(styles: .Bold))
-			self.path        = wrap(colorful)(wrap: Color.Wrap(foreground: .Yellow))
+			self.colorful = colorful
+			bulletin    = wrap(colorful)(wrap: Color.Wrap(foreground: .Blue, style: .Bold))
+			bullets     = self.bulletin(string: "***") + " "
+			URL         = wrap(colorful)(wrap: Color.Wrap(styles: .Underlined))
+			projectName = wrap(colorful)(wrap: Color.Wrap(styles: .Bold))
+			path        = wrap(colorful)(wrap: Color.Wrap(foreground: .Yellow))
 		}
 		
 		let bulletin: Wrap

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -90,6 +90,6 @@ public struct ColorOptions: OptionsType {
 	
 	public static func evaluate(m: CommandMode) -> Result<ColorOptions> {
 		return create
-			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "apply Terminal colors and formatting — ‘auto’ || ‘always’ || ‘never’")
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply color and terminal formatting (one of ‘auto’, ‘always’, or ‘never’)")
 	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -48,9 +48,12 @@ public enum ColorArgument: String, ArgumentType {
 	
 	public var isColorful: Bool {
 		switch self {
-		case .Always: return true
-		case .Never:  return false
-		case .Auto:   return Terminal.isTTY && !Terminal.isDumb
+		case .Always:
+			return true
+		case .Never:
+			return false
+		case .Auto:
+			return Terminal.isTTY && !Terminal.isDumb
 		}
 	}
 	

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -84,7 +84,7 @@ public struct ColorOptions: OptionsType {
 		}
 	}
 	
-	static func create(argument: ColorArgument) -> ColorOptions {
+	public static func create(argument: ColorArgument) -> ColorOptions {
 		return self(argument: argument, formatting: Formatting(argument.isColorful))
 	}
 	

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -29,7 +29,7 @@ internal struct Formatting {
 	static let projectName = [StyleParameter.Bold] as Color.Wrap
 	static let path = Color.Wrap(foreground: .Yellow)
 	
-	static func quote(string: String, quotationMark: String = "\u{0022}" /* double quote */) -> String {
+	static func quote(string: String, quotationMark: String = "\"") -> String {
 		return Color.Wrap(foreground: .Green).autowrap(quotationMark + string + quotationMark)
 	}
 	

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -83,6 +83,7 @@ public struct ColorOptions: OptionsType {
 			case .Success(let options):
 				return options.unbox.argument.isColorful
 			case .Failure(let error):
+				// Most likely an illegal value for `--color`.
 				fatalError(error.description)
 			}
 

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -93,6 +93,6 @@ public struct ColorOptions: OptionsType {
 	
 	public static func evaluate(m: CommandMode) -> Result<ColorOptions> {
 		return create
-			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "Terminal coloring and styling")
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply formatting and colors to terminal messages")
 	}
 }

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -32,11 +32,11 @@ public struct UpdateCommand: CommandType {
 public struct UpdateOptions: OptionsType {
 	public let buildAfterUpdate: Bool
 	public let configuration: String
-	private let checkoutOptions: CheckoutOptions
+	internal let checkoutOptions: CheckoutOptions
 
 	/// The build options corresponding to these options.
 	public var buildOptions: BuildOptions {
-		return BuildOptions(configuration: configuration, skipCurrent: true, directoryPath: checkoutOptions.directoryPath)
+		return BuildOptions(configuration: configuration, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, directoryPath: checkoutOptions.directoryPath)
 	}
 
 	/// If `buildAfterUpdate` is true, this will be a signal representing the

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -32,7 +32,7 @@ public struct UpdateCommand: CommandType {
 public struct UpdateOptions: OptionsType {
 	public let buildAfterUpdate: Bool
 	public let configuration: String
-	internal let checkoutOptions: CheckoutOptions
+	public let checkoutOptions: CheckoutOptions
 
 	/// The build options corresponding to these options.
 	public var buildOptions: BuildOptions {

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -51,13 +51,12 @@ public struct UpdateOptions: OptionsType {
 		}
 	}
 
-	public static func create(color: ColorOptions)(configuration: String)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
+	public static func create(configuration: String)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
 		return self(buildAfterUpdate: buildAfterUpdate, configuration: configuration, checkoutOptions: checkoutOptions)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions> {
 		return create
-			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
 			<*> m <| Option(key: "build", defaultValue: true, usage: "skip the building of dependencies after updating")
 			<*> CheckoutOptions.evaluate(m, useBinariesAddendum: " (ignored if --no-build option is present)")

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -51,12 +51,13 @@ public struct UpdateOptions: OptionsType {
 		}
 	}
 
-	public static func create(configuration: String)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
+	public static func create(color: ColorOptions)(configuration: String)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
 		return self(buildAfterUpdate: buildAfterUpdate, configuration: configuration, checkoutOptions: checkoutOptions)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions> {
 		return create
+			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
 			<*> m <| Option(key: "build", defaultValue: true, usage: "skip the building of dependencies after updating")
 			<*> CheckoutOptions.evaluate(m, useBinariesAddendum: " (ignored if --no-build option is present)")


### PR DESCRIPTION
_Resolves #121_

Adds colors and formatting to most `carthage.println`s. Imports [jdhealy/PrettyColors](//github.com/jdhealy/PrettyColors).

Basically just the bare minimum of commits to Carthage to allow for flexibility based off your feedback.

I based most of the color and formatting choices off [homebrew](//github.com/homebrew/homebrew).

Output looks like this in iTerm 2 with custom pastel-ish colors:
![screen shot 2015-01-12 at 1 00 04 pm](https://cloud.githubusercontent.com/assets/782837/5944325/132421c6-a6f4-11e4-8a46-414e479d8637.png)

Output looks like this in Terminal.app using basic colors:
![screen shot 2015-01-14 at 6 35 44 pm](https://cloud.githubusercontent.com/assets/782837/5944351/4975b384-a6f4-11e4-82b4-dc31359c01c4.png)

## Feedback
- Color and formatting choices
  - Any preferences on colors or formatting?
  - I've styled the output so far with [widely-supported styles](https://github.com/jdhealy/PrettyColors/wiki/Terminal-Support) _(bold and underlined)_ and [nearly-universal colors](https://github.com/jdhealy/PrettyColors/blob/development/Source/Color/Named.swift). 

- Command line arguments and environment variables
  - Should we check any environment variables? `$TERM`?
  - `--no-colors` flag?

- PrettyColors as a framework of CarthageKit
  - I embedded PrettyColors inside of CarthageKit like all the other dependencies, but the library is actually only used in the `carthage` target. Should it be taken out of CarthageKit?

- Lastly, I'd really welcome feedback on the library. It's pinned in the Cartfile at [`edf8291df2`](https://github.com/jdhealy/PrettyColors/commit/edf8291df2f524ed62dcfa60227b988535ccf6eb), which is essentially `v1.0.0-rc1`. So, please raise any concerns or observations! :smiley: