### PR TITLE
Accept multiple platforms in BuildOptions

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -51,7 +51,7 @@ public enum CarthageError: Equatable {
 
 	/// The project is not sharing any framework schemes, so Carthage cannot
 	/// discover them.
-	case NoSharedFrameworkSchemes(ProjectIdentifier, Platform?)
+	case NoSharedFrameworkSchemes(ProjectIdentifier, Set<Platform>)
 
 	/// The project is not sharing any schemes, so Carthage cannot discover
 	/// them.
@@ -197,10 +197,11 @@ extension CarthageError: Printable {
 		case let .MissingEnvironmentVariable(variable):
 			return "Environment variable not set: \(variable)"
 
-		case let .NoSharedFrameworkSchemes(projectIdentifier, platform):
+		case let .NoSharedFrameworkSchemes(projectIdentifier, platforms):
 			var description = "Dependency \"\(projectIdentifier.name)\" has no shared framework schemes"
-			if let platform = platform {
-				description += " for platform \(platform)"
+			if !platforms.isEmpty {
+				let platformsString = ", ".join(map(platforms) { $0.description })
+				description += " for any of the platforms: \(platformsString)"
 			}
 
 			switch projectIdentifier {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -523,7 +523,7 @@ public final class Project {
 	/// Attempts to build each Carthage dependency that has been checked out.
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
-	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, forPlatform platform: Platform?) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, forPlatforms platforms: Set<Platform>) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 		return loadResolvedCartfile()
 			|> flatMap(.Merge) { resolvedCartfile in SignalProducer(values: resolvedCartfile.dependencies) }
 			|> flatMap(.Concat) { dependency -> SignalProducer<BuildSchemeProducer, CarthageError> in
@@ -532,7 +532,7 @@ public final class Project {
 					return .empty
 				}
 
-				return buildDependencyProject(dependency.project, self.directoryURL, withConfiguration: configuration, platform: platform)
+				return buildDependencyProject(dependency.project, self.directoryURL, withConfiguration: configuration, platforms: platforms)
 					|> catch { error in
 						switch error {
 						case .NoSharedFrameworkSchemes:

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -200,7 +200,7 @@ class XcodeSpec: QuickSpec {
 
 		it("should build for one platform") {
 			let project = ProjectIdentifier.GitHub(GitHubRepository(owner: "github", name: "Archimedes"))
-			let result = buildDependencyProject(project, directoryURL, withConfiguration: "Debug", platform: .Mac)
+			let result = buildDependencyProject(project, directoryURL, withConfiguration: "Debug", platforms: [ .Mac ])
 				|> flatten(.Concat)
 				|> ignoreTaskData
 				|> on(next: { (project, scheme) in

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -224,6 +224,7 @@ public enum BuildPlatform: Equatable {
 	/// Build only for watchOS.
 	case watchOS
 
+	/// Build for multiple platforms within the list.
 	case Multiple([BuildPlatform])
 
 	/// The set of `Platform` corresponding to this setting.

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -202,7 +202,7 @@ public struct BuildOptions: OptionsType {
 	public static func evaluate(m: CommandMode) -> Result<BuildOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build")
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platform to build for (one of ‘all’, ‘Mac’, or ‘iOS’)")
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’ or comma-separated values of the formers except for ‘all’)")
 			<*> m <| Option(key: "skip-current", defaultValue: true, usage: "don't skip building the Carthage project (in addition to its dependencies)")
 			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline")

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -241,9 +241,9 @@ public enum BuildPlatform: Equatable {
 		case .watchOS:
 			return [ .watchOS ]
 
-		case let .Multiple(platforms):
-			return reduce(platforms, []) { (set, platform) in
-				return set.union(platform.platforms)
+		case let .Multiple(buildPlatforms):
+			return reduce(buildPlatforms, []) { (set, buildPlatform) in
+				return set.union(buildPlatform.platforms)
 			}
 		}
 	}
@@ -277,8 +277,8 @@ extension BuildPlatform: Printable {
 		case .watchOS:
 			return "watchOS"
 
-		case let .Multiple(platforms):
-			return ", ".join(platforms.map { $0.description })
+		case let .Multiple(buildPlatforms):
+			return ", ".join(buildPlatforms.map { $0.description })
 		}
 	}
 }

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -211,7 +211,7 @@ public struct BuildOptions: OptionsType {
 }
 
 /// Represents the user’s chosen platform to build for.
-public enum BuildPlatform {
+public enum BuildPlatform: Equatable {
 	/// Build for all available platforms.
 	case All
 
@@ -246,6 +246,19 @@ public enum BuildPlatform {
 				return set.union(platform.platforms)
 			}
 		}
+	}
+}
+
+public func ==(lhs: BuildPlatform, rhs: BuildPlatform) -> Bool {
+	switch (lhs, rhs) {
+	case let (.Multiple(left), .Multiple(right)):
+		return left == right
+
+	case (.All, .All), (.iOS, .iOS), (.Mac, .Mac), (.watchOS, .watchOS):
+		return true
+
+	case _:
+		return false
 	}
 }
 

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -315,7 +315,7 @@ extension BuildPlatform: ArgumentType {
 		default:
 			var buildPlatforms = [BuildPlatform]()
 			for string in commaSeparated {
-				if let found = findBuildPlatform(string) {
+				if let found = findBuildPlatform(string) where found != .All {
 					buildPlatforms.append(found)
 				} else {
 					// Reject if an invalid value is included in the comma-

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -32,13 +32,13 @@ public struct UpdateOptions: OptionsType {
 	public let checkoutAfterUpdate: Bool
 	public let buildAfterUpdate: Bool
 	public let configuration: String
-	public let buildPlatform: BuildPlatform
+	public let buildPlatformList: BuildPlatformList
 	public let verbose: Bool
 	public let checkoutOptions: CheckoutOptions
 
 	/// The build options corresponding to these options.
 	public var buildOptions: BuildOptions {
-		return BuildOptions(configuration: configuration, buildPlatform: buildPlatform, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath)
+		return BuildOptions(configuration: configuration, buildPlatformList: buildPlatformList, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath)
 	}
 
 	/// If `checkoutAfterUpdate` and `buildAfterUpdate` are both true, this will
@@ -53,14 +53,14 @@ public struct UpdateOptions: OptionsType {
 		}
 	}
 
-	public static func create(configuration: String)(buildPlatform: BuildPlatform)(verbose: Bool)(checkoutAfterUpdate: Bool)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
-		return self(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, verbose: verbose, checkoutOptions: checkoutOptions)
+	public static func create(configuration: String)(buildPlatformList: BuildPlatformList)(verbose: Bool)(checkoutAfterUpdate: Bool)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
+		return self(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatformList: buildPlatformList, verbose: verbose, checkoutOptions: checkoutOptions)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platform to build for (ignored if --no-build option is present)")
+			<*> m <| Option(key: "platform", defaultValue: BuildPlatformList(), usage: "the platforms to build for (ignored if --no-build option is present)")
 			<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
 			<*> m <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
 			<*> m <| Option(key: "build", defaultValue: true, usage: "skip the building of dependencies after updating (ignored if --no-checkout option is present)")

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -60,7 +60,7 @@ public struct UpdateOptions: OptionsType {
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platform to build for (ignored if --no-build option is present)")
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (ignored if --no-build option is present)")
 			<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
 			<*> m <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
 			<*> m <| Option(key: "build", defaultValue: true, usage: "skip the building of dependencies after updating (ignored if --no-checkout option is present)")

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -32,13 +32,13 @@ public struct UpdateOptions: OptionsType {
 	public let checkoutAfterUpdate: Bool
 	public let buildAfterUpdate: Bool
 	public let configuration: String
-	public let buildPlatformList: BuildPlatformList
+	public let buildPlatform: BuildPlatform
 	public let verbose: Bool
 	public let checkoutOptions: CheckoutOptions
 
 	/// The build options corresponding to these options.
 	public var buildOptions: BuildOptions {
-		return BuildOptions(configuration: configuration, buildPlatformList: buildPlatformList, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath)
+		return BuildOptions(configuration: configuration, buildPlatform: buildPlatform, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath)
 	}
 
 	/// If `checkoutAfterUpdate` and `buildAfterUpdate` are both true, this will
@@ -53,14 +53,14 @@ public struct UpdateOptions: OptionsType {
 		}
 	}
 
-	public static func create(configuration: String)(buildPlatformList: BuildPlatformList)(verbose: Bool)(checkoutAfterUpdate: Bool)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
-		return self(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatformList: buildPlatformList, verbose: verbose, checkoutOptions: checkoutOptions)
+	public static func create(configuration: String)(buildPlatform: BuildPlatform)(verbose: Bool)(checkoutAfterUpdate: Bool)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
+		return self(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, verbose: verbose, checkoutOptions: checkoutOptions)
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
-			<*> m <| Option(key: "platform", defaultValue: BuildPlatformList(), usage: "the platforms to build for (ignored if --no-build option is present)")
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platform to build for (ignored if --no-build option is present)")
 			<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
 			<*> m <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
 			<*> m <| Option(key: "build", defaultValue: true, usage: "skip the building of dependencies after updating (ignored if --no-checkout option is present)")


### PR DESCRIPTION
Resolves #592.

This allows `BuildOptions` to take comma-separated values for the `--platform` option as follows: `--platform ios,mac`

This is a breaking change to CarthageKit's public APIs.