### PR TITLE
Remove xcconfigs from public Cartfile.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,5 @@
 github "ReactiveCocoa/ReactiveCocoa" "swift-development"
 github "Carthage/LlamaKit" == 0.1.1
-github "jspahrsummers/xcconfigs" >= 0.6
 github "Carthage/Commandant" "master"
 github "Carthage/ReactiveTask" "master"
 github "thoughtbot/Argo" ~> 0.2


### PR DESCRIPTION
This already exists in `Cartfile.private`, which is the correct place for it to live according to @jspahrsummers.

See https://twitter.com/jspahrsummers/status/566837562736508928 for a brief explanation.