### PR TITLE
Disable binary downloads when using submodules

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -498,12 +498,21 @@ public final class Project {
 						let project = dependency.project
 						let revision = dependency.version.commitish
 
+						let submoduleFound = submodulesByPath[project.relativePath] != nil
+						let checkoutOrCloneProject = self.checkoutOrCloneProject(project, atRevision: revision, submodulesByPath: submodulesByPath)
+
+						// Disable binary downloads for the dependency if that
+						// is already checked out as a submodule.
+						if submoduleFound {
+							return checkoutOrCloneProject
+						}
+
 						return self.installBinariesForProject(project, atRevision: revision)
 							|> flatMap(.Merge) { installed in
 								if installed {
 									return .empty
 								} else {
-									return self.checkoutOrCloneProject(project, atRevision: revision, submodulesByPath: submodulesByPath)
+									return checkoutOrCloneProject
 								}
 							}
 					}

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -40,7 +40,10 @@ public struct CheckoutOptions: OptionsType {
 	public let colorOptions: ColorOptions
 
 	public static func create(useSSH: Bool)(useSubmodules: Bool)(useBinaries: Bool)(colorOptions: ColorOptions)(directoryPath: String) -> CheckoutOptions {
-		return self(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: useBinaries, colorOptions: colorOptions)
+		// Disable binary downloads when using submodules.
+		// See https://github.com/Carthage/Carthage/issues/419.
+		let shouldUseBinaries = useSubmodules ? false : useBinaries
+		return self(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: shouldUseBinaries, colorOptions: colorOptions)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<CheckoutOptions, CommandantError<CarthageError>> {
@@ -51,7 +54,7 @@ public struct CheckoutOptions: OptionsType {
 		return create
 			<*> m <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 			<*> m <| Option(key: "use-submodules", defaultValue: false, usage: "add dependencies as Git submodules")
-			<*> m <| Option(key: "use-binaries", defaultValue: true, usage: "check out dependency repositories even when prebuilt frameworks exist" + useBinariesAddendum)
+			<*> m <| Option(key: "use-binaries", defaultValue: true, usage: "check out dependency repositories even when prebuilt frameworks exist, disabled if --use-submodules option is present" + useBinariesAddendum)
 			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")
 	}


### PR DESCRIPTION
Fixes #419:

> 1. Disable binary downloads by default when using submodules

I'm not sure if f448fc5 is needed and d4fbb78 is sufficient.