### PR TITLE
Fix precompiled framework platform determination

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -49,6 +49,9 @@ public enum CarthageError: Equatable {
 	// An error occurred reading a dSYM or framework's UUIDs.
 	case InvalidUUIDs(description: String)
 
+	/// An error occurred when parsing the contents of a framework's Info.plist.
+	case InfoPlistParseFailed(plistURL: NSURL, reason: String)
+
 	/// The project is not sharing any framework schemes, so Carthage cannot
 	/// discover them.
 	case NoSharedFrameworkSchemes(ProjectIdentifier, Set<Platform>)
@@ -112,6 +115,9 @@ public func == (lhs: CarthageError, rhs: CarthageError) -> Bool {
 	
 	case let (.InvalidArchitectures(left), .InvalidArchitectures(right)):
 		return left == right
+
+	case let (.InfoPlistParseFailed(la, lb), .InfoPlistParseFailed(ra, rb)):
+		return la == ra && lb == rb
 
 	case let (.NoSharedFrameworkSchemes(la, lb), .NoSharedFrameworkSchemes(ra, rb)):
 		return la == ra && lb == rb
@@ -193,6 +199,9 @@ extension CarthageError: Printable {
 
 		case let .InvalidUUIDs(description):
 			return "Invalid architecture UUIDs: \(description)"
+
+		case let .InfoPlistParseFailed(plistURL, reason):
+			return "Failed to parse the framework Info.plist file at \(plistURL.path!): \(reason)"
 
 		case let .MissingEnvironmentVariable(variable):
 			return "Environment variable not set: \(variable)"

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -639,8 +639,8 @@ private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, C
 		}
 		// Neither DTPlatformName nor CFBundleSupportedPlatforms can not be used 
 		// because Xcode 6 and below do not include either in Mac OSX frameworks.
-		|> tryMap { propertyList -> Result<String, CarthageError> in
-			if let sdkName = propertyList["DTSDKName"] as? String {
+		|> tryMap { plist -> Result<String, CarthageError> in
+			if let sdkName = plist["DTSDKName"] as? String {
 				return .success(sdkName)
 			}
 			return .failure(.InfoPlistParseFailed(plistURL: plistURL, reason: "the value for the DTSDKName key is not a string"))

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -409,8 +409,7 @@ public final class Project {
 	/// Sends the URL to the framework after copying.
 	private func copyFrameworkToBuildFolder(frameworkURL: NSURL) -> SignalProducer<NSURL, CarthageError> {
 		return infoPlistForFramework(frameworkURL)
-			|> flatMap(.Merge) { infoPlistURL in platformsForInfoPlist(infoPlistURL) }
-			|> take(1)
+			|> flatMap(.Merge) { infoPlistURL in platformForInfoPlist(infoPlistURL) }
 			|> map { platform in self.directoryURL.URLByAppendingPathComponent(platform.relativePath, isDirectory: true) }
 			|> map { platformFolderURL in platformFolderURL.URLByAppendingPathComponent(frameworkURL.lastPathComponent!) }
 			|> flatMap(.Merge) { destinationFrameworkURL in copyProduct(frameworkURL, destinationFrameworkURL.URLByResolvingSymlinksInPath!) }
@@ -613,9 +612,8 @@ private func infoPlistForFramework(frameworkURL: NSURL) -> SignalProducer<NSURL,
 		|> take(1)
 }
 
-/// Sends the platforms specified in the given Info.plist for the
-/// CFBundleSupportedPlatforms key.
-private func platformsForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, CarthageError> {
+/// Sends the platform specified in the given Info.plist.
+private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, CarthageError> {
 	return SignalProducer(value: plistURL)
 		|> startOn(QueueScheduler(name: "org.carthage.CarthageKit.Project.platformForInfoPlist"))
 		|> tryMap { URL in

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -608,7 +608,7 @@ private func filesInDirectory(directoryURL: NSURL, typeIdentifier: String) -> Si
 /// Sends the URL for the Info.plist of the specified Framework.
 private func infoPlistForFramework(frameworkURL: NSURL) -> SignalProducer<NSURL, CarthageError> {
 	return filesInDirectory(frameworkURL, "com.apple.property-list")
-		|> filter { $0.lastPathComponent == "Info.plist" }
+		|> filter { plist in plist.lastPathComponent == "Info.plist" }
 		|> take(1)
 }
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -631,8 +631,8 @@ private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, C
 			}
 			return .failure(.ReadFailed(plistURL, error))
 		}
-		|> tryMap { plist -> Result<Dictionary<String, AnyObject>, CarthageError> in
-			if let plist = plist as? Dictionary<String, AnyObject> {
+		|> tryMap { plist -> Result<[String: AnyObject], CarthageError> in
+			if let plist = plist as? [String: AnyObject] {
 				return .success(plist)
 			}
 			return .failure(.InfoPlistParseFailed(plistURL: plistURL, reason: "the root plist object is not a dictionary of values by strings"))

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -629,13 +629,13 @@ private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, C
 			if let pist: AnyObject = plist {
 				return .success(pist)
 			}
-			return .failure(CarthageError.ReadFailed(plistURL, error))
+			return .failure(.ReadFailed(plistURL, error))
 		}
 		|> tryMap { plist -> Result<Dictionary<String, AnyObject>, CarthageError> in
 			if let plist = plist as? Dictionary<String, AnyObject> {
 				return .success(plist)
 			}
-			return .failure(CarthageError.InfoPlistParseFailed(plistURL: plistURL, reason: "the root plist object is not a dictionary of values by strings"))
+			return .failure(.InfoPlistParseFailed(plistURL: plistURL, reason: "the root plist object is not a dictionary of values by strings"))
 		}
 		// Neither DTPlatformName nor CFBundleSupportedPlatforms can not be used 
 		// because Xcode 6 and below do not include either in Mac OSX frameworks.
@@ -643,7 +643,7 @@ private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, C
 			if let sdkName = propertyList["DTSDKName"] as? String {
 				return .success(sdkName)
 			}
-			return .failure(CarthageError.InfoPlistParseFailed(plistURL: plistURL, reason: "the value for the DTSDKName key is not a string"))
+			return .failure(.InfoPlistParseFailed(plistURL: plistURL, reason: "the value for the DTSDKName key is not a string"))
 		}
 		// Thus, the SDK name must be trimmed to match the platform name, e.g.
 		// macosx10.10 -> macosx

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -648,8 +648,7 @@ private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, C
 		// Thus, the SDK name must be trimmed to match the platform name, e.g.
 		// macosx10.10 -> macosx
 		|> map { sdkName in sdkName.stringByTrimmingCharactersInSet(NSCharacterSet.letterCharacterSet().invertedSet) }
-		|> tryMap { platform in SDK.fromString(platform) }
-		|> map { sdk in sdk.platform }
+		|> tryMap { platform in SDK.fromString(platform).map { $0.platform } }
 }
 
 /// Sends the URL to each framework bundle found in the given directory.

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -639,7 +639,7 @@ private func platformForInfoPlist(plistURL: NSURL) -> SignalProducer<Platform, C
 			return .failure(CarthageError.InfoPlistParseFailed(plistURL: plistURL, reason: "the root plist object is not a dictionary of values by strings"))
 		}
 		// Neither DTPlatformName nor CFBundleSupportedPlatforms can not be used 
-        // because Xcode 6 and below do not include either in Mac OSX frameworks.
+		// because Xcode 6 and below do not include either in Mac OSX frameworks.
 		|> tryMap { propertyList -> Result<String, CarthageError> in
 			if let sdkName = propertyList["DTSDKName"] as? String {
 				return .success(sdkName)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1283,7 +1283,7 @@ private func stripArchitecture(frameworkURL: NSURL, architecture: String) -> Sig
 }
 
 /// Returns a signal of all architectures present in a given framework.
-private func architecturesInFramework(frameworkURL: NSURL) -> SignalProducer<String, CarthageError> {
+public func architecturesInFramework(frameworkURL: NSURL) -> SignalProducer<String, CarthageError> {
 	return SignalProducer.try { () -> Result<NSURL, CarthageError> in
 			return binaryURL(frameworkURL)
 		}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -354,7 +354,7 @@ public enum SDK: String {
 
 	/// Attempts to parse an SDK name from a string returned from `xcodebuild`.
 	public static func fromString(string: String) -> Result<SDK, CarthageError> {
-		return Result(self(rawValue: string), failWith: .ParseError(description: "unexpected SDK key \"\(string)\""))
+		return Result(self(rawValue: string.lowercaseString), failWith: .ParseError(description: "unexpected SDK key \"\(string)\""))
 	}
 
 	/// The platform that this SDK targets.
@@ -1283,7 +1283,7 @@ private func stripArchitecture(frameworkURL: NSURL, architecture: String) -> Sig
 }
 
 /// Returns a signal of all architectures present in a given framework.
-public func architecturesInFramework(frameworkURL: NSURL) -> SignalProducer<String, CarthageError> {
+private func architecturesInFramework(frameworkURL: NSURL) -> SignalProducer<String, CarthageError> {
 	return SignalProducer.try { () -> Result<NSURL, CarthageError> in
 			return binaryURL(frameworkURL)
 		}


### PR DESCRIPTION
Currently platform determination of precompiled binaries depends on the architecture of the framework. However, with the addition of watchOS frameworks, this behavior is now incorrect, as both watchOS and iOS frameworks share the `arm` prefix on their architectures, resulting in the behavior documented in #757. To remedy this, instead of relying on architecture, we instead perform the following:

- For each downloaded framework, locate the included Info.plist (location differs in Mac OSX vs. iOS frameworks)
- Within the Info.plist, search for the DTSDKName key
- Strip the version numbers from the SDK name, e.g. `macosx10.10` → `macosx`
- Move the framework to the folder that matches the platform name, as before

Fixes #757

I've tested this with RAC 3.0 and the 4.0 alpha. Let me know if there's any additional cases worth looking into.