### PR TITLE
Don't count nested frameworks in frameworksInDirectory(_:)

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -596,6 +596,13 @@ private func frameworksInDirectory(directoryURL: NSURL) -> SignalProducer<NSURL,
 
 			return false
 		}
+		|> filter { URL in
+			// Skip nested frameworks
+			let frameworksInURL = URL.pathComponents?.filter { pathComponent in
+				return (pathComponent as? String)?.pathExtension == "framework"
+			}
+			return frameworksInURL?.count == 1
+		}
 }
 
 /// Determines whether a Release is a suitable candidate for binary frameworks.


### PR DESCRIPTION
Resolves #444.

Carthage shouldn't be independently copying nested vendored frameworks.