### PR TITLE
Handle nonexistent directory in `isGitRepository`

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -394,6 +394,10 @@ public func resolveReferenceInRepository(repositoryFileURL: NSURL, reference: St
 /// Attempts to determine whether the given directory represents a Git
 /// repository.
 public func isGitRepository(directoryURL: NSURL) -> SignalProducer<Bool, NoError> {
+	if !NSFileManager.defaultManager().fileExistsAtPath(directoryURL.path!) {
+		return SignalProducer(value: false)
+	}
+	
 	return launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL)
 		|> map { _ in true }
 		|> catch { _ in SignalProducer(value: false) }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -397,7 +397,7 @@ public func isGitRepository(directoryURL: NSURL) -> SignalProducer<Bool, NoError
 	if !NSFileManager.defaultManager().fileExistsAtPath(directoryURL.path!) {
 		return SignalProducer(value: false)
 	}
-	
+
 	return launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL)
 		|> map { _ in true }
 		|> catch { _ in SignalProducer(value: false) }


### PR DESCRIPTION
After upgrading to 0.9, I started getting crashes like:

> *** Cloning SwiftCheck
*** Checking out SwiftCheck at "v0.3.0"
2015-09-13 03:05:31.289 carthage[56929:3098569] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'working directory doesn't exist.'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff9107d03c __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x00007fff9234176e objc_exception_throw + 43
	2   CoreFoundation                      0x00007fff9107ceed +[NSException raise:format:] + 205
	3   Foundation                          0x00007fff93eb71d6 -[NSConcreteTask launchWithDictionary:] + 582
	4   ReactiveTask                        0x0000000107769a45 _TFFFF12ReactiveTask10launchTaskFVS_15TaskDescriptionGV13ReactiveCocoa14SignalProducerGOS_9TaskEventCSo6NSData_OS_17ReactiveTaskError_U_FTGVSs6SinkOfGOS1_5EventGS3_S4__S5___CS1_19CompositeDisposable_T_U0_FTCS_P33_8622FA0C3FE9071537A42FE3BB905E344PipeS9__GS2_GS3_S4__S5__U_FTGS6_GS7_GS3_S4__S5___S8__T_ + 1253
	5   ReactiveTask                        0x000000010776348b _TPA__TFFFF12ReactiveTask10launchTaskFVS_15TaskDescriptionGV13ReactiveCocoa14SignalProducerGOS_9TaskEventCSo6NSData_OS_17ReactiveTaskError_U_FTGVSs6SinkOfGOS1_5EventGS3_S4__S5___CS1_19CompositeDisposable_T_U0_FTCS_P33_8622FA0C3FE9071537A42FE3BB905E344PipeS9__GS2_GS3_S4__S5__U_FTGS6_GS7_GS3_S4__S5___S8__T_ + 251

Tracked it down to 561c0851ffe41594350138bb7c09cd2543913ddf which left out a check for directory existence in `isGitRepository` before attempting to launch a git task in it.

So, here’s that.