### PR TITLE
Upload CarthageKit.framework to releases with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ deploy:
   api-key:
     secure: c1fMI4p8oUVGi7SkDLqXpZDhrVVnLWU8J6+rWc3pTMmeNmEGopZpCiiQupHoHXx+Fq3+8R4M2iG0IgfcVTb6q5HD2RH0+q57/p9vcYIlCS8E/1o2BPUHUfH1Poc1vs7VdFpjWFmbm6Twnnffbz3AsELjv3mJyRxR6fUAliwfnWk=
   file: Carthage.pkg
+  file: CarthageKit.framework.zip
   skip_cleanup: true
   on:
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test: clean bootstrap
 
 clean:
 	rm -f "$(OUTPUT_PACKAGE)"
+	rm -f "$(OUTPUT_FRAMEWORK_ZIP)"
 	rm -rf "$(TEMPORARY_FOLDER)"
 	$(BUILD_TOOL) $(XCODEFLAGS) clean
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,16 @@ BUILD_TOOL?=xcodebuild
 
 XCODEFLAGS=-workspace 'Carthage.xcworkspace' -scheme 'carthage' DSTROOT=$(TEMPORARY_FOLDER)
 
+OUTPUT_PACKAGE=Carthage.pkg
+OUTPUT_FRAMEWORK=CarthageKit.framework
+OUTPUT_FRAMEWORK_ZIP=CarthageKit.framework.zip
+
 BUILT_BUNDLE=$(TEMPORARY_FOLDER)/Applications/carthage.app
-CARTHAGEKIT_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/CarthageKit.framework
+CARTHAGEKIT_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/$(OUTPUT_FRAMEWORK)
 CARTHAGE_EXECUTABLE=$(BUILT_BUNDLE)/Contents/MacOS/carthage
 
 FRAMEWORKS_FOLDER=/Library/Frameworks
 BINARIES_FOLDER=/usr/local/bin
-
-OUTPUT_PACKAGE=Carthage.pkg
 
 VERSION_STRING=$(shell agvtool what-marketing-version -terse1)
 COMPONENTS_PLIST=Source/carthage/Components.plist
@@ -36,22 +38,22 @@ install: package
 	sudo installer -pkg Carthage.pkg -target /
 
 uninstall:
-	rm -rf "$(FRAMEWORKS_FOLDER)/CarthageKit.framework"
+	rm -rf "$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)"
 	rm -f "$(BINARIES_FOLDER)/carthage"
 
 installables: clean bootstrap
 	$(BUILD_TOOL) $(XCODEFLAGS) install
 
 	mkdir -p "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)"
-	mv -f "$(CARTHAGEKIT_BUNDLE)" "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/CarthageKit.framework"
+	mv -f "$(CARTHAGEKIT_BUNDLE)" "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)"
 	mv -f "$(CARTHAGE_EXECUTABLE)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage"
 	rm -rf "$(BUILT_BUNDLE)"
 
 prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
-	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/CarthageKit.framework" "$(PREFIX)/Frameworks/"
+	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
-	install_name_tool -add_rpath "@executable_path/../Frameworks/CarthageKit.framework/Versions/Current/Frameworks/"  "$(PREFIX)/bin/carthage"
+	install_name_tool -add_rpath "@executable_path/../Frameworks/$(OUTPUT_FRAMEWORK)/Versions/Current/Frameworks/"  "$(PREFIX)/bin/carthage"
 
 package: installables
 	pkgbuild \
@@ -61,3 +63,5 @@ package: installables
 		--root "$(TEMPORARY_FOLDER)" \
 		--version "$(VERSION_STRING)" \
 		"$(OUTPUT_PACKAGE)"
+	
+	(cd "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" && zip -q -r --symlinks - "$(OUTPUT_FRAMEWORK)") > "$(OUTPUT_FRAMEWORK_ZIP)"


### PR DESCRIPTION
Now `make package` will archive `CarthageKit.framework` into the working directory automatically.