### PR TITLE
Strip .git suffix from GitHub repository name as GitURL does

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -59,20 +59,20 @@ public struct GitURL: Equatable {
 	public var name: String? {
 		let components = split(URLString, allowEmptySlices: false) { $0 == "/" }
 
-		return components.last.map { self.stripGitSuffix($0) }
+		return components.last.map { stripGitSuffix($0) }
 	}
 
 	public init(_ URLString: String) {
 		self.URLString = URLString
 	}
+}
 
-	/// Strips any trailing .git in the given name, if one exists.
-	private func stripGitSuffix(string: String) -> String {
-		if string.hasSuffix(".git") {
-			return string.substringToIndex(advance(string.endIndex, -4))
-		} else {
-			return string
-		}
+/// Strips any trailing .git in the given name, if one exists.
+public func stripGitSuffix(string: String) -> String {
+	if string.hasSuffix(".git") {
+		return string.substringToIndex(advance(string.endIndex, -4))
+	} else {
+		return string
 	}
 }
 

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -136,7 +136,7 @@ public struct GitHubRepository: Equatable {
 	public init(server: Server = .GitHub, owner: String, name: String) {
 		self.server = server
 		self.owner = owner
-		self.name = name
+		self.name = stripGitSuffix(name)
 	}
 
 	/// Matches an identifier of the form "owner/name".

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -167,7 +167,14 @@ public struct GitHubRepository: Equatable {
 			let name = pathComponents.removeLast()
 			let owner = pathComponents.removeLast()
 			let hostnameWithSubdirectories = host.stringByAppendingPathComponent(join("/", pathComponents))
-			return .success(self(server: .Enterprise(scheme: scheme, hostname: hostnameWithSubdirectories), owner: owner, name: name))
+
+			// If the host name starts with “github.com”, that is not an enterprise
+			// one.
+			if hostnameWithSubdirectories.hasPrefix(Server.GitHub.hostname) {
+				return .success(self(owner: owner, name: name))
+			} else {
+				return .success(self(server: .Enterprise(scheme: scheme, hostname: hostnameWithSubdirectories), owner: owner, name: name))
+			}
 		}
 
 		return .failure(CarthageError.ParseError(description: "invalid GitHub repository identifier \"\(identifier)\""))

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -136,7 +136,7 @@ public struct GitHubRepository: Equatable {
 	public init(server: Server = .GitHub, owner: String, name: String) {
 		self.server = server
 		self.owner = owner
-		self.name = stripGitSuffix(name)
+		self.name = name
 	}
 
 	/// Matches an identifier of the form "owner/name".
@@ -151,7 +151,7 @@ public struct GitHubRepository: Equatable {
 		if let match = NWORegex.firstMatchInString(identifier, options: nil, range: range) {
 			let owner = (identifier as NSString).substringWithRange(match.rangeAtIndex(1))
 			let name = (identifier as NSString).substringWithRange(match.rangeAtIndex(2))
-			return .success(self(owner: owner, name: name))
+			return .success(self(owner: owner, name: stripGitSuffix(name)))
 		}
 
 		// GitHub Enterprise
@@ -171,9 +171,9 @@ public struct GitHubRepository: Equatable {
 			// If the host name starts with “github.com”, that is not an enterprise
 			// one.
 			if hostnameWithSubdirectories.hasPrefix(Server.GitHub.hostname) {
-				return .success(self(owner: owner, name: name))
+				return .success(self(owner: owner, name: stripGitSuffix(name)))
 			} else {
-				return .success(self(server: .Enterprise(scheme: scheme, hostname: hostnameWithSubdirectories), owner: owner, name: name))
+				return .success(self(server: .Enterprise(scheme: scheme, hostname: hostnameWithSubdirectories), owner: owner, name: stripGitSuffix(name)))
 			}
 		}
 

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -40,9 +40,9 @@ class CartfileSpec: QuickSpec {
 			expect(depConfigs.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(owner: "jspahrsummers", name: "xcconfigs"))))
 			expect(depConfigs.version).to(equal(VersionSpecifier.Any))
 
-			let depiOSCharts = cartfile.dependencies[4]
-			expect(depiOSCharts.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(owner: "danielgindi", name: "ios-charts"))))
-			expect(depiOSCharts.version).to(equal(VersionSpecifier.Any))
+			let depCharts = cartfile.dependencies[4]
+			expect(depCharts.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(owner: "danielgindi", name: "ios-charts"))))
+			expect(depCharts.version).to(equal(VersionSpecifier.Any))
 
 			let depErrorTranslations2 = cartfile.dependencies[5]
 			expect(depErrorTranslations2.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(server: .Enterprise(scheme: "https", hostname: "enterprise.local/ghe"), owner: "desktop", name: "git-error-translations"))))

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -22,7 +22,7 @@ class CartfileSpec: QuickSpec {
 			expect(result.error).to(beNil())
 
 			let cartfile = result.value!
-			expect(cartfile.dependencies.count).to(equal(6))
+			expect(cartfile.dependencies.count).to(equal(7))
 
 			let depReactiveCocoa = cartfile.dependencies[0]
 			expect(depReactiveCocoa.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(owner: "ReactiveCocoa", name: "ReactiveCocoa"))))
@@ -40,11 +40,15 @@ class CartfileSpec: QuickSpec {
 			expect(depConfigs.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(owner: "jspahrsummers", name: "xcconfigs"))))
 			expect(depConfigs.version).to(equal(VersionSpecifier.Any))
 
-			let depErrorTranslations2 = cartfile.dependencies[4]
+			let depiOSCharts = cartfile.dependencies[4]
+			expect(depiOSCharts.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(owner: "danielgindi", name: "ios-charts"))))
+			expect(depiOSCharts.version).to(equal(VersionSpecifier.Any))
+
+			let depErrorTranslations2 = cartfile.dependencies[5]
 			expect(depErrorTranslations2.project).to(equal(ProjectIdentifier.GitHub(GitHubRepository(server: .Enterprise(scheme: "https", hostname: "enterprise.local/ghe"), owner: "desktop", name: "git-error-translations"))))
 			expect(depErrorTranslations2.version).to(equal(VersionSpecifier.Any))
 
-			let depErrorTranslations = cartfile.dependencies[5]
+			let depErrorTranslations = cartfile.dependencies[6]
 			expect(depErrorTranslations.project).to(equal(ProjectIdentifier.Git(GitURL("https://enterprise.local/desktop/git-error-translations2.git"))))
 			expect(depErrorTranslations.version).to(equal(VersionSpecifier.GitReference("development")))
 		}

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -36,7 +36,7 @@ class ResolverSpec: QuickSpec {
 		it("should resolve a Cartfile") {
 			let resolver = Resolver(versionsForDependency: self.versionsForDependency, cartfileForDependency: self.cartfileForDependency, resolvedGitReference: self.resolvedGitReference)
 			let dependencies = self.orderedDependencies(resolver, fromCartfile: self.loadTestCartfile("TestCartfile"))
-			expect(dependencies.count).to(equal(7));
+			expect(dependencies.count).to(equal(8));
 
 			var generator = dependencies.generate()
 
@@ -44,6 +44,7 @@ class ResolverSpec: QuickSpec {
 			expect(generator.next()).to(equal([ "Mantle": PinnedVersion("1.3.0") ]))
 			expect(generator.next()).to(equal([ "git-error-translations": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "git-error-translations2": PinnedVersion("8ff4393ede2ca86d5a78edaf62b3a14d90bffab9") ]))
+			expect(generator.next()).to(equal([ "ios-charts": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "libextobjc": PinnedVersion("0.4.1") ]))
 			expect(generator.next()).to(equal([ "xcconfigs": PinnedVersion("1.3.0") ]))
 			expect(generator.next()).to(equal([ "objc-build-scripts": PinnedVersion("3.0.0") ]))

--- a/Source/CarthageKitTests/TestCartfile
+++ b/Source/CarthageKitTests/TestCartfile
@@ -5,6 +5,9 @@ github "Mantle/Mantle" ~> 1.0
 github "jspahrsummers/libextobjc" == 0.4.1
 github "jspahrsummers/xcconfigs" # here is an intra-line comment
 
+# name with .git suffix
+github "danielgindi/ios-charts.git"
+
 # GitHub Enterprise
 github "https://enterprise.local/ghe/desktop/git-error-translations"
 


### PR DESCRIPTION
Addresses https://github.com/Carthage/Carthage/issues/745#issuecomment-139491947.

The following is the current output before this PR with the input `github "https://github.com/danielgindi/ios-charts.git"` or `github "danielgindi/ios-charts.git"`:

```sh
*** Cloning ios-charts.git
A shell task failed with exit code 128:
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```
