### PR TITLE
Accept ad hoc code signing

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -698,6 +698,16 @@ public struct BuildSettings {
 			return .Success(nil)
 		}
 	}
+
+	/// Attempts to determine the code signing identity.
+	public var codeSigningIdentity: Result<String, CarthageError> {
+		return self["CODE_SIGN_IDENTITY"]
+	}
+
+	/// Attempts to determine if ad hoc code signing is allowed.
+	public var adHocCodeSigningAllowed: Result<Bool, CarthageError> {
+		return self["AD_HOC_CODE_SIGNING_ALLOWED"].map { $0 == "YES" }
+	}
 }
 
 extension BuildSettings: CustomStringConvertible {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -219,7 +219,15 @@ public func buildableSDKs(sdks: [SDK], _ scheme: String, _ configuration: String
 			
 			return BuildSettings.loadWithArguments(identityCheckArgs)
 				.filter { settings -> Bool in
-					if let configuredSigningIdentity = settings["CODE_SIGN_IDENTITY"].value
+					let codeSigningIdentity = settings.codeSigningIdentity.value
+
+					if settings.adHocCodeSigningAllowed.value != false && codeSigningIdentity == "-" {
+						// Accept ad hoc code signing. Normally, this would be
+						// used for Cocoa (OS X) framework targets.
+						return true
+					}
+
+					if let configuredSigningIdentity = codeSigningIdentity
 						where !availableIdentities.contains(configuredSigningIdentity) {
 							let quotedSDK = formatting.quote(sdk.rawValue)
 							let quotedIdentity = formatting.quote(configuredSigningIdentity)
@@ -228,6 +236,7 @@ public func buildableSDKs(sdks: [SDK], _ scheme: String, _ configuration: String
 							
 							return false
 					}
+
 					return true
 				}
 				.map { _ in sdk }


### PR DESCRIPTION
Fixes #897.

If `AD_HOC_CODE_SIGNING_ALLOWED=NO` and `CODE_SIGN_IDENTITY=-` are both set, an error like `ad hoc code signing not allowed with SDK 'iOS 9.1'` would happen, and `-sdk macosx` does not have the former setting, but other sdks have the setting:

```bash
$ xcodebuild -workspace ReactiveCocoa.xcworkspace/ -scheme ReactiveCocoa-Mac -showBuildSettings | grep CODE_SIGN
    CODE_SIGNING_ALLOWED = YES
    EXPANDED_CODE_SIGN_IDENTITY = 
    EXPANDED_CODE_SIGN_IDENTITY_NAME = 

$ xcodebuild -workspace ReactiveCocoa.xcworkspace/ -scheme ReactiveCocoa-iOS -sdk iphonesimulator -showBuildSettings | grep CODE_SIGN
    AD_HOC_CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_ALLOWED = NO
    CODE_SIGN_CONTEXT_CLASS = XCiPhoneSimulatorCodeSignContext
    EXPANDED_CODE_SIGN_IDENTITY = 
    EXPANDED_CODE_SIGN_IDENTITY_NAME = 

$ xcodebuild -workspace ReactiveCocoa.xcworkspace/ -scheme ReactiveCocoa-iOS -sdk iphoneos -showBuildSettings | grep CODE_SIGN 
    AD_HOC_CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_ALLOWED = YES
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_CONTEXT_CLASS = XCiPhoneOSCodeSignContext
    CODE_SIGN_IDENTITY = iPhone Developer
    EXPANDED_CODE_SIGN_IDENTITY = 
    EXPANDED_CODE_SIGN_IDENTITY_NAME = 

```