### PR TITLE
Allow github releases with null names

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -118,11 +118,14 @@ public struct GitHubRelease: Equatable {
 	public let ID: Int
 
 	/// The name of this release.
-	public let name: String
+	public let name: String?
 
-	/// The name of this release, with fallback to its tag when the name is an empty string.
+	/// The name of this release, with fallback to its tag when the name is an empty string or nil.
 	public var nameWithFallback: String {
-		return name.isEmpty ? tag : name
+		if let name = name {
+			return name.isEmpty ? tag : name
+		}
+		return tag
 	}
 
 	/// The name of the tag upon which this release is based.
@@ -194,14 +197,14 @@ extension GitHubRelease: Printable {
 }
 
 extension GitHubRelease: Decodable {
-	public static func create(ID: Int)(name: String)(tag: String)(draft: Bool)(prerelease: Bool)(assets: [Asset]) -> GitHubRelease {
+	public static func create(ID: Int)(name: String?)(tag: String)(draft: Bool)(prerelease: Bool)(assets: [Asset]) -> GitHubRelease {
 		return self(ID: ID, name: name, tag: tag, draft: draft, prerelease: prerelease, assets: assets)
 	}
 
 	public static func decode(j: JSON) -> Decoded<GitHubRelease> {
 		return self.create
 			<^> j <| "id"
-			<*> j <| "name"
+			<*> j <|? "name"
 			<*> j <| "tag_name"
 			<*> j <| "draft"
 			<*> j <| "prerelease"

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -122,8 +122,8 @@ public struct GitHubRelease: Equatable {
 
 	/// The name of this release, with fallback to its tag when the name is an empty string or nil.
 	public var nameWithFallback: String {
-		if let name = name {
-			return name.isEmpty ? tag : name
+		if let name = name where !name.isEmpty {
+			return name
 		}
 		return tag
 	}


### PR DESCRIPTION
JSON deserialization of a GitHub release fails when the name field is null. Currently, the implementation of `GitHubRelease` only accepts empty strings as values of name. This ammends releases to allow nil strings as well.