### PR TITLE
Use `cp -Rf` instead of `cp -rf` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ installables: clean bootstrap
 
 prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
-	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
+	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
 	install_name_tool -add_rpath "@executable_path/../Frameworks/$(OUTPUT_FRAMEWORK)/Versions/Current/Frameworks/"  "$(PREFIX)/bin/carthage"
 


### PR DESCRIPTION
`-r` option of `cp` copies symbolic links as normal files.
As the result of that, `CarthageKit.framework` that distributed by Homebrew contains a lot of duplicated files inside that.
`-R` option copies symbolic links as symbolic links.

On my testing, this fix reduces the size of `carthage-0.10.el_capitan.bottle.tar.gz` from 11.4MB to 3.5MB.