### PR TITLE
Run `git submodule sync` recursively

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -425,7 +425,7 @@ public func addSubmoduleToRepository(repositoryFileURL: NSURL, submodule: Submod
 				// Just check out and stage the correct revision.
 				return fetchRepository(submoduleDirectoryURL, remoteURL: fetchURL, refspec: "+refs/heads/*:refs/remotes/origin/*")
 					|> then(launchGitTask([ "config", "--file", ".gitmodules", "submodule.\(submodule.name).url", submodule.URL.URLString ], repositoryFileURL: repositoryFileURL))
-					|> then(launchGitTask([ "submodule", "--quiet", "sync" ], repositoryFileURL: repositoryFileURL))
+					|> then(launchGitTask([ "submodule", "--quiet", "sync", "--recursive" ], repositoryFileURL: repositoryFileURL))
 					|> then(checkoutSubmodule(submodule, submoduleDirectoryURL))
 					|> then(launchGitTask([ "add", "--force", submodule.path ], repositoryFileURL: repositoryFileURL))
 					|> then(.empty)


### PR DESCRIPTION
`--recursive` option for `submodule sync` is introduced in [git 1.8.1](https://github.com/git/git/blob/5d417842efeafb6e109db7574196901c4e95d273/Documentation/RelNotes/1.8.1.txt#L98) (but that is documented in [2.0.2](https://github.com/git/git/blob/ebc5da3208824e25a89672a3b91bd13629b215fe/Documentation/RelNotes/2.0.2.txt#L4-L5)).

Fixes #184.