### PR TITLE
Use a more descriptive description for downloads

### DIFF
--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -143,7 +143,7 @@ internal struct ProjectEventSink: SinkType {
 			carthage.println(formatting.bullets + "Checking out " + formatting.projectName(string: project.name) + " at " + formatting.quote(revision))
 
 		case let .DownloadingBinaries(project, release):
-			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(string: project.name) + " at " + formatting.quote(release))
+			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(string: project.name) + ".framework binary at " + formatting.quote(release))
 
 		case let .SkippedDownloadingBinaries(project, message):
 			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(string: project.name) + " due to the error:\n\t" + formatting.quote(message))

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -146,7 +146,7 @@ internal struct ProjectEventSink: SinkType {
 			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(string: project.name) + ".framework binary at " + formatting.quote(release))
 
 		case let .SkippedDownloadingBinaries(project, message):
-			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(string: project.name) + " due to the error:\n\t" + formatting.quote(message))
+			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(string: project.name) + ".framework binary due to the error:\n\t" + formatting.quote(message))
 
 		case let .SkippedBuilding(project, message):
 			carthage.println(formatting.bullets + "Skipped building " + formatting.projectName(string: project.name) + " due to the error:\n" + message)


### PR DESCRIPTION
I'm hoping that this will make it a little clearer that it's downloading a pre-built copy. I wanted to include the work _binary_ since the flag is `--use-binaries`.