### PR TITLE
Inherit the environment of the parent

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -232,8 +232,11 @@ internal struct GitHubCredentials {
 	/// Attempts to load credentials from the Git credential store.
 	static func loadFromGit() -> SignalProducer<GitHubCredentials?, CarthageError> {
 		let data = "url=https://github.com".dataUsingEncoding(NSUTF8StringEncoding)!
-
-		return launchGitTask([ "credential", "fill" ], standardInput: SignalProducer(value: data), environment: ["GIT_TERMINAL_PROMPT": "0"])
+		
+		var environment = NSProcessInfo.processInfo().environment as! [String: String]
+		environment["GIT_TERMINAL_PROMPT"] = "0"
+		
+		return launchGitTask([ "credential", "fill" ], standardInput: SignalProducer(value: data), environment: environment)
 			|> flatMap(.Concat) { string -> SignalProducer<String, CarthageError> in
 				return string.linesProducer |> promoteErrors(CarthageError.self)
 			}


### PR DESCRIPTION
This can be important, as I’ve found out. Specifically, our CI depends on having the environment set. Without it, our credentials can't be looked up, leading to anonymous API usage which can be rate limited.