### PR TITLE
Add make command for building homebrew tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ installables: clean bootstrap
 	mv -f "$(CARTHAGE_EXECUTABLE)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage"
 	rm -rf "$(BUILT_BUNDLE)"
 
+homebrew: installables
+	mkdir -p "homebrew/Frameworks" "homebrew/bin"
+	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "homebrew/Frameworks/"
+	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "homebrew/bin/"
+	install_name_tool -add_rpath "@executable_path/../Frameworks/$(OUTPUT_FRAMEWORK)/Versions/Current/Frameworks/"  "homebrew/bin/carthage"
+	tar -cvzf "carthage-$(VERSION_STRING).tar.gz" "homebrew"
+	rm -r homebrew
+
 prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
 	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"


### PR DESCRIPTION
This follows the same basic pattern as `prefix_install`, except that it
creates a tarball with the executable and CarthageKit in it.

These tarballs could be attached to releases along with the package and
CarthageKit, and installed via homebrew as pre-built binaries.

I'm unsure on if this removes the need for `prefix_install`.

Assuming this is acceptable, I can submit a PR for homebrew that uses this
tarball for installation. You can see a proof of concept of how this would work
[in my personal tap](https://github.com/gfontenot/homebrew-formulae).