### PR TITLE
Remove deploy:on:all_branches from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    all_branches: true


### PR DESCRIPTION
That has no effect for GitHub Releases.

http://docs.travis-ci.com/user/deployment/releases/ says:

> Please note that deploying GitHub Releases works only for tags, not for branches.