### PR TITLE
Fix merge order of frameworks to ensure that the device build should be the base (destination) one

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1001,8 +1001,8 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		.flatMap(.Concat) { platform, sdks -> SignalProducer<(Platform, [SDK]), CarthageError> in
 			let filterResult = sdkFilter(sdks: sdks, scheme: scheme, configuration: configuration, project: project)
 			return SignalProducer(result: filterResult.map { sdks in
-				// Ensure that a device SDK are ordered before than a simulator
-				// SDK of the same platform.
+				// Ensure that device SDKs are ordered before simulator SDKs of
+				// the same platform.
 				return (platform, sdks.sort())
 			})
 		}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -993,8 +993,8 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 
 			case 2:
 				let (simulatorSDKs, deviceSDKs) = SDK.splitSDKs(sdks)
-				let deviceSDK = deviceSDKs.first!
-				let simulatorSDK = simulatorSDKs.first!
+				guard let deviceSDK = deviceSDKs.first else { fatalError("Could not find device SDK in \(sdks)") }
+				guard let simulatorSDK = simulatorSDKs.first else { fatalError("Could not find simulator SDK in \(sdks)") }
 
 				return settingsByTarget(buildSDK(deviceSDK))
 					.flatMap(.Concat) { settingsEvent -> SignalProducer<TaskEvent<(BuildSettings, BuildSettings)>, CarthageError> in

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -299,7 +299,7 @@ extension Platform: CustomStringConvertible {
 }
 
 /// Represents an SDK buildable by Xcode.
-public enum SDK: String, Comparable {
+public enum SDK: String {
 	/// Mac OS X.
 	case MacOSX = "macosx"
 
@@ -368,39 +368,6 @@ public enum SDK: String, Comparable {
 		case .MacOSX:
 			return .Mac
 		}
-	}
-}
-
-public func < (lhs: SDK, rhs: SDK) -> Bool {
-	switch (lhs, rhs) {
-	// Prefer Mac OS X SDK.
-	case (.MacOSX, _):
-		return true
-
-	case (_, .MacOSX):
-		return false
-
-	// Prefer device SDK over simulator SDK in same platform.
-	case (.iPhoneOS, .iPhoneSimulator):
-		return true
-
-	case (.iPhoneSimulator, .iPhoneOS):
-		return false
-
-	case (.watchOS, .watchSimulator):
-		return true
-
-	case (.watchSimulator, .watchOS):
-		return false
-
-	case (.tvOS, .tvSimulator):
-		return true
-
-	case (.tvSimulator, .tvOS):
-		return false
-
-	case _:
-		return true
 	}
 }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -975,9 +975,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 		}
 		.flatMap(.Concat) { platform, sdks -> SignalProducer<(Platform, [SDK]), CarthageError> in
 			let filterResult = sdkFilter(sdks: sdks, scheme: scheme, configuration: configuration, project: project)
-			return SignalProducer(result: filterResult.map { sdks in
-				return (platform, sdks)
-			})
+			return SignalProducer(result: filterResult.map { (platform, $0) })
 		}
 		.filter { _, sdks in
 			return !sdks.isEmpty

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -328,18 +328,10 @@ public enum SDK: String {
 
 	/// Split the given SDKs into simulator ones and device ones.
 	private static func splitSDKs<S: SequenceType where S.Generator.Element == SDK>(sdks: S) -> (simulators: [SDK], devices: [SDK]) {
-		var simulators: [SDK] = []
-		var devices: [SDK] = []
-
-		sdks.forEach { sdk in
-			if sdk.isSimulator {
-				simulators.append(sdk)
-			} else {
-				devices.append(sdk)
-			}
-		}
-
-		return (simulators: simulators, devices: devices)
+		return (
+			simulators: sdks.filter { $0.isSimulator },
+			devices: sdks.filter { !$0.isSimulator }
+		)
 	}
 
 	/// Returns whether this is a simulator SDK.


### PR DESCRIPTION
Should fix #824.

The order of SDK list which comes form `xcodebuild -showBuildSettings | grep SUPPORTED_PLATFORMS` are different depending on the platform.

- iOS: `iphonesimulator iphoneos`
- watchOS: `watchsimulator watchos`
- tvOS: `appletvos appletvsimulator`

In tvOS case, the simulator build had been the base framework when merging with the device build. Thus, `CFBundleSupportedPlatforms` would be `AppleTVSimulator` and `DTPlatformName` would be `appletvsimulator` in the resulting Info.plist.

This fix ensures that the device build should be the base one when merging the two frameworks.