### PR TITLE
Fix wrong build order with nested dependencies

### DIFF
--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -201,7 +201,7 @@ private struct DependencyGraph: Equatable {
 	var allNodes: Set<DependencyNode> = []
 
 	/// All nodes that have dependencies, associated with those lists of
-	/// dependencies themselves.
+	/// dependencies themselves including the intermediates.
 	var edges: [DependencyNode: Set<DependencyNode>] = [:]
 
 	/// The root nodes of the graph (i.e., those dependencies that are listed
@@ -280,6 +280,15 @@ private struct DependencyGraph: Equatable {
 			var nodeSet = edges[dependencyOf] ?? Set()
 			nodeSet.insert(node)
 			edges[dependencyOf] = nodeSet
+
+			// Add a nested dependency to the list of its ancestor.
+			let edgesCopy = edges
+			for (ancestor, var itsDependencies) in edgesCopy {
+				if itsDependencies.contains(dependencyOf) {
+					itsDependencies.insert(node)
+					edges[ancestor] = itsDependencies
+				}
+			}
 		} else {
 			roots.insert(node)
 		}

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -279,6 +279,12 @@ private struct DependencyGraph: Equatable {
 		if let dependencyOf = dependencyOf {
 			var nodeSet = edges[dependencyOf] ?? Set()
 			nodeSet.insert(node)
+
+			// If the given node has its dependencies, add thme also to the list.
+			if let dependenciesOfNode = edges[node] {
+				nodeSet.unionInPlace(dependenciesOfNode)
+			}
+
 			edges[dependencyOf] = nodeSet
 
 			// Add a nested dependency to the list of its ancestor.

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -214,17 +214,21 @@ private struct DependencyGraph: Equatable {
 			let lhsDependencies = self.edges[lhs]
 			let rhsDependencies = self.edges[rhs]
 
-			// If the right node or its nested dependencies have a dependency on
-			// the left node, the left node needs to be built first (and is thus
-			// ordered first).
-			if let rhsDependencies = rhsDependencies where self.edgeDependsOn(rhsDependencies, dependsOn: lhs) {
-				return true
+			if let rhsDependencies = rhsDependencies {
+				// If the right node has a dependency on the left node, the
+				// left node needs to be built first (and is thus ordered
+				// first).
+				if rhsDependencies.contains(lhs) {
+					return true
+				}
 			}
 
-			// If the left node or its nested dependencies have a dependency on
-			// the right node, the right node needs to be built first.
-			if let lhsDependencies = lhsDependencies where self.edgeDependsOn(lhsDependencies, dependsOn: rhs) {
-				return false
+			if let lhsDependencies = lhsDependencies {
+				// If the left node has a dependency on the right node, the
+				// right node needs to be built first.
+				if lhsDependencies.contains(rhs) {
+					return false
+				}
 			}
 
 			// If neither node depends on each other, sort the one with the
@@ -244,22 +248,6 @@ private struct DependencyGraph: Equatable {
 	}
 
 	init() {}
-
-	/// Determines whether the set of nodes or the dependencies of them have a
-	/// dependency on the given node.
-	func edgeDependsOn(edge: Set<DependencyNode>, dependsOn: DependencyNode) -> Bool {
-		if edge.contains(dependsOn) {
-			return true
-		}
-
-		for node in edge {
-			if let nodeDependencies = self.edges[node] where edgeDependsOn(nodeDependencies, dependsOn: dependsOn) {
-				return true
-			}
-		}
-
-		return false
-	}
 
 	/// Attempts to add the given node to the graph, optionally as a dependency
 	/// of another.

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -214,21 +214,17 @@ private struct DependencyGraph: Equatable {
 			let lhsDependencies = self.edges[lhs]
 			let rhsDependencies = self.edges[rhs]
 
-			if let rhsDependencies = rhsDependencies {
-				// If the right node has a dependency on the left node, the
-				// left node needs to be built first (and is thus ordered
-				// first).
-				if rhsDependencies.contains(lhs) {
-					return true
-				}
+			// If the right node or its nested dependencies have a dependency on
+			// the left node, the left node needs to be built first (and is thus
+			// ordered first).
+			if let rhsDependencies = rhsDependencies where self.edgeDependsOn(rhsDependencies, dependsOn: lhs) {
+				return true
 			}
 
-			if let lhsDependencies = lhsDependencies {
-				// If the left node has a dependency on the right node, the
-				// right node needs to be built first.
-				if lhsDependencies.contains(rhs) {
-					return false
-				}
+			// If the left node or its nested dependencies have a dependency on
+			// the right node, the right node needs to be built first.
+			if let lhsDependencies = lhsDependencies where self.edgeDependsOn(lhsDependencies, dependsOn: rhs) {
+				return false
 			}
 
 			// If neither node depends on each other, sort the one with the
@@ -248,6 +244,22 @@ private struct DependencyGraph: Equatable {
 	}
 
 	init() {}
+
+	/// Determines whether the set of nodes or the dependencies of them have a
+	/// dependency on the given node.
+	func edgeDependsOn(edge: Set<DependencyNode>, dependsOn: DependencyNode) -> Bool {
+		if edge.contains(dependsOn) {
+			return true
+		}
+
+		for node in edge {
+			if let nodeDependencies = self.edges[node] where edgeDependsOn(nodeDependencies, dependsOn: dependsOn) {
+				return true
+			}
+		}
+
+		return false
+	}
 
 	/// Attempts to add the given node to the graph, optionally as a dependency
 	/// of another.

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -280,7 +280,7 @@ private struct DependencyGraph: Equatable {
 			var nodeSet = edges[dependencyOf] ?? Set()
 			nodeSet.insert(node)
 
-			// If the given node has its dependencies, add thme also to the list.
+			// If the given node has its dependencies, add them also to the list.
 			if let dependenciesOfNode = edges[node] {
 				nodeSet.unionInPlace(dependenciesOfNode)
 			}


### PR DESCRIPTION
Should fix #415.

The results in `Cartfile.resolved` with `github "Carthage/Carthage" "master"`:

```
// before (Carthage 0.8)
github "robrix/Box" "1.2.2"
github "jdhealy/PrettyColors" "v2.0.0"
github "thoughtbot/Runes" "v2.0.0"
github "Carthage/ReactiveTask" "0.7-beta.3"
github "antitypical/Result" "0.4.4"
github "Carthage/Commandant" "0.6.1"
github "ReactiveCocoa/ReactiveCocoa" "v3.0-RC.1"
github "thoughtbot/Argo" "v1.0.4"
github "Carthage/Carthage" "aed38106616578f6269b5d72f4d2dbad58beceab"

// after
github "robrix/Box" "1.2.2"
github "jdhealy/PrettyColors" "v2.0.0"
github "thoughtbot/Runes" "v2.0.0"
github "antitypical/Result" "0.4.4"
github "Carthage/Commandant" "0.6.1"
github "ReactiveCocoa/ReactiveCocoa" "v3.0-RC.1"
github "Carthage/ReactiveTask" "0.7-beta.3"
github "thoughtbot/Argo" "v1.0.4"
github "Carthage/Carthage" "aed38106616578f6269b5d72f4d2dbad58beceab"
```
