### PR TITLE
When enumerating schemes, increase timeout for `xcodebuild -list` from 4s to 8s

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -145,7 +145,7 @@ public enum CarthageError {
 
 		case let .XcodebuildListTimeout(project):
 			return CarthageErrorCode.XcodebuildListTimeout.error([
-				NSLocalizedDescriptionKey: "Timeout whilst listing project \"\(project)\" schemes. This could mean that no shared schemes could be found or xcodebuild is just taking too long to execute"
+				NSLocalizedDescriptionKey: "Failed to discover shared schemes in project \"(project)\"—either the project does not have any shared schemes, or xcodebuild never returned"
 			])
 			
 		case let .DuplicateDependencies(duplicateDeps):

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -25,6 +25,7 @@ public enum CarthageErrorCode: Int {
 	case InvalidArchitectures
 	case MissingEnvironmentVariable
 	case NoSharedSchemes
+	case XcodebuildListTimeout
 	case DuplicateDependencies
 
 	func error(userInfo: [NSObject: AnyObject]?) -> NSError {
@@ -71,6 +72,9 @@ public enum CarthageError {
 	/// The project is not sharing any schemes, so Carthage cannot discover
 	/// them.
 	case NoSharedSchemes(ProjectLocator)
+
+	/// Timeout whilst running `xcodebuild list` to enumerate shared schemes.
+	case XcodebuildListTimeout(ProjectLocator)
 
 	/// A cartfile contains duplicate dependencies, either in itself or across
 	/// other cartfiles.
@@ -139,6 +143,11 @@ public enum CarthageError {
 				NSLocalizedDescriptionKey: "Project \"\(project)\" has no shared schemes"
 			])
 
+		case let .XcodebuildListTimeout(project):
+			return CarthageErrorCode.XcodebuildListTimeout.error([
+				NSLocalizedDescriptionKey: "Timeout whilst listing project \"\(project)\" schemes. This could mean that no shared schemes could be found or xcodebuild is just taking too long to execute"
+			])
+			
 		case let .DuplicateDependencies(duplicateDeps):
 			let deps = duplicateDeps
 				.sorted(<) // important to match expected order in test cases

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -145,7 +145,7 @@ public enum CarthageError {
 
 		case let .XcodebuildListTimeout(project):
 			return CarthageErrorCode.XcodebuildListTimeout.error([
-				NSLocalizedDescriptionKey: "Failed to discover shared schemes in project \"(project)\"—either the project does not have any shared schemes, or xcodebuild never returned"
+				NSLocalizedDescriptionKey: "Failed to discover shared schemes in project \(project)—either the project does not have any shared schemes, or xcodebuild never returned"
 			])
 			
 		case let .DuplicateDependencies(duplicateDeps):

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -234,8 +234,6 @@ public func schemesInProject(project: ProjectLocator) -> ColdSignal<String> {
 		// xcodebuild has a bug where xcodebuild -list can sometimes hang
 		// indefinitely on projects that don't share any schemes, so
 		// automatically bail out if it looks like that's happening.
-		// xcodebuild may also take a while to execute;
-		// see https://github.com/carthage/carthage/issues/299
 		.timeoutWithError(CarthageError.XcodebuildListTimeout(project).error, afterInterval: 8, onScheduler: QueueScheduler())
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
 }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -234,7 +234,9 @@ public func schemesInProject(project: ProjectLocator) -> ColdSignal<String> {
 		// xcodebuild has a bug where xcodebuild -list can sometimes hang
 		// indefinitely on projects that don't share any schemes, so
 		// automatically bail out if it looks like that's happening.
-		.timeoutWithError(CarthageError.NoSharedSchemes(project).error, afterInterval: 4, onScheduler: QueueScheduler())
+		// xcodebuild may also take a while to execute;
+		// see https://github.com/carthage/carthage/issues/299
+		.timeoutWithError(CarthageError.XcodebuildListTimeout(project).error, afterInterval: 8, onScheduler: QueueScheduler())
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
 }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -901,7 +901,7 @@ public func buildDependencyProject(dependency: ProjectIdentifier, rootDirectoryU
 ///
 /// Returns an error with an issue filing suggestion.
 private func addIssueFilingSuggestionToError(error: NSError, repo: GitHubRepository) -> NSError {
-	var userInfo = error.userInfo!
+	var userInfo = error.userInfo ?? NSMutableDictionary()
 
 	userInfo[NSLocalizedDescriptionKey] = error.localizedDescription + "\n\nIf you believe this to be a project configuration error, please file an issue with the maintainers at \(repo.newIssueURL.absoluteString!)"
 


### PR DESCRIPTION
Also adds CarthageError.XcodebuildListTimeout. See issue #299.