### PR TITLE
Revise phrasing in OS X getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
 ##### If you're building for OS X
 
 1. Create a [Cartfile][] that lists the frameworks you’d like to use in your project.
-1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder, then build each one.
+1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder and build each one.
 1. On your application targets’ “General” settings tab, in the “Embedded Binaries” section, drag and drop each framework you want to use from the [Carthage/Build][] folder on disk.
 
 ##### If you're building for iOS


### PR DESCRIPTION
I think this rewording will clarify that `carthage update` itself will build each dependency (and sub-dependencies). Elsewhere in the readme, we use `then` to specify a subsequent action to be performed.