### PR TITLE
Make a GitHub API request failure a warning and non-fatal

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -78,8 +78,10 @@ public enum ProjectEvent {
 	/// there weren't any viable binaries after all.
 	case DownloadingBinaries(ProjectIdentifier, String)
 
-	/// A request to the GitHub API failed due to authentication or rate-limiting.
-	case GitHubAPIRequestFailed(ProjectIdentifier, String)
+	/// Downloading any available binaries of the project is being skipped,
+	/// because of a GitHub API request failure which is due to authentication
+	/// or rate-limiting.
+	case SkippedDownloadingBinaries(ProjectIdentifier, String)
 }
 
 /// Represents a project that is using Carthage.
@@ -368,7 +370,7 @@ public final class Project {
 				case .GitHubAPIRequestFailed:
 					// Log the GitHub API request failure, not to error out,
 					// because that should not be fatal error.
-					sendNext(self._projectEventsObserver, .GitHubAPIRequestFailed(project, error.description))
+					sendNext(self._projectEventsObserver, .SkippedDownloadingBinaries(project, error.description))
 					return .empty
 
 				default:

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -77,6 +77,9 @@ public enum ProjectEvent {
 	/// being downloaded. This may still be followed by `CheckingOut` event if
 	/// there weren't any viable binaries after all.
 	case DownloadingBinaries(ProjectIdentifier, String)
+
+	/// A request to the GitHub API failed due to authentication or rate-limiting.
+	case GitHubAPIRequestFailed(ProjectIdentifier, String)
 }
 
 /// Represents a project that is using Carthage.
@@ -360,6 +363,18 @@ public final class Project {
 	private func downloadMatchingBinariesForProject(project: ProjectIdentifier, atRevision revision: String, fromRepository repository: GitHubRepository, withAuthorizationHeaderValue authorizationHeaderValue: String?) -> SignalProducer<NSURL, CarthageError> {
 		return releaseForTag(revision, repository, authorizationHeaderValue)
 			|> filter(binaryFrameworksCanBeProvidedByRelease)
+			|> catch { error in
+				switch error {
+				case .GitHubAPIRequestFailed:
+					// Log the GitHub API request failure, not to error out,
+					// because that should not be fatal error.
+					sendNext(self._projectEventsObserver, .GitHubAPIRequestFailed(project, error.description))
+					return .empty
+
+				default:
+					return SignalProducer(error: error)
+				}
+			}
 			|> on(next: { release in
 				sendNext(self._projectEventsObserver, ProjectEvent.DownloadingBinaries(project, release.nameWithFallback))
 			})

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -145,7 +145,7 @@ internal struct ProjectEventSink: SinkType {
 		case let .DownloadingBinaries(project, release):
 			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(string: project.name) + " at " + formatting.quote(release))
 
-		case let .GitHubAPIRequestFailed(project, message):
+		case let .SkippedDownloadingBinaries(project, message):
 			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(string: project.name) + " due to the error:\n\t" + formatting.quote(message))
 		}
 	}

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -144,6 +144,9 @@ internal struct ProjectEventSink: SinkType {
 
 		case let .DownloadingBinaries(project, release):
 			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(string: project.name) + " at " + formatting.quote(release))
+
+		case let .GitHubAPIRequestFailed(project, message):
+			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(string: project.name) + " due to the error:\n\t" + formatting.quote(message))
 		}
 	}
 }


### PR DESCRIPTION
Resolves #465.