### PR TITLE
[Version] Only strip leading "v" or "version-" when parsing SemVer

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -89,7 +89,11 @@ extension SemanticVersion: Scannable {
 			return .failure(CarthageError.ParseError(description: "expected major version number in \"\(version!)\""))
 		}
 
-		let minor = (components.count > 1 ? components[1].toInt() : 0)
+		let minor = (components.count > 1 ? components[1].toInt() : nil)
+		if minor == nil {
+			return .failure(CarthageError.ParseError(description: "expected minor version number in \"\(version!)\""))
+		}
+
 		let patch = (components.count > 2 ? components[2].toInt() : 0)
 
 		return .success(self(major: major!, minor: minor ?? 0, patch: patch ?? 0))

--- a/Source/CarthageKitTests/VersionSpec.swift
+++ b/Source/CarthageKitTests/VersionSpec.swift
@@ -31,8 +31,11 @@ class SemanticVersionSpec: QuickSpec {
 
 		it("should parse semantic versions") {
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("1.4")).value).to(equal(SemanticVersion(major: 1, minor: 4, patch: 0)))
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v1")).value).to(beNil())
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8.9")).value).to(equal(SemanticVersion(major: 2, minor: 8, patch: 9)))
+		}
+
+		it("should fail on invalid semantic versions") {
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v1")).value).to(beNil())
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8-alpha")).value).to(beNil())
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("null-string-beta-2")).value).to(beNil())
 		}

--- a/Source/CarthageKitTests/VersionSpec.swift
+++ b/Source/CarthageKitTests/VersionSpec.swift
@@ -31,9 +31,10 @@ class SemanticVersionSpec: QuickSpec {
 
 		it("should parse semantic versions") {
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("1.4")).value).to(equal(SemanticVersion(major: 1, minor: 4, patch: 0)))
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v1")).value).to(equal(SemanticVersion(major: 1, minor: 0, patch: 0)))
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v1")).value).to(beNil())
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8.9")).value).to(equal(SemanticVersion(major: 2, minor: 8, patch: 9)))
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8-alpha")).value).to(beNil())
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("null-string-beta-2")).value).to(beNil())
 		}
 	}
 }


### PR DESCRIPTION
This means you can have arbitrary, non-version tags that _happen_ to end in numbers, and those trailing numbers will no longer be interpreted as a semantic version.