### PR TITLE
Ask git not to prompt for credentials

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -233,7 +233,7 @@ internal struct GitHubCredentials {
 	static func loadFromGit() -> SignalProducer<GitHubCredentials?, CarthageError> {
 		let data = "url=https://github.com".dataUsingEncoding(NSUTF8StringEncoding)!
 
-		return launchGitTask([ "credential", "fill" ], standardInput: SignalProducer(value: data))
+		return launchGitTask([ "credential", "fill" ], standardInput: SignalProducer(value: data), environment: ["GIT_TERMINAL_PROMPT": "0"])
 			|> map { string -> SignalProducer<String, CarthageError> in
 				return string.linesProducer |> promoteErrors(CarthageError.self)
 			}


### PR DESCRIPTION
This was introduced with Git 2.3. My Apple-provided Git is 2.3.2 on my 10.10.3 system with Xcode 6.3.1.

Should fix #449, #447, #445, and #219 on most systems. I’m not sure when or how Apple updates the system Git, so I don’t know which versions won’t be fixed.