### PR TITLE
Add `DebugSinkOf`

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -134,7 +134,7 @@ extension Submodule: Printable {
 
 /// Shells out to `git` with the given arguments, optionally in the directory
 /// of an existing repository.
-public func launchGitTask(arguments: [String], repositoryFileURL: NSURL? = nil, standardInput: SignalProducer<NSData, NoError>? = nil, standardOutput: SinkOfNSData? = nil, standardError: SinkOfNSData? = nil, environment: [String: String]? = nil) -> SignalProducer<String, CarthageError> {
+public func launchGitTask(arguments: [String], repositoryFileURL: NSURL? = nil, standardInput: SignalProducer<NSData, NoError>? = nil, standardOutput: DataSink? = nil, standardError: DataSink? = nil, environment: [String: String]? = nil) -> SignalProducer<String, CarthageError> {
 	let taskDescription = TaskDescription(launchPath: "/usr/bin/env", arguments: [ "git" ] + arguments, workingDirectoryPath: repositoryFileURL?.path, environment: environment, standardInput: standardInput)
 
 	return launchTask(taskDescription, standardOutput: standardOutput, standardError: standardError)
@@ -195,7 +195,7 @@ public func listTags(repositoryFileURL: NSURL) -> SignalProducer<String, Carthag
 /// the path could not be loaded.
 public func contentsOfFileInRepository(repositoryFileURL: NSURL, path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
 	let showObject = "\(revision):\(path)"
-	return launchGitTask([ "show", showObject ], repositoryFileURL: repositoryFileURL, standardError: SinkOfNSData { _ in () })
+	return launchGitTask([ "show", showObject ], repositoryFileURL: repositoryFileURL, standardError: DataSink { _ in () })
 }
 
 /// Checks out the working tree of the given (ideally bare) repository, at the
@@ -352,7 +352,7 @@ public func submodulesInRepository(repositoryFileURL: NSURL, revision: String = 
 	let modulesObject = "\(revision):.gitmodules"
 	let baseArguments = [ "config", "--blob", modulesObject, "-z" ]
 
-	return launchGitTask(baseArguments + [ "--get-regexp", "submodule\\..*\\.path" ], repositoryFileURL: repositoryFileURL, standardError: SinkOfNSData { _ in () })
+	return launchGitTask(baseArguments + [ "--get-regexp", "submodule\\..*\\.path" ], repositoryFileURL: repositoryFileURL, standardError: DataSink { _ in () })
 		|> catch { _ in SignalProducer<String, NoError>.empty }
 		|> map { value in parseConfigEntries(value, keyPrefix: "submodule.", keySuffix: ".path") }
 		|> flatten(.Concat)
@@ -381,7 +381,7 @@ public func commitExistsInRepository(repositoryFileURL: NSURL, revision: String 
 			return
 		}
 
-		launchGitTask([ "rev-parse", "\(revision)^{commit}" ], repositoryFileURL: repositoryFileURL, standardOutput: SinkOfNSData { _ in () }, standardError: SinkOfNSData { _ in () })
+		launchGitTask([ "rev-parse", "\(revision)^{commit}" ], repositoryFileURL: repositoryFileURL, standardOutput: DataSink { _ in () }, standardError: DataSink { _ in () })
 			|> then(SignalProducer<Bool, CarthageError>(value: true))
 			|> catch { _ in SignalProducer<Bool, NoError>(value: false) }
 			|> startWithSignal { signal, signalDisposable in
@@ -393,7 +393,7 @@ public func commitExistsInRepository(repositoryFileURL: NSURL, revision: String 
 
 /// Attempts to resolve the given reference into an object SHA.
 public func resolveReferenceInRepository(repositoryFileURL: NSURL, reference: String) -> SignalProducer<String, CarthageError> {
-	return launchGitTask([ "rev-parse", "\(reference)^{object}" ], repositoryFileURL: repositoryFileURL, standardError: SinkOfNSData { _ in () })
+	return launchGitTask([ "rev-parse", "\(reference)^{object}" ], repositoryFileURL: repositoryFileURL, standardError: DataSink { _ in () })
 		|> map { string in string.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) }
 		|> catch { _ in SignalProducer(error: CarthageError.RepositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No object named \"\(reference)\" exists", underlyingError: nil)) }
 }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -134,7 +134,7 @@ extension Submodule: Printable {
 
 /// Shells out to `git` with the given arguments, optionally in the directory
 /// of an existing repository.
-public func launchGitTask(arguments: [String], repositoryFileURL: NSURL? = nil, standardInput: SignalProducer<NSData, NoError>? = nil, standardOutput: SinkOf<NSData>? = nil, standardError: SinkOf<NSData>? = nil, environment: [String: String]? = nil) -> SignalProducer<String, CarthageError> {
+public func launchGitTask(arguments: [String], repositoryFileURL: NSURL? = nil, standardInput: SignalProducer<NSData, NoError>? = nil, standardOutput: SinkOfNSData? = nil, standardError: SinkOfNSData? = nil, environment: [String: String]? = nil) -> SignalProducer<String, CarthageError> {
 	let taskDescription = TaskDescription(launchPath: "/usr/bin/env", arguments: [ "git" ] + arguments, workingDirectoryPath: repositoryFileURL?.path, environment: environment, standardInput: standardInput)
 
 	return launchTask(taskDescription, standardOutput: standardOutput, standardError: standardError)
@@ -195,7 +195,7 @@ public func listTags(repositoryFileURL: NSURL) -> SignalProducer<String, Carthag
 /// the path could not be loaded.
 public func contentsOfFileInRepository(repositoryFileURL: NSURL, path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
 	let showObject = "\(revision):\(path)"
-	return launchGitTask([ "show", showObject ], repositoryFileURL: repositoryFileURL, standardError: SinkOf<NSData> { _ in () })
+	return launchGitTask([ "show", showObject ], repositoryFileURL: repositoryFileURL, standardError: SinkOfNSData { _ in () })
 }
 
 /// Checks out the working tree of the given (ideally bare) repository, at the
@@ -352,7 +352,7 @@ public func submodulesInRepository(repositoryFileURL: NSURL, revision: String = 
 	let modulesObject = "\(revision):.gitmodules"
 	let baseArguments = [ "config", "--blob", modulesObject, "-z" ]
 
-	return launchGitTask(baseArguments + [ "--get-regexp", "submodule\\..*\\.path" ], repositoryFileURL: repositoryFileURL, standardError: SinkOf<NSData> { _ in () })
+	return launchGitTask(baseArguments + [ "--get-regexp", "submodule\\..*\\.path" ], repositoryFileURL: repositoryFileURL, standardError: SinkOfNSData { _ in () })
 		|> catch { _ in SignalProducer<String, NoError>.empty }
 		|> map { value in parseConfigEntries(value, keyPrefix: "submodule.", keySuffix: ".path") }
 		|> flatten(.Concat)
@@ -381,7 +381,7 @@ public func commitExistsInRepository(repositoryFileURL: NSURL, revision: String 
 			return
 		}
 
-		launchGitTask([ "rev-parse", "\(revision)^{commit}" ], repositoryFileURL: repositoryFileURL, standardOutput: SinkOf<NSData> { _ in () }, standardError: SinkOf<NSData> { _ in () })
+		launchGitTask([ "rev-parse", "\(revision)^{commit}" ], repositoryFileURL: repositoryFileURL, standardOutput: SinkOfNSData { _ in () }, standardError: SinkOfNSData { _ in () })
 			|> then(SignalProducer<Bool, CarthageError>(value: true))
 			|> catch { _ in SignalProducer<Bool, NoError>(value: false) }
 			|> startWithSignal { signal, signalDisposable in
@@ -393,7 +393,7 @@ public func commitExistsInRepository(repositoryFileURL: NSURL, revision: String 
 
 /// Attempts to resolve the given reference into an object SHA.
 public func resolveReferenceInRepository(repositoryFileURL: NSURL, reference: String) -> SignalProducer<String, CarthageError> {
-	return launchGitTask([ "rev-parse", "\(reference)^{object}" ], repositoryFileURL: repositoryFileURL, standardError: SinkOf<NSData> { _ in () })
+	return launchGitTask([ "rev-parse", "\(reference)^{object}" ], repositoryFileURL: repositoryFileURL, standardError: SinkOfNSData { _ in () })
 		|> map { string in string.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) }
 		|> catch { _ in SignalProducer(error: CarthageError.RepositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No object named \"\(reference)\" exists", underlyingError: nil)) }
 }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -770,7 +770,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		var buildScheme = xcodebuildTask("build", copiedArgs)
 		buildScheme.workingDirectoryPath = workingDirectoryURL.path!
 
-		return launchTask(buildScheme, standardOutput: SinkOf { data in
+		return launchTask(buildScheme, standardOutput: SinkOfNSData { data in
 				sendNext(stdoutSink, data)
 			})
 			|> catch { error in SignalProducer(error: .TaskError(error)) }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -770,7 +770,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		var buildScheme = xcodebuildTask("build", copiedArgs)
 		buildScheme.workingDirectoryPath = workingDirectoryURL.path!
 
-		return launchTask(buildScheme, standardOutput: SinkOfNSData { data in
+		return launchTask(buildScheme, standardOutput: DataSink { data in
 				sendNext(stdoutSink, data)
 			})
 			|> catch { error in SignalProducer(error: .TaskError(error)) }

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -118,7 +118,7 @@ class XcodeSpec: QuickSpec {
 			var output: String = ""
 			let codeSign = TaskDescription(launchPath: "/usr/bin/xcrun", arguments: [ "codesign", "--verify", "--verbose", targetURL.path! ])
 
-			let codesignResult = launchTask(codeSign, standardError: SinkOfNSData { data -> () in
+			let codesignResult = launchTask(codeSign, standardError: DataSink { data -> () in
 					output += NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))! as String
 				})
 				|> wait

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -118,7 +118,7 @@ class XcodeSpec: QuickSpec {
 			var output: String = ""
 			let codeSign = TaskDescription(launchPath: "/usr/bin/xcrun", arguments: [ "codesign", "--verify", "--verbose", targetURL.path! ])
 
-			let codesignResult = launchTask(codeSign, standardError: SinkOf<NSData> { data -> () in
+			let codesignResult = launchTask(codeSign, standardError: SinkOfNSData { data -> () in
 					output += NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))! as String
 				})
 				|> wait

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -49,7 +49,7 @@ public struct BuildCommand: CommandType {
 						|> filter { _ in false }
 						|> observe(stderrSink)
 
-					let stderrSinkWrapper: SinkOfNSData = SinkOfNSData { data in
+					let stderrSinkWrapper: DataSink = DataSink { data in
 						stderrSink.put(.Next(Box(data)))
 						return
 					}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -49,7 +49,7 @@ public struct BuildCommand: CommandType {
 						|> filter { _ in false }
 						|> observe(stderrSink)
 
-					let stderrSinkWrapper: SinkOf<NSData> = SinkOf { data in
+					let stderrSinkWrapper: SinkOfNSData = SinkOfNSData { data in
 						stderrSink.put(.Next(Box(data)))
 						return
 					}


### PR DESCRIPTION
Xcode debugger can't step into `SinkType.put()`.
Using `DebugSinkOf` instead of `SinkOf` allow step into `SinkType.put()`

https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2021