### PR TITLE
Use NSFileManager.moveItemAtURL() as a fallback of rename() system call when EXDEV error occurred

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -573,10 +573,11 @@ private func cacheDownloadedBinary(downloadURL: NSURL, toURL cachedURL: NSURL) -
 			}
 		}
 		|> try { newDownloadURL in
-			if rename(downloadURL.fileSystemRepresentation, newDownloadURL.fileSystemRepresentation) == 0 {
+			var error: NSError?
+			if NSFileManager.defaultManager().moveItemAtURL(downloadURL, toURL: newDownloadURL, error: &error) {
 				return .success(())
 			} else {
-				return .failure(.TaskError(.POSIXError(errno)))
+				return .failure(.WriteFailed(newDownloadURL, error))
 			}
 		}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -573,6 +573,20 @@ private func cacheDownloadedBinary(downloadURL: NSURL, toURL cachedURL: NSURL) -
 			}
 		}
 		|> try { newDownloadURL in
+			// Tries `rename()` system call at first.
+			if rename(downloadURL.fileSystemRepresentation, newDownloadURL.fileSystemRepresentation) == 0 {
+				return .success(())
+			}
+
+			if errno != EXDEV {
+				return .failure(.TaskError(.POSIXError(errno)))
+			}
+
+			// If the “Cross-device link” error occurred, then falls back to
+			// `NSFileManager.moveItemAtURL()`.
+			//
+			// See https://github.com/Carthage/Carthage/issues/706 and
+			// https://github.com/Carthage/Carthage/issues/711.
 			var error: NSError?
 			if NSFileManager.defaultManager().moveItemAtURL(downloadURL, toURL: newDownloadURL, error: &error) {
 				return .success(())


### PR DESCRIPTION
Should fix #706 and #711.

The [manpage of `rename()`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/rename.2.html) says:

> Both old and new must be of the same type (that is, both must be either directories or non-directories) and __must reside on the same file system__.

On the other hand, the documentation of `NSFileManager.moveItemAtURL()` says:

> If the source and destination of the move operation are not on the same volume, this method copies the item first and then removes it from its current location.