### PR TITLE
Fix building in symlinked checkouts

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -421,7 +421,7 @@ public final class Project {
 			.map { sdk in sdk.platform }
 			.map { platform in self.directoryURL.URLByAppendingPathComponent(platform.relativePath, isDirectory: true) }
 			.map { platformFolderURL in platformFolderURL.URLByAppendingPathComponent(frameworkURL.lastPathComponent!) }
-			.mergeMap { destinationFrameworkURL in copyFramework(frameworkURL, destinationFrameworkURL) }
+			.mergeMap { destinationFrameworkURL in copyFramework(frameworkURL, destinationFrameworkURL.URLByResolvingSymlinksInPath!) }
 	}
 
 	/// Checks out the given project into its intended working directory,

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -855,7 +855,7 @@ public func buildDependencyProject(dependency: ProjectIdentifier, rootDirectoryU
 		// Link this dependency's Carthage/Build folder to that of the root
 		// project, so it can see all products built already, and so we can
 		// automatically drop this dependency's product in the right place.
-		let dependencyBinariesURL = dependencyURL.URLByResolvingSymlinksInPath!.URLByAppendingPathComponent(CarthageBinariesFolderPath, isDirectory: true)
+		let dependencyBinariesURL = dependencyURL.URLByAppendingPathComponent(CarthageBinariesFolderPath, isDirectory: true)
 
 		if !NSFileManager.defaultManager().removeItemAtURL(dependencyBinariesURL, error: nil) {
 			let dependencyParentURL = dependencyBinariesURL.URLByDeletingLastPathComponent!


### PR DESCRIPTION
This allows folders in Carthage/Checkouts to be symlinks, if users want to overwrite or otherwise manipulate those folders after `carthage checkout` completes but before `carthage build` runs.