### PR TITLE
Warn .NoSharedFrameworkSchemes error, not to error out

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -48,7 +48,7 @@ public enum CarthageError: Equatable {
 
 	/// The project is not sharing any framework schemes, so Carthage cannot
 	/// discover them.
-	case NoSharedFrameworkSchemes(ProjectIdentifier)
+	case NoSharedFrameworkSchemes(ProjectIdentifier, Platform?)
 
 	/// The project is not sharing any schemes, so Carthage cannot discover
 	/// them.
@@ -110,8 +110,8 @@ public func == (lhs: CarthageError, rhs: CarthageError) -> Bool {
 	case let (.InvalidArchitectures(left), .InvalidArchitectures(right)):
 		return left == right
 
-	case let (.NoSharedFrameworkSchemes(left), .NoSharedFrameworkSchemes(right)):
-		return left == right
+	case let (.NoSharedFrameworkSchemes(la, lb), .NoSharedFrameworkSchemes(ra, rb)):
+		return la == ra && lb == rb
 
 	case let (.NoSharedSchemes(la, lb), .NoSharedSchemes(ra, rb)):
 		return la == ra && lb == rb
@@ -191,8 +191,11 @@ extension CarthageError: Printable {
 		case let .MissingEnvironmentVariable(variable):
 			return "Environment variable not set: \(variable)"
 
-		case let .NoSharedFrameworkSchemes(projectIdentifier):
+		case let .NoSharedFrameworkSchemes(projectIdentifier, platform):
 			var description = "Dependency \"\(projectIdentifier.name)\" has no shared framework schemes"
+			if let platform = platform {
+				description += " for platform \(platform)"
+			}
 
 			switch projectIdentifier {
 			case let .GitHub(repository):

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1009,8 +1009,8 @@ public func buildDependencyProject(dependency: ProjectIdentifier, rootDirectoryU
 			return schemeProducers
 				|> mapError { error in
 					switch (dependency, error) {
-					case let (_, .NoSharedFrameworkSchemes(_)):
-						return .NoSharedFrameworkSchemes(dependency)
+					case let (_, .NoSharedFrameworkSchemes(_, platform)):
+						return .NoSharedFrameworkSchemes(dependency, platform)
 
 					case let (.GitHub(repo), .NoSharedSchemes(project, _)):
 						return .NoSharedSchemes(project, repo)
@@ -1091,7 +1091,7 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 							return false
 						}
 					}
-					|> concat(SignalProducer(error: .NoSharedFrameworkSchemes(.Git(GitURL(directoryURL.path!)))))
+					|> concat(SignalProducer(error: .NoSharedFrameworkSchemes(.Git(GitURL(directoryURL.path!)), platform)))
 					|> take(1)
 					|> flatMap(.Merge) { project, schemes in SignalProducer(values: schemes.map { ($0, project) }) }
 			}

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -147,6 +147,9 @@ internal struct ProjectEventSink: SinkType {
 
 		case let .SkippedDownloadingBinaries(project, message):
 			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(string: project.name) + " due to the error:\n\t" + formatting.quote(message))
+
+		case let .SkippedBuilding(project, message):
+			carthage.println(formatting.bullets + "Skipped building " + formatting.projectName(string: project.name) + " due to the error:\n" + message)
 		}
 	}
 }


### PR DESCRIPTION
This improves console output for that error, and make it possible to continue building other dependencies.

This is based on the discussion in #675. /cc @yasuoza