### PR TITLE
cleaner implementation of stripGitSuffix function

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -69,8 +69,7 @@ public struct GitURL: Equatable {
 	/// Strips any trailing .git in the given name, if one exists.
 	private func stripGitSuffix(string: String) -> String {
 		if string.hasSuffix(".git") {
-			let nsString = string as NSString
-			return nsString.substringToIndex(nsString.length - 4) as String
+			return string.substringToIndex(advance(string.endIndex, -4))
 		} else {
 			return string
 		}


### PR DESCRIPTION
This may be a more simple way to achieve this function's goal of removing potential ".git" suffixes.

Hope it helps! 