### PR TITLE
Completely remove git submodules when using prebuilt binaries

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -335,9 +335,7 @@ public final class Project {
 						|> flatMap(.Concat) { directoryURL in
 							return frameworksInDirectory(directoryURL)
 								|> flatMap(.Merge, self.copyFrameworkToBuildFolder)
-								|> on(completed: {
-									_ = NSFileManager.defaultManager().trashItemAtURL(checkoutDirectoryURL, resultingItemURL: nil, error: nil)
-								})
+								|> then(removeSubmoduleFromRepository(self.directoryURL, checkoutDirectoryURL))
 								|> then(SignalProducer(value: directoryURL))
 						}
 						|> tryMap { (temporaryDirectoryURL: NSURL) -> Result<Bool, CarthageError> in


### PR DESCRIPTION
Addresses the comment in #419:

> if a binary is downloaded, the submodule will be removed (__and incompletely, at that__)

This clarify, by deleting `.gitmodules` entries too, the fact that submodules are removed.