### PR TITLE
Copy bcsymbolmap files when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
   $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
   ```
 
-  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries.
+  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries as well as ensures that necessary bitcode-related files are also copied.
 
 ##### Copying debug symbols for debugging and crash reporting
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
   $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
   ```
 
-  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries as well as ensures that necessary bitcode-related files are also copied.
+  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files are copied when archiving.
 
 ##### Copying debug symbols for debugging and crash reporting
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -667,7 +667,7 @@ private func copyBuildProductIntoDirectory(directoryURL: NSURL, settings: BuildS
 			return copyProduct(source, target)
 		}
 		|> flatMap(.Merge) { url in
-			return copyBCSymbolMapForBuildProductIntoDirectory(directoryURL, settings)
+			return copyBCSymbolMapsForBuildProductIntoDirectory(directoryURL, settings)
 				|> then(SignalProducer(value: url))
 		}
 }
@@ -676,7 +676,7 @@ private func copyBuildProductIntoDirectory(directoryURL: NSURL, settings: BuildS
 /// the given folder. Does nothing if bitcode is disabled.
 ///
 /// Returns a signal that will send the URL after copying for each file.
-private func copyBCSymbolMapForBuildProductIntoDirectory(directoryURL: NSURL, settings: BuildSettings) -> SignalProducer<NSURL, CarthageError> {
+private func copyBCSymbolMapsForBuildProductIntoDirectory(directoryURL: NSURL, settings: BuildSettings) -> SignalProducer<NSURL, CarthageError> {
 	if settings.bitcodeEnabled.value == true {
 		return SignalProducer(result: settings.wrapperURL)
 			|> flatMap(.Merge) { wrapperURL in BCSymbolMapsForFramework(wrapperURL) }
@@ -838,7 +838,7 @@ private func mergeBuildProductsIntoDirectory(firstProductSettings: BuildSettings
 
 			return mergeProductBinaries
 				|> then(mergeProductModules)
-				|> then(copyBCSymbolMapForBuildProductIntoDirectory(destinationFolderURL, secondProductSettings))
+				|> then(copyBCSymbolMapsForBuildProductIntoDirectory(destinationFolderURL, secondProductSettings))
 				|> then(SignalProducer(value: productURL))
 		}
 }


### PR DESCRIPTION
These files are necessary in order to archive a built product that includes bitcode.
This change makes it copy the bcsymbolmap files to the Carthage/Build/$plat folder,
as well as archiving them with `carthage archive` and installing them from prebuilt
archives.

Note, I have not actually tested the prebuilt archive stuff, as there are no prebuilt
archives with bcsymbolmap files (that I'm aware of) today.

This also changes `carthage copy-frameworks` to also copy the bcsymbolmap files
into the build products folder whenever an archive is done. It has a flag
`--copy-bcsymbolmaps` that can be used to copy them on other builds too if desired.