### PR TITLE
Use GITHUB_ACCESS_TOKEN as auth for cloning github.com private repos in HTTPS

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -119,7 +119,13 @@ public struct GitHubRepository: Equatable {
 
 	/// The URL that should be used for cloning this repository over HTTPS.
 	public var HTTPSURL: GitURL {
-		return GitURL("\(server)/\(owner)/\(name).git")
+		let gitAuth = parseGitHubAccessTokenFromEnvironment()
+
+		var serverAuth:String = ""
+		if let auth = gitAuth[server.hostname] {
+			serverAuth = "\(auth)@"
+		}
+		return GitURL("\(server.scheme)://\(serverAuth)\(server.hostname)/\(owner)/\(name).git")
 	}
 
 	/// The URL that should be used for cloning this repository over SSH.


### PR DESCRIPTION
When specifying GIT_AUTH environment variable in the form of either "domain.com=token" or "domain.com=username:pass" the value will be injected into the git url to provide headless authentication for build servers.

The default "token" or "username:password" will be applied to all github.com requests.