### PR TITLE
Fix "fatal: destination path … already exists" on checkout

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -400,10 +400,9 @@ public func isGitRepository(directoryURL: NSURL) -> SignalProducer<Bool, NoError
 
 	return launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL)
 		|> map { outputIncludingLineEndings in
-			let relativeGitDirectory = outputIncludingLineEndings.stringByTrimmingCharactersInSet(.newlineCharacterSet())
-			let gitDirectory = directoryURL.URLByAppendingPathComponent(relativeGitDirectory).path
+			let relativeOrAbsoluteGitDirectory = outputIncludingLineEndings.stringByTrimmingCharactersInSet(.newlineCharacterSet())
 			var isDirectory: ObjCBool = false
-			let directoryExists = gitDirectory.map { NSFileManager.defaultManager().fileExistsAtPath($0, isDirectory: &isDirectory) } ?? false
+			let directoryExists = NSFileManager.defaultManager().fileExistsAtPath(relativeOrAbsoluteGitDirectory, isDirectory: &isDirectory)
 			return directoryExists && isDirectory
 		}
 		|> catch { _ in SignalProducer(value: false) }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -401,14 +401,14 @@ public func isGitRepository(directoryURL: NSURL) -> SignalProducer<Bool, NoError
 	return launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL)
 		|> map { outputIncludingLineEndings in
 			let relativeOrAbsoluteGitDirectory = outputIncludingLineEndings.stringByTrimmingCharactersInSet(.newlineCharacterSet())
-			var absoluteGitDirectory: String
+			var absoluteGitDirectory: String?
 			if (relativeOrAbsoluteGitDirectory as NSString).absolutePath {
 				absoluteGitDirectory = relativeOrAbsoluteGitDirectory
 			} else {
-				absoluteGitDirectory = (directoryURL.path! as NSString).stringByAppendingPathComponent(relativeOrAbsoluteGitDirectory)
+				absoluteGitDirectory = directoryURL.URLByAppendingPathComponent(relativeOrAbsoluteGitDirectory).path
 			}
 			var isDirectory: ObjCBool = false
-			let directoryExists = NSFileManager.defaultManager().fileExistsAtPath(absoluteGitDirectory, isDirectory: &isDirectory)
+			let directoryExists = absoluteGitDirectory.map { NSFileManager.defaultManager().fileExistsAtPath($0, isDirectory: &isDirectory) } ?? false
 			return directoryExists && isDirectory
 		}
 		|> catch { _ in SignalProducer(value: false) }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -401,8 +401,14 @@ public func isGitRepository(directoryURL: NSURL) -> SignalProducer<Bool, NoError
 	return launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL)
 		|> map { outputIncludingLineEndings in
 			let relativeOrAbsoluteGitDirectory = outputIncludingLineEndings.stringByTrimmingCharactersInSet(.newlineCharacterSet())
+			var absoluteGitDirectory: String
+			if (relativeOrAbsoluteGitDirectory as NSString).absolutePath {
+				absoluteGitDirectory = relativeOrAbsoluteGitDirectory
+			} else {
+				absoluteGitDirectory = (directoryURL.path! as NSString).stringByAppendingPathComponent(relativeOrAbsoluteGitDirectory)
+			}
 			var isDirectory: ObjCBool = false
-			let directoryExists = NSFileManager.defaultManager().fileExistsAtPath(relativeOrAbsoluteGitDirectory, isDirectory: &isDirectory)
+			let directoryExists = NSFileManager.defaultManager().fileExistsAtPath(absoluteGitDirectory, isDirectory: &isDirectory)
 			return directoryExists && isDirectory
 		}
 		|> catch { _ in SignalProducer(value: false) }


### PR DESCRIPTION
`git rev-parse --git-dir` returns not only relative path but also absolute path. When absolute path was returned, it caused "fatal: destination path" error.

```sh
% git rev-parse --git-dir
.git
% cd Carthage/Checkouts/Argo
% git rev-parse --git-dir
/Users/norio/Documents/workspace/github/Carthage/.git/modules/Carthage/Checkouts/Argo
% 
```

