### PR TITLE
Avoid crashing with unknown SDKs for universal framework targets

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -545,7 +545,7 @@ public final class Project {
 	/// Attempts to build each Carthage dependency that has been checked out.
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
-	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, forPlatforms platforms: Set<Platform>, sdkFilter: SDKFilterCallback = { $0.0 }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, forPlatforms platforms: Set<Platform>, sdkFilter: SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 		return loadResolvedCartfile()
 			|> flatMap(.Merge) { resolvedCartfile in SignalProducer(values: resolvedCartfile.dependencies) }
 			|> flatMap(.Concat) { dependency -> SignalProducer<BuildSchemeProducer, CarthageError> in

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -887,15 +887,13 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		}
 		|> flatMap(.Concat) { platform, sdks -> SignalProducer<(Platform, [SDK], Bool), CarthageError> in
 			let filterResult = sdkFilter(sdks: sdks, scheme: scheme, configuration: configuration, project: project)
-
-			if let filteredSDKs = filterResult.value where filteredSDKs.isEmpty {
-				return .empty
-			}
-
 			return SignalProducer(result: filterResult.map { filteredSDKs in
 				let isFiltered = filteredSDKs.count != sdks.count
 				return (platform, filteredSDKs, isFiltered)
 			})
+		}
+		|> filter { _, sdks, _ in
+			return !sdks.isEmpty
 		}
 		|> flatMap(.Concat) { platform, sdks, isFiltered in
 			let folderURL = workingDirectoryURL.URLByAppendingPathComponent(platform.relativePath, isDirectory: true).URLByResolvingSymlinksInPath!

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1202,11 +1202,14 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 				let initialValue = (project, scheme)
 
 				let wrappedSDKFilter: SDKFilterCallback = { sdks, scheme, configuration, project in
+					let filteredSDKs: [SDK]
+
 					if platforms.isEmpty {
-						return sdkFilter(sdks: sdks, scheme: scheme, configuration: configuration, project: project)
+						filteredSDKs = sdks
+					} else {
+						filteredSDKs = sdks.filter { platforms.contains($0.platform) }
 					}
 
-					let filteredSDKs = sdks.filter { platforms.contains($0.platform) }
 					return sdkFilter(sdks: filteredSDKs, scheme: scheme, configuration: configuration, project: project)
 				}
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -787,12 +787,11 @@ private func mergeBuildProductsIntoDirectory(firstProductSettings: BuildSettings
 /// A callback function used to determine whether or not an SDK should be built
 public typealias SDKFilterCallback = (sdks: [SDK], scheme: String, configuration: String, project: ProjectLocator) -> Result<[SDK], CarthageError>
 
-/// Builds one scheme of the given project, for all supported SDKs, or only for
-/// the SDKs whose platform is contained in the given platform set.
+/// Builds one scheme of the given project, for all supported SDKs.
 ///
 /// Returns a signal of all standard output from `xcodebuild`, and a signal
 /// which will send the URL to each product successfully built.
-public func buildScheme(scheme: String, withConfiguration configuration: String, inProject project: ProjectLocator, #workingDirectoryURL: NSURL, platforms: Set<Platform> = [], sdkFilter: SDKFilterCallback = { .success($0.0) }) -> SignalProducer<TaskEvent<NSURL>, CarthageError> {
+public func buildScheme(scheme: String, withConfiguration configuration: String, inProject project: ProjectLocator, #workingDirectoryURL: NSURL, sdkFilter: SDKFilterCallback = { .success($0.0) }) -> SignalProducer<TaskEvent<NSURL>, CarthageError> {
 	precondition(workingDirectoryURL.fileURL)
 
 	let buildArgs = BuildArguments(project: project, scheme: scheme, configuration: configuration)
@@ -869,10 +868,6 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		|> reduce([:]) { (var sdksByPlatform: [Platform: [SDK]], sdk: SDK) in
 			let platform = sdk.platform
 
-			if !platforms.isEmpty && !platforms.contains(platform) {
-				return sdksByPlatform
-			}
-
 			if var sdks = sdksByPlatform[platform] {
 				sdks.append(sdk)
 				sdksByPlatform.updateValue(sdks, forKey: platform)
@@ -892,16 +887,24 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		}
 		|> flatMap(.Concat) { platform, sdks -> SignalProducer<(Platform, [SDK], Bool), CarthageError> in
 			let filterResult = sdkFilter(sdks: sdks, scheme: scheme, configuration: configuration, project: project)
-			return SignalProducer(result: filterResult.map { (platform, $0, !sdks.isEmpty) })
+
+			if let filteredSDKs = filterResult.value where filteredSDKs.isEmpty {
+				return .empty
+			}
+
+			return SignalProducer(result: filterResult.map { filteredSDKs in
+				let isFiltered = filteredSDKs.count != sdks.count
+				return (platform, filteredSDKs, isFiltered)
+			})
 		}
-		|> flatMap(.Concat) { platform, sdks, isMissingSigningIdentities in
+		|> flatMap(.Concat) { platform, sdks, isFiltered in
 			let folderURL = workingDirectoryURL.URLByAppendingPathComponent(platform.relativePath, isDirectory: true).URLByResolvingSymlinksInPath!
 
 			// TODO: Generalize this further?
 			switch sdks.count {
 			case 0:
-				let identityAddendum = isMissingSigningIdentities ? " (you're missing one or more signing identities)" : ""
-				fatalError("No valid SDKs found to build\(identityAddendum)")
+				let filterlingAddendum = isFiltered ? " (you may be missing one or more signing identities)" : ""
+				fatalError("No valid SDKs found to build\(filterlingAddendum)")
 
 			case 1:
 				return buildSDK(sdks[0])
@@ -1198,7 +1201,16 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 			|> map { (scheme: String, project: ProjectLocator) -> BuildSchemeProducer in
 				let initialValue = (project, scheme)
 
-				let buildProgress = buildScheme(scheme, withConfiguration: configuration, inProject: project, workingDirectoryURL: directoryURL, platforms: platforms, sdkFilter: sdkFilter)
+				let wrappedSDKFilter: SDKFilterCallback = { sdks, scheme, configuration, project in
+					if platforms.isEmpty {
+						return sdkFilter(sdks: sdks, scheme: scheme, configuration: configuration, project: project)
+					}
+
+					let filteredSDKs = sdks.filter { platforms.contains($0.platform) }
+					return sdkFilter(sdks: filteredSDKs, scheme: scheme, configuration: configuration, project: project)
+				}
+
+				let buildProgress = buildScheme(scheme, withConfiguration: configuration, inProject: project, workingDirectoryURL: directoryURL, sdkFilter: wrappedSDKFilter)
 					// Discard any existing Success values, since we want to
 					// use our initial value instead of waiting for
 					// completion.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1194,7 +1194,6 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 
 				let wrappedSDKFilter: SDKFilterCallback = { sdks, scheme, configuration, project in
 					let filteredSDKs: [SDK]
-
 					if platforms.isEmpty {
 						filteredSDKs = sdks
 					} else {

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -22,7 +22,7 @@ class XcodeSpec: QuickSpec {
 		let targetFolderURL = NSURL(fileURLWithPath: NSTemporaryDirectory().stringByAppendingPathComponent(NSProcessInfo.processInfo().globallyUniqueString), isDirectory: true)!
 
 		var machineHasiOSIdentity: Bool = false
-		var sdkFilter: SDKFilterCallback = { $0.0 }
+		var sdkFilter: SDKFilterCallback = { .success($0.0) }
 
 		beforeSuite {
 			machineHasiOSIdentity = iOSSigningIdentitiesConfigured()
@@ -33,7 +33,7 @@ class XcodeSpec: QuickSpec {
 			// See https://github.com/Carthage/Carthage/pull/766#issuecomment-141671784.
 			if !machineHasiOSIdentity {
 				sdkFilter = { args in
-					args.0.filter { sdk in
+					let filtered = args.0.filter { sdk in
 						switch sdk {
 						case .MacOSX, .iPhoneSimulator, .watchSimulator, .tvSimulator:
 							return true
@@ -42,6 +42,7 @@ class XcodeSpec: QuickSpec {
 							return false
 						}
 					}
+					return .success(filtered)
 				}
 			}
 		}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -106,10 +106,10 @@ public struct BuildCommand: CommandType {
 		let project = Project(directoryURL: directoryURL)
 
 		let sdkFilter: SDKFilterCallback = { sdks, scheme, configuration, project in
-			let sdks = buildableSDKs(sdks, scheme, configuration, project, options.colorOptions.formatting)
+			let result = buildableSDKs(sdks, scheme, configuration, project, options.colorOptions.formatting)
 				|> first
 			
-			return sdks!.value!
+			return result!
 		}
 
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)


### PR DESCRIPTION
Fixes #797. This changes the public `SDKFilterCallback` signature to return `Result<[SDK], CarthageError>`.

The output using Xcode 7.0 with this is as follows:

```sh
$ carthage build
*** xcodebuild output can be found in /var/folders/03/cr990fvs5g73tt4gq52h3j7r0000gn/T/carthage-xcodebuild.aQ45sV.log
*** Building scheme "Nimble-OSX" in Nimble.xcodeproj
*** Building scheme "Nimble-iOS" in Nimble.xcodeproj
A shell task failed with exit code 64:
xcodebuild: error: SDK "appletvsimulator" cannot be located.
```

or 

```sh
$ carthage build --platform ios
*** xcodebuild output can be found in /var/folders/03/cr990fvs5g73tt4gq52h3j7r0000gn/T/carthage-xcodebuild.a4PqQN.log
*** Building scheme "Nimble-iOS" in Nimble.xcodeproj
```

The above correctly ignores tvOS platform which is included in the universal framework target.