### PR TITLE
Disable all Swift optimization for now

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -664,6 +664,7 @@
 			baseConfigurationReference = D0D1212619E878CC005E4BAA /* Debug.xcconfig */;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -672,6 +673,7 @@
 			baseConfigurationReference = D0D1212819E878CC005E4BAA /* Release.xcconfig */;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Release;
 		};
@@ -738,6 +740,7 @@
 			baseConfigurationReference = D0D1212719E878CC005E4BAA /* Profile.xcconfig */;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Profile;
 		};
@@ -775,6 +778,7 @@
 			baseConfigurationReference = D0D1212919E878CC005E4BAA /* Test.xcconfig */;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Test;
 		};


### PR DESCRIPTION
It’s unclear if this will actually fix any observed issues or not, but we do know that Swift 1.1 is #dangerzone with optimization: https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1632

Resolves #345.