### PR TITLE
Check if a submodule is initialized/updated when adding it to a repository

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -432,6 +432,10 @@ public func addSubmoduleToRepository(repositoryFileURL: NSURL, _ submodule: Subm
 	let submoduleDirectoryURL = repositoryFileURL.URLByAppendingPathComponent(submodule.path, isDirectory: true)
 
 	return isGitRepository(submoduleDirectoryURL)
+		.map { isRepository in
+			// Check if the submodule is initialized/updated already.
+			return isRepository && NSFileManager.defaultManager().fileExistsAtPath(submoduleDirectoryURL.URLByAppendingPathComponent(".git").path!)
+		}
 		.promoteErrors(CarthageError.self)
 		.flatMap(.Merge) { submoduleExists -> SignalProducer<(), CarthageError> in
 			if submoduleExists {


### PR DESCRIPTION
Fixes #817. Fixes #901.

This enables to run `carthage update --use-submodules` (or `bootstrap`) on repositories that are using submodules and the submodules are not initialized or updated yet.

#819 didn't fix the issue. :bow: 