### PR TITLE
Fix error descriptions of some `.ParseError`

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -332,7 +332,7 @@ public enum SDK: String {
 
 	/// Attempts to parse an SDK name from a string returned from `xcodebuild`.
 	public static func fromString(string: String) -> Result<SDK, CarthageError> {
-		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected SDK key \(string)"))
+		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected SDK key \"\(string)\""))
 	}
 
 	/// The platform that this SDK targets.
@@ -403,7 +403,7 @@ public enum ProductType: String {
 	/// Attempts to parse a product type from a string returned from
 	/// `xcodebuild`.
 	public static func fromString(string: String) -> Result<ProductType, CarthageError> {
-		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected product type \"(string)\""))
+		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected product type \"\(string)\""))
 	}
 }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -332,7 +332,7 @@ public enum SDK: String {
 
 	/// Attempts to parse an SDK name from a string returned from `xcodebuild`.
 	public static func fromString(string: String) -> Result<SDK, CarthageError> {
-		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected SDK key \"(string)\""))
+		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected SDK key \(string)"))
 	}
 
 	/// The platform that this SDK targets.


### PR DESCRIPTION
Takes over @neonichu's work in #621.