### PR TITLE
Checks if cache dependency folder is writable.

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -44,12 +44,8 @@ private let CarthageUserCachesURL: NSURL = {
 				return Result(error: error)
 			}
 		} else {
-			return try { (error: NSErrorPointer) -> NSURL? in
-				let attributes = [NSFilePosixPermissions : NSNumber(short:755)]
-				fileManager.createDirectoryAtURL(dependenciesURL, withIntermediateDirectories: true, attributes:attributes, error: error)
-				return dependenciesURL
-			}
-		}		
+			return try { fileManager.createDirectoryAtURL(dependenciesURL, withIntermediateDirectories: true, attributes: [NSFilePosixPermissions : NSNumber(short:755)], error: $0) }.map { dependenciesURL }
+		}
 	}
 
 	switch URLResult {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -36,23 +36,20 @@ private let CarthageUserCachesURL: NSURL = {
 		let dependenciesURL = cachesURL.URLByAppendingPathComponent(CarthageKitBundleIdentifier, isDirectory: true)
 		let dependenciesPath = dependenciesURL.absoluteString!
 		
-		let result: Result<NSURL, NSError>
 		if fileManager.fileExistsAtPath(dependenciesPath, isDirectory:nil) {
 			if fileManager.isWritableFileAtPath(dependenciesPath) {
-				result = Result(value: dependenciesURL)
+				return Result(value: dependenciesURL)
 			} else {
 				let error = NSError(domain: CarthageKitBundleIdentifier, code: 0, userInfo: nil)
-				result = Result(error: error)
+				return Result(error: error)
 			}
 		} else {
-			result = try { (error: NSErrorPointer) -> NSURL? in
+			return try { (error: NSErrorPointer) -> NSURL? in
 				let attributes = [NSFilePosixPermissions : NSNumber(short:755)]
 				fileManager.createDirectoryAtURL(dependenciesURL, withIntermediateDirectories: true, attributes:attributes, error: error)
 				return dependenciesURL
 			}
-		}
-		
-		return result
+		}		
 	}
 
 	switch URLResult {


### PR DESCRIPTION
If not falls back to '~/.carthage' folder. Also the fall back
URL is constructed using the $HOME enviromental variable if
available otherwise by expanding the tilde.

This commit also fixes an issue with Homebrew testing carthage
in a sandboxed mode. For more info about the Homebrew issue check
https://github.com/Homebrew/homebrew/pull/43884