### PR TITLE
Allow dependencies which have no projects, not to error out with `.NoSharedFrameworkSchemes`

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1033,7 +1033,6 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 			}
 			|> flatMap(.Merge) { scheme, project -> SignalProducer<(String, ProjectLocator), CarthageError> in
 				return locatorBuffer
-					|> filter { project, schemes in !schemes.isEmpty }
 					// This scheduler hop is required to avoid disallowed recursive signals.
 					// See https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2042.
 					|> startOn(QueueScheduler(name: "org.carthage.CarthageKit.Xcode.buildInDirectory"))

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -186,7 +186,7 @@ class XcodeSpec: QuickSpec {
 
 			expect(result.error).notTo(beNil())
 
-			var expectedError: Bool
+			let expectedError: Bool
 			switch result.error {
 			case .Some(.NoSharedFrameworkSchemes):
 				expectedError = true


### PR DESCRIPTION
Fixes https://github.com/Carthage/Carthage/pull/632#issuecomment-124813933.