### PR TITLE
Remove Equatable implementations for enums without associated values

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -298,16 +298,6 @@ public enum Platform: Equatable {
 	}
 }
 
-public func == (lhs: Platform, rhs: Platform) -> Bool {
-	switch (lhs, rhs) {
-	case (.Mac, .Mac), (.iOS, .iOS):
-		return true
-
-	default:
-		return false
-	}
-}
-
 extension Platform: Printable {
 	public var description: String {
 		switch self {
@@ -405,16 +395,6 @@ public enum SDK: Equatable {
 	}
 }
 
-public func == (lhs: SDK, rhs: SDK) -> Bool {
-	switch (lhs, rhs) {
-	case (.MacOSX, .MacOSX), (.iPhoneSimulator, .iPhoneSimulator), (.iPhoneOS, .iPhoneOS), (.watchOS, .watchOS), (.watchSimulator, .watchSimulator):
-		return true
-
-	default:
-		return false
-	}
-}
-
 extension SDK: Printable {
 	public var description: String {
 		switch self {
@@ -463,22 +443,6 @@ public enum ProductType: Equatable {
 		default:
 			return .failure(.ParseError(description: "unexpected product type \"(string)\""))
 		}
-	}
-}
-
-public func ==(lhs: ProductType, rhs: ProductType) -> Bool {
-	switch (lhs, rhs) {
-	case (.Framework, .Framework):
-		return true
-
-	case (.StaticLibrary, .StaticLibrary):
-		return true
-
-	case (.TestBundle, .TestBundle):
-		return true
-
-	default:
-		return false
 	}
 }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -251,7 +251,7 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 }
 
 /// Represents a platform to build for.
-public enum Platform: Equatable {
+public enum Platform {
 	/// Mac OS X.
 	case Mac
 
@@ -314,7 +314,7 @@ extension Platform: Printable {
 }
 
 /// Represents an SDK buildable by Xcode.
-public enum SDK: Equatable {
+public enum SDK {
 	/// Mac OS X.
 	case MacOSX
 
@@ -417,7 +417,7 @@ extension SDK: Printable {
 }
 
 /// Describes the type of product built by an Xcode target.
-public enum ProductType: Equatable {
+public enum ProductType {
 	/// A framework bundle.
 	case Framework
 

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -196,7 +196,7 @@ public struct BuildOptions: OptionsType {
 }
 
 /// Represents the user’s chosen platform to build for.
-public enum BuildPlatform: Equatable {
+public enum BuildPlatform {
 	/// Build for all available platforms.
 	case All
 

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -227,25 +227,6 @@ public enum BuildPlatform: Equatable {
 	}
 }
 
-public func == (lhs: BuildPlatform, rhs: BuildPlatform) -> Bool {
-	switch (lhs, rhs) {
-	case (.All, .All):
-		return true
-
-	case (.iOS, .iOS):
-		return true
-
-	case (.Mac, .Mac):
-		return true
-
-	case (.watchOS, .watchOS):
-		return true
-
-	default:
-		return false
-	}
-}
-
 extension BuildPlatform: Printable {
 	public var description: String {
 		switch self {


### PR DESCRIPTION
This is the same as ReactiveCocoa/ReactiveCocoa#2049.