### PR TITLE
Move dependencies for CLI tools into Cartfile.private

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,5 @@
 github "ReactiveCocoa/ReactiveCocoa" "swift-development"
 github "Carthage/LlamaKit" == 0.1.1
 github "jspahrsummers/xcconfigs" >= 0.6
-github "Carthage/Commandant" "master"
 github "Carthage/ReactiveTask" "master"
 github "thoughtbot/Argo" ~> 0.2
-github "jdhealy/PrettyColors" ~> 1.0.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,5 @@
 github "Quick/Quick" == 0.2.0
 github "Quick/Nimble"
 github "jspahrsummers/xcconfigs" >= 0.6
+github "Carthage/Commandant" "master"
+github "jdhealy/PrettyColors" ~> 1.0.0


### PR DESCRIPTION
As discussed with @jspahrsummers [on Twitter](https://twitter.com/py/status/566830853997613058).