### PR TITLE
Style: Convert errant spaces to tab.

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -102,7 +102,7 @@ extension Cartfile {
 	}
 
 	/// Returns the dependencies in a cartfile as a counted set containing the
-    /// corresponding projects, represented as a dictionary.
+	/// corresponding projects, represented as a dictionary.
 	private var dependencyCountedSet: [ProjectIdentifier: Int] {
 		return buildCountedSet(self.dependencies.map { $0.project })
 	}


### PR DESCRIPTION
Noticed some spaced mixed below a tab in `Cartfile.swift`.