### PR TITLE
Remove redundant watchOS definition from BuildPlatform.acceptedStrings

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -270,7 +270,7 @@ extension BuildPlatform: ArgumentType {
 	private static let acceptedStrings: [String: BuildPlatform] = [
 		"Mac": .Mac, "macosx": .Mac,
 		"iOS": .iOS, "iphoneos": .iOS, "iphonesimulator": .iOS,
-		"watchOS": .watchOS, "watchos": .watchOS, "watchsimulator": .watchOS,
+		"watchOS": .watchOS, "watchsimulator": .watchOS,
 		"all": .All
 	]
 


### PR DESCRIPTION
Resolves https://github.com/Carthage/Carthage/pull/552#discussion_r32374292.