### PR TITLE
Set ONLY_ACTIVE_ARCH=NO when building

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -207,7 +207,7 @@ public func locateProjectsInDirectory(directoryURL: NSURL) -> SignalProducer<Pro
 /// Creates a task description for executing `xcodebuild` with the given
 /// arguments.
 public func xcodebuildTask(task: String, buildArguments: BuildArguments) -> TaskDescription {
-	return TaskDescription(launchPath: "/usr/bin/xcrun", arguments: buildArguments.arguments + [ task ])
+	return TaskDescription(launchPath: "/usr/bin/xcrun", arguments: buildArguments.arguments + [ task, "ONLY_ACTIVE_ARCH=NO" ])
 }
 
 /// Sends each scheme found in the given project.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -120,6 +120,7 @@ public struct BuildArguments {
 
 		if let sdk = sdk {
 			args += sdk.arguments
+			args += [ "ONLY_ACTIVE_ARCH=NO" ]
 		}
 
 		return args
@@ -207,7 +208,7 @@ public func locateProjectsInDirectory(directoryURL: NSURL) -> SignalProducer<Pro
 /// Creates a task description for executing `xcodebuild` with the given
 /// arguments.
 public func xcodebuildTask(task: String, buildArguments: BuildArguments) -> TaskDescription {
-	return TaskDescription(launchPath: "/usr/bin/xcrun", arguments: buildArguments.arguments + [ task, "ONLY_ACTIVE_ARCH=NO" ])
+	return TaskDescription(launchPath: "/usr/bin/xcrun", arguments: buildArguments.arguments + [ task ])
 }
 
 /// Sends each scheme found in the given project.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -99,6 +99,10 @@ public struct BuildArguments {
 	/// The platform SDK to build for.
 	public var sdk: SDK?
 
+	/// The build setting whether the product includes only object code for
+	/// the native architecture.
+	public var onlyActiveArchitecture: OnlyActiveArchitecture = .NotSpecified
+
 	public init(project: ProjectLocator, scheme: String? = nil, configuration: String? = nil, sdk: SDK? = nil) {
 		self.project = project
 		self.scheme = scheme
@@ -120,8 +124,9 @@ public struct BuildArguments {
 
 		if let sdk = sdk {
 			args += sdk.arguments
-			args += [ "ONLY_ACTIVE_ARCH=NO" ]
 		}
+
+		args += onlyActiveArchitecture.arguments
 
 		return args
 	}
@@ -413,6 +418,34 @@ extension SDK: Printable {
 
 		case .watchSimulator:
 			return "watchOS Simulator"
+		}
+	}
+}
+
+/// Represents a build setting whether the product includes only object code
+/// for the native architecture.
+public enum OnlyActiveArchitecture {
+	/// Not specified.
+	case NotSpecified
+
+	/// The product includes only code for the native architecture.
+	case Yes
+
+	/// The product includes code for its target's valid architectures.
+	case No
+
+	/// The arguments that should be passed to `xcodebuild` to specify the
+	/// setting for this case.
+	private var arguments: [String] {
+		switch self {
+		case .NotSpecified:
+			return []
+
+		case .Yes:
+			return [ "ONLY_ACTIVE_ARCH=YES" ]
+
+		case .No:
+			return [ "ONLY_ACTIVE_ARCH=NO" ]
 		}
 	}
 }
@@ -794,16 +827,19 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 
 	let buildArgs = BuildArguments(project: project, scheme: scheme, configuration: configuration)
 	let buildSDK = { (sdk: SDK) -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> in
-		var copiedArgs = buildArgs
-		copiedArgs.sdk = sdk
+		var argsForLoading = buildArgs
+		argsForLoading.sdk = sdk
 
-		var buildScheme = xcodebuildTask("build", copiedArgs)
+		var argsForBuilding = argsForLoading
+		argsForBuilding.onlyActiveArchitecture = .No
+
+		var buildScheme = xcodebuildTask("build", argsForBuilding)
 		buildScheme.workingDirectoryPath = workingDirectoryURL.path!
 
 		return launchTask(buildScheme)
 			|> mapError { .TaskError($0) }
 			|> flatMapTaskEvents(.Concat) { _ in
-				return BuildSettings.loadWithArguments(copiedArgs)
+				return BuildSettings.loadWithArguments(argsForLoading)
 					|> filter { settings in
 						// Only copy build products for the product types we care about.
 						if let productType = settings.productType.value {


### PR DESCRIPTION
Resolves #504.

~~This currently sets the flag for all `xcodebuild` tasks other than `xcodebuild build`.~~