### PR TITLE
Strip `Modules` directory too in copy-frameworks

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1353,6 +1353,11 @@ public func stripModulesDirectory(frameworkURL: NSURL) -> SignalProducer<(), Car
 	return SignalProducer.try {
 		let modulesDirectoryURL = frameworkURL.URLByAppendingPathComponent("Modules", isDirectory: true)
 
+		var isDirectory: ObjCBool = false
+		if !NSFileManager.defaultManager().fileExistsAtPath(modulesDirectoryURL.path!, isDirectory: &isDirectory) || !isDirectory {
+			return .success(())
+		}
+
 		var error: NSError? = nil
 		if !NSFileManager.defaultManager().removeItemAtURL(modulesDirectoryURL, error: &error) {
 			return .failure(.WriteFailed(modulesDirectoryURL, error))

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1229,7 +1229,7 @@ public func stripFramework(frameworkURL: NSURL, #keepingArchitectures: [String],
 		|> filter { !contains(keepingArchitectures, $0) }
 		|> flatMap(.Concat) { stripArchitecture(frameworkURL, $0) }
 
-	// Xcode doesn't copy “Modules” directory at all.
+	// Xcode doesn't copy `Modules` directory at all.
 	let stripModules = stripModulesDirectory(frameworkURL)
 
 	let sign = codesigningIdentity.map { codesign(frameworkURL, $0) } ?? .empty
@@ -1348,7 +1348,7 @@ public func architecturesInFramework(frameworkURL: NSURL) -> SignalProducer<Stri
 		}
 }
 
-/// Strips “Modules” directory from the given framework.
+/// Strips `Modules` directory from the given framework.
 public func stripModulesDirectory(frameworkURL: NSURL) -> SignalProducer<(), CarthageError> {
 	return SignalProducer.try {
 		let modulesDirectoryURL = frameworkURL.URLByAppendingPathComponent("Modules", isDirectory: true)

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -151,6 +151,9 @@ class XcodeSpec: QuickSpec {
 				expect(strippedArchitectures?.value).notTo(contain("i386"))
 				expect(strippedArchitectures?.value).to(contain("armv7"))
 				expect(strippedArchitectures?.value).to(contain("arm64"))
+
+				let modulesDirectoryURL = targetURL.URLByAppendingPathComponent("Modules", isDirectory: true)
+				expect(NSFileManager.defaultManager().fileExistsAtPath(modulesDirectoryURL.path!)).to(beFalsy())
 				
 				var output: String = ""
 				let codeSign = TaskDescription(launchPath: "/usr/bin/xcrun", arguments: [ "codesign", "--verify", "--verbose", targetURL.path! ])


### PR DESCRIPTION
Fixes #383.

Xcode doesn't copy `Modules` directory in a framework at all in its “Copy Files Phase”.