### PR TITLE
Copy dSYM files alongside built frameworks

### DIFF
--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -67,13 +67,21 @@ class XcodeSpec: QuickSpec {
 
 			for dependency in projectNames {
 				let macPath = buildFolderURL.URLByAppendingPathComponent("Mac/\(dependency).framework").path!
+				let macdSYMPath = macPath.stringByAppendingPathExtension("dSYM")!
 				let iOSPath = buildFolderURL.URLByAppendingPathComponent("iOS/\(dependency).framework").path!
+				let iOSdSYMPath = iOSPath.stringByAppendingPathExtension("dSYM")!
 
 				var isDirectory: ObjCBool = false
 				expect(NSFileManager.defaultManager().fileExistsAtPath(macPath, isDirectory: &isDirectory)).to(beTruthy())
 				expect(isDirectory).to(beTruthy())
 
+				expect(NSFileManager.defaultManager().fileExistsAtPath(macdSYMPath, isDirectory: &isDirectory)).to(beTruthy())
+				expect(isDirectory).to(beTruthy())
+
 				expect(NSFileManager.defaultManager().fileExistsAtPath(iOSPath, isDirectory: &isDirectory)).to(beTruthy())
+				expect(isDirectory).to(beTruthy())
+
+				expect(NSFileManager.defaultManager().fileExistsAtPath(iOSdSYMPath, isDirectory: &isDirectory)).to(beTruthy())
 				expect(isDirectory).to(beTruthy())
 			}
 			let frameworkFolderURL = buildFolderURL.URLByAppendingPathComponent("iOS/ReactiveCocoaLayout.framework")


### PR DESCRIPTION
Fixes #507.

This is basically working at this point. I'm open to any feedback you have on the approach I've taken. Currently I just look for `*.framework.dSYM` and copy that into Carthage's build directory alongside the framework.

The main thing missing here is creating a universal dSYM for both iOS platforms. I'm not entirely sure whether this is necessary, as you usually won't need to symbolicate crash reports for simulator builds—but maybe there's a use case I'm not thinking of?

This could probably do with a test that the iOS dSYM includes the arm architectures rather than simulator.