### PR TITLE
Build schemes from workspaces, not projects

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -245,12 +245,6 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		// automatically bail out if it looks like that's happening.
 		|> timeoutWithError(.XcodebuildListTimeout(project, nil), afterInterval: 8, onScheduler: QueueScheduler())
 		|> map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
-		|> filter { (line: String) -> Bool in
-			if let schemePath = project.fileURL.URLByAppendingPathComponent("xcshareddata/xcschemes/\(line).xcscheme").path {
-				return NSFileManager.defaultManager().fileExistsAtPath(schemePath)
-			}
-			return false
-		}
 }
 
 /// Represents a platform to build for.
@@ -1015,6 +1009,18 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 			|> filter { projects in !projects.isEmpty }
 			|> flatMap(.Merge) { (projects: [(ProjectLocator, [String])]) -> SignalProducer<(String, ProjectLocator), CarthageError> in
 				return SignalProducer(values: projects)
+					|> flatMap(.Concat) { (project: ProjectLocator, schemes: [String]) in
+						// Only look for schemes that actually reside in the project
+						return SignalProducer(values: schemes)
+							|> filter { (scheme: String) -> Bool in
+								if let schemePath = project.fileURL.URLByAppendingPathComponent("xcshareddata/xcschemes/\(scheme).xcscheme").path {
+									return NSFileManager.defaultManager().fileExistsAtPath(schemePath)
+								}
+								return false
+							}
+							|> collect
+							|> map { (project, $0) }
+					}
 					|> filter { (project: ProjectLocator, schemes: [String]) in
 						switch project {
 						case .ProjectFile where !schemes.isEmpty:


### PR DESCRIPTION
We were filtering out schemes that don’t actually sit in the given
project. That works great when you’re deciding what to build, but not
when you’re deciding where to build it from.

We should be building from the workspace (if there is one) to correctly pick up dependencies.

Move the filtering to happen only where we decide which schemes to
build.