### PR TITLE
Fix error on `carthage update`

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -399,12 +399,12 @@ public func isGitRepository(directoryURL: NSURL) -> SignalProducer<Bool, NoError
 	}
 
 	return launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL)
-		|> map { outputIncludeLineEndings in
-			let relativeGitDirectory = outputIncludeLineEndings.stringByTrimmingCharactersInSet(.newlineCharacterSet())
+		|> map { outputIncludingLineEndings in
+			let relativeGitDirectory = outputIncludingLineEndings.stringByTrimmingCharactersInSet(.newlineCharacterSet())
 			let gitDirectory = directoryURL.URLByAppendingPathComponent(relativeGitDirectory).path
 			var isDirectory: ObjCBool = false
-			let isExists = gitDirectory.map { NSFileManager.defaultManager().fileExistsAtPath($0, isDirectory: &isDirectory) } ?? false
-			return isExists && isDirectory
+			let directoryExists = gitDirectory.map { NSFileManager.defaultManager().fileExistsAtPath($0, isDirectory: &isDirectory) } ?? false
+			return directoryExists && isDirectory
 		}
 		|> catch { _ in SignalProducer(value: false) }
 }


### PR DESCRIPTION
When submodule was already checked out,
`carthage update` stopped with following error:
```
fatal: destination path '…' already exists and is not an empty directory.
```

It was caused in `isGitRepository()`.
The output from `launchGitTask` contained line ending,
so `fileExistsAtPath()` never returned true.
Besides the output pointed relative path of `directoryURL`,
and it was not current directory of `defaultManager()`.