### PR TITLE
Fix "no identity found" on `copy-frameworks` for watchOS Simulator

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -47,7 +47,7 @@ public struct CopyFrameworksCommand: CommandType {
 private func codeSigningIdentity() -> SignalProducer<String?, CarthageError> {
 	return SignalProducer.try {
 		if codeSigningAllowed() {
-			return getEnvironmentVariable("EXPANDED_CODE_SIGN_IDENTITY").map { $0 }
+			return getEnvironmentVariable("EXPANDED_CODE_SIGN_IDENTITY").map { $0.isEmpty ? nil : $0 }
 		} else {
 			return .success(nil)
 		}


### PR DESCRIPTION
Xcode 7.0.1 set environments on building for watchOS Simulator:
```sh
CODE_SIGNING_ALLOWED=YES
EXPANDED_CODE_SIGN_IDENTITY=""
```
It cause launching `codesign` with empty identity option and error.

Xcode 7.1 beta 2 is same for watchOS Simulator.
But it is not happen for tvOS Simulator.

Is this related to #755?