### PR TITLE
Add fallback to show a tag when the release title is empty

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -83,6 +83,11 @@ public struct GitHubRelease: Equatable {
 	/// The name of this release.
 	public let name: String
 
+	/// The name of this release, with fallback to its tag when the name is an empty string.
+	public var nameWithFallback: String {
+		return name.isEmpty ? tag : name
+	}
+
 	/// The name of the tag upon which this release is based.
 	public let tag: String
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -387,7 +387,7 @@ public final class Project {
 		return releaseForTag(revision, repository, credentials)
 			.filter(binaryFrameworksCanBeProvidedByRelease)
 			.on(next: { release in
-				self._projectEventsSink.put(.DownloadingBinaries(project, release.name))
+				self._projectEventsSink.put(.DownloadingBinaries(project, release.nameWithFallback))
 			})
 			.concatMap { release in
 				return ColdSignal


### PR DESCRIPTION
GitHub releases allow an empty title.

When the release title is empty, carthage shows
```
*** Downloading ProjectName at ""
```