### PR TITLE
Add -destination flag to build arguments when building for the simulator

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -168,7 +168,7 @@ public struct BuildArguments {
 		}
 
 		if let destination = destination {
-			args += [ "-destination", destination.description]
+			args += [ "-destination", destination.description ]
 		}
 
 		args += onlyActiveArchitecture.arguments

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -129,6 +129,9 @@ public struct BuildArguments {
 	/// The run destination to try building for.
 	public var destination: BuildDestination?
 
+	/// The amount of time xcodebuild spends looking for the destination (in seconds).
+	public var destinationTimeout: UInt?
+
 	/// The build setting whether the product includes only object code for
 	/// the native architecture.
 	public var onlyActiveArchitecture: OnlyActiveArchitecture = .NotSpecified
@@ -158,6 +161,10 @@ public struct BuildArguments {
 
 		if let destination = destination {
 			args += [ "-destination", destination.description ]
+		}
+
+		if let destinationTimeout = destinationTimeout {
+			args += [ "-destination-timeout", String(destinationTimeout) ]
 		}
 
 		args += onlyActiveArchitecture.arguments
@@ -831,6 +838,9 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 			// Example: Target is at 8.0, project at 7.0, xcodebuild chooses the first
 			// simulator on the list, iPad 2 7.1, which is invalid for the target.
 			argsForBuilding.destination = BuildDestination.iOSSimulator(name: "iPhone 6", OS: "latest")
+			// Also set the destonation lookup timeout. Since we're building for the simulator the lookup
+			// shouldn't take more than a fraction of a second.
+			argsForBuilding.destinationTimeout = 3 // Set to 3 just to be safe.
 		}
 
 		var buildScheme = xcodebuildTask("build", argsForBuilding)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -804,6 +804,11 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		var argsForBuilding = argsForLoading
 		argsForBuilding.onlyActiveArchitecture = .No
 
+		// If SDK is the iOS simulator, then also find and set a valid destination.
+		// This fixes problems when the project deployment version is lower than the target's
+		// and includes simulators unsupported by the target.
+		// Example: Target is at 8.0, project at 7.0, xcodebuild chooses the first
+		// simulator on the list, iPad 2 7.1, which is invalid for the target.
 		func fetchDestination() -> SignalProducer<String?, ReactiveTaskError> {
 			if sdk == .iPhoneSimulator {
 				let destinationLookup = TaskDescription(launchPath: "/usr/bin/xcrun", arguments: [ "simctl", "list", "devices" ])
@@ -811,9 +816,12 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 					|> ignoreTaskData
 					|> map { data in
 						let string = NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))!
+						// The output as of Xcode 6.4 is structured text so we parse it using regex. The destination will be omitted altogether if parsing fails.
+						// Xcode 7.0 beta 4 added a JSON output option to simctl so this can be switched once 7.0 becomes a requirement.
 						let regex = NSRegularExpression(pattern: "-- iOS [0-9.]+ --\\n.*?\\(([0-9A-Z]{8}-([0-9A-Z]{4}-){3}[0-9A-Z]{12})\\)", options: nil, error: nil)!
 						let lastDeviceResult = regex.matchesInString(string as String, options: nil, range: NSRange(location: 0, length: string.length)).last as? NSTextCheckingResult
 						return lastDeviceResult.map { result in
+							// We use the ID here instead of the name as it's guaranteed to be unique, the name isn't.
 							let deviceID = string.substringWithRange(result.rangeAtIndex(1))
 							return "platform=iOS Simulator,id=\(deviceID)"
 						}
@@ -826,6 +834,8 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 			|> flatMap(.Concat) { destination -> SignalProducer<TaskEvent<NSData>, ReactiveTaskError> in
 				if let destination = destination {
 					argsForBuilding.destination = destination
+					// Also set the destonation lookup timeout. Since we're building for the simulator the lookup
+					// shouldn't take more than a fraction of a second, but we set to 3 just to be safe.
 					argsForBuilding.destinationTimeout = 3
 				}
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -812,7 +812,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 					|> map { data in
 						let string = NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))!
 						let regex = NSRegularExpression(pattern: "-- iOS [0-9.]+ --\\n.*?\\(([0-9A-Z]{8}-([0-9A-Z]{4}-){3}[0-9A-Z]{12})\\)", options: nil, error: nil)!
-						let lastDeviceResult = regex.matchesInString(string as String, options: nil, range: NSRange(location: 0, length: (string as NSString).length)).last as? NSTextCheckingResult
+						let lastDeviceResult = regex.matchesInString(string as String, options: nil, range: NSRange(location: 0, length: string.length)).last as? NSTextCheckingResult
 						return lastDeviceResult.map { result in
 							let deviceID = string.substringWithRange(result.rangeAtIndex(1))
 							return "platform=iOS Simulator,id=\(deviceID)"

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -124,21 +124,10 @@ public struct BuildArguments {
 	public var configuration: String?
 
 	/// The platform SDK to build for.
-	public var sdk: SDK? {
-		didSet {
-			// If SDK is the iOS simulator, then also set the destination.
-			// This fixes problems when the project deployment version is lower than the target's
-			// and includes simulators unsupported by the target.
-			// Example: Target is at 8.0, project at 7.0, xcodebuild chooses the first
-			// simulator on the list, iPad 2 7.1, which is invalid for the target.
-			if sdk == .iPhoneSimulator {
-				self.destination = BuildDestination.iOSSimulator(name: "iPhone 6", OS: "latest")
-			}
-		}
-	}
+	public var sdk: SDK?
 
 	/// The run destination to try building for.
-	private var destination: BuildDestination?
+	public var destination: BuildDestination?
 
 	/// The build setting whether the product includes only object code for
 	/// the native architecture.
@@ -834,6 +823,15 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 
 		var argsForBuilding = argsForLoading
 		argsForBuilding.onlyActiveArchitecture = .No
+
+		if sdk == .iPhoneSimulator {
+			// If SDK is the iOS simulator, then also set the destination.
+			// This fixes problems when the project deployment version is lower than the target's
+			// and includes simulators unsupported by the target.
+			// Example: Target is at 8.0, project at 7.0, xcodebuild chooses the first
+			// simulator on the list, iPad 2 7.1, which is invalid for the target.
+			argsForBuilding.destination = BuildDestination.iOSSimulator(name: "iPhone 6", OS: "latest")
+		}
 
 		var buildScheme = xcodebuildTask("build", argsForBuilding)
 		buildScheme.workingDirectoryPath = workingDirectoryURL.path!


### PR DESCRIPTION
This fixes problems when the project deployment version is lower than the target's deployment version. In that case `xcodebuild` chooses the first destination on the list, which is iPad 2 (7.1) as of Xcode 6.4. Some projects that have targets for both a static library and dynamic framework have such a configuration (for example [HTMLReader](https://github.com/nolanw/HTMLReader)), as they support a lower deployment version for the static library than the framework.

The destination name is hardcoded to iPhone 6 because I'm currently not aware of a way to list all valid destinations.