### PR TITLE
[WIP] Use per-project settings specified in Cartfile.private

### DIFF
--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -16,8 +16,7 @@ class ProjectSpec: QuickSpec {
 		let directoryURL = NSBundle(forClass: self.dynamicType).URLForResource("CartfilePrivateOnly", withExtension: nil)!
 
 		it("should load a combined Cartfile when only a Cartfile.private is present") {
-			let result = Project(directoryURL: directoryURL).loadCombinedCartfile().single()
-
+			let result = Project(settings: ProjectSettings(directoryURL: directoryURL)).loadCombinedCartfile().single()
 			expect(result.isSuccess()).to(beTruthy())
 
 			let dependencies = result.value()?.dependencies ?? []

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -21,7 +21,9 @@ public struct BootstrapCommand: CommandType {
 		// `update` flags.
 		return ColdSignal.fromResult(UpdateOptions.evaluate(mode))
 			.map { options -> ColdSignal<()> in
-				return options.loadProject()
+				return ColdSignal.fromResult(options.projectSettings)
+					.map { settings in loadProjectWithSettings(settings, options.checkoutOptions.colorOptions) }
+					.merge(identity)
 					.map { project -> ColdSignal<()> in
 						return ColdSignal.lazy {
 							if NSFileManager.defaultManager().fileExistsAtPath(project.resolvedCartfileURL.path!) {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -57,7 +57,7 @@ public struct BuildCommand: CommandType {
 	/// cold signals representing each scheme being built.
 	private func buildProjectInDirectoryURL(directoryURL: NSURL, options: BuildOptions) -> (HotSignal<NSData>, ColdSignal<BuildSchemeSignal>) {
 		let (stdoutSignal, stdoutSink) = HotSignal<NSData>.pipe()
-		let project = Project(directoryURL: directoryURL)
+		let project = Project(settings: ProjectSettings(directoryURL: directoryURL))
 
 		var buildSignal = project.loadCombinedCartfile()
 			.map { _ in project }
@@ -219,7 +219,7 @@ extension BuildPlatform: ArgumentType {
 				return platform
 			}
 		}
-		
+
 		return nil
 	}
 }


### PR DESCRIPTION
Resolves #262.

**To do:**

- [ ] Encapsulate `CheckoutOptions` entirely within `UpdateOptions`
- [ ] Parse boolean settings in the OGDL form `setting-name {true,false}`
- [ ] Use parsed settings for default `ProjectSettings` values, before overriding from the command line
- [ ] Unit test parsing of settings
- [ ] Never allow settings in `Cartfile`, only `Cartfile.private`
- [ ] [Document](https://github.com/Carthage/Carthage/tree/6e848c76c3544198776b5c6a0c759d95104d1745/Documentation) supported settings