### PR TITLE
Avoid curried function syntax

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -53,12 +53,8 @@ extension GitHubError: CustomStringConvertible {
 }
 
 extension GitHubError: Decodable {
-	public static func create(message: String) -> GitHubError {
-		return self.init(message: message)
-	}
-	
 	public static func decode(j: JSON) -> Decoded<GitHubError> {
-		return self.create
+		return self.init
 			<^> j <| "message"
 	}
 }
@@ -271,8 +267,10 @@ public struct GitHubRelease: Equatable {
 			return "Asset { name = \(name), contentType = \(contentType), URL = \(URL) }"
 		}
 
-		public static func create(ID: Int)(name: String)(contentType: String)(URL: NSURL) -> Asset {
-			return self.init(ID: ID, name: name, contentType: contentType, URL: URL)
+		public static func create(ID: Int) -> String -> String -> NSURL -> Asset {
+			return { name in { contentType in { URL in
+				return self.init(ID: ID, name: name, contentType: contentType, URL: URL)
+			} } }
 		}
 
 		public static func decode(j: JSON) -> Decoded<Asset> {
@@ -306,8 +304,10 @@ extension GitHubRelease: CustomStringConvertible {
 }
 
 extension GitHubRelease: Decodable {
-	public static func create(ID: Int)(name: String?)(tag: String)(draft: Bool)(prerelease: Bool)(assets: [Asset]) -> GitHubRelease {
-		return self.init(ID: ID, name: name, tag: tag, draft: draft, prerelease: prerelease, assets: assets)
+	public static func create(ID: Int) -> String? -> String -> Bool -> Bool -> [Asset] -> GitHubRelease {
+		return { name in { tag in { draft in { prerelease in { assets in
+			return self.init(ID: ID, name: name, tag: tag, draft: draft, prerelease: prerelease, assets: assets)
+		} } } } }
 	}
 
 	public static func decode(j: JSON) -> Decoded<GitHubRelease> {

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -65,8 +65,10 @@ private struct ArchiveOptions: OptionsType {
 	let outputPath: String
 	let colorOptions: ColorOptions
 
-	static func create(outputPath: String)(colorOptions: ColorOptions)(frameworkName: String) -> ArchiveOptions {
-		return self.init(frameworkName: frameworkName, outputPath: outputPath, colorOptions: colorOptions)
+	static func create(outputPath: String) -> ColorOptions -> String -> ArchiveOptions {
+		return { colorOptions in { frameworkName in
+			return self.init(frameworkName: frameworkName, outputPath: outputPath, colorOptions: colorOptions)
+		} }
 	}
 
 	static func evaluate(m: CommandMode) -> Result<ArchiveOptions, CommandantError<CarthageError>> {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -193,8 +193,10 @@ public struct BuildOptions: OptionsType {
 	public let verbose: Bool
 	public let directoryPath: String
 
-	public static func create(configuration: String)(buildPlatform: BuildPlatform)(skipCurrent: Bool)(colorOptions: ColorOptions)(verbose: Bool)(directoryPath: String) -> BuildOptions {
-		return self.init(configuration: configuration, buildPlatform: buildPlatform, skipCurrent: skipCurrent, colorOptions: colorOptions, verbose: verbose, directoryPath: directoryPath)
+	public static func create(configuration: String) -> BuildPlatform -> Bool -> ColorOptions -> Bool -> String -> BuildOptions {
+		return { buildPlatform in { skipCurrent in { colorOptions in { verbose in { directoryPath in
+			return self.init(configuration: configuration, buildPlatform: buildPlatform, skipCurrent: skipCurrent, colorOptions: colorOptions, verbose: verbose, directoryPath: directoryPath)
+		} } } } }
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<BuildOptions, CommandantError<CarthageError>> {

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -39,11 +39,13 @@ public struct CheckoutOptions: OptionsType {
 	public let useBinaries: Bool
 	public let colorOptions: ColorOptions
 
-	public static func create(useSSH: Bool)(useSubmodules: Bool)(useBinaries: Bool)(colorOptions: ColorOptions)(directoryPath: String) -> CheckoutOptions {
-		// Disable binary downloads when using submodules.
-		// See https://github.com/Carthage/Carthage/issues/419.
-		let shouldUseBinaries = useSubmodules ? false : useBinaries
-		return self.init(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: shouldUseBinaries, colorOptions: colorOptions)
+	public static func create(useSSH: Bool) -> Bool -> Bool -> ColorOptions -> String -> CheckoutOptions {
+		return { useSubmodules in { useBinaries in { colorOptions in { directoryPath in
+			// Disable binary downloads when using submodules.
+			// See https://github.com/Carthage/Carthage/issues/419.
+			let shouldUseBinaries = useSubmodules ? false : useBinaries
+			return self.init(directoryPath: directoryPath, useSSH: useSSH, useSubmodules: useSubmodules, useBinaries: shouldUseBinaries, colorOptions: colorOptions)
+		} } } }
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<CheckoutOptions, CommandantError<CarthageError>> {

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -37,8 +37,10 @@ private struct FetchOptions: OptionsType {
 	let colorOptions: ColorOptions
 	let repositoryURL: GitURL
 
-	static func create(colorOptions: ColorOptions)(repositoryURL: GitURL) -> FetchOptions {
-		return self.init(colorOptions: colorOptions, repositoryURL: repositoryURL)
+	static func create(colorOptions: ColorOptions) -> GitURL -> FetchOptions {
+		return { repositoryURL in
+			return self.init(colorOptions: colorOptions, repositoryURL: repositoryURL)
+		}
 	}
 
 	static func evaluate(m: CommandMode) -> Result<FetchOptions, CommandantError<CarthageError>> {

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -13,8 +13,10 @@ import Result
 import PrettyColors
 
 /// Wraps a string with terminal colors and formatting or passes it through, depending on `colorful`.
-private func wrap(colorful: Bool)(wrap: Color.Wrap)(string: String) -> String {
-	return colorful ? wrap.wrap(string) : string
+private func wrap(colorful: Bool, wrap: Color.Wrap) -> String -> String {
+	return { string in
+		return colorful ? wrap.wrap(string) : string
+	}
 }
 
 /// Argument for whether to color and format terminal output.
@@ -66,11 +68,11 @@ public struct ColorOptions: OptionsType {
 		
 		init(_ colorful: Bool) {
 			self.colorful = colorful
-			bulletin      = wrap(colorful)(wrap: Color.Wrap(foreground: .Blue, style: .Bold))
+			bulletin      = wrap(colorful, wrap: Color.Wrap(foreground: .Blue, style: .Bold))
 			bullets       = bulletin(string: "***") + " "
-			URL           = wrap(colorful)(wrap: Color.Wrap(styles: .Underlined))
-			projectName   = wrap(colorful)(wrap: Color.Wrap(styles: .Bold))
-			path          = wrap(colorful)(wrap: Color.Wrap(foreground: .Yellow))
+			URL           = wrap(colorful, wrap: Color.Wrap(styles: .Underlined))
+			projectName   = wrap(colorful, wrap: Color.Wrap(styles: .Bold))
+			path          = wrap(colorful, wrap: Color.Wrap(foreground: .Yellow))
 		}
 
 		/// Wraps a string in bullets, one space of padding, and formatting.
@@ -80,7 +82,7 @@ public struct ColorOptions: OptionsType {
 
 		/// Wraps a string in quotation marks and formatting.
 		func quote(string: String, quotationMark: String = "\"") -> String {
-			return wrap(colorful)(wrap: Color.Wrap(foreground: .Green))(string: quotationMark + string + quotationMark)
+			return wrap(colorful, wrap: Color.Wrap(foreground: .Green))(quotationMark + string + quotationMark)
 		}
 	}
 	

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -53,8 +53,10 @@ public struct UpdateOptions: OptionsType {
 		}
 	}
 
-	public static func create(configuration: String)(buildPlatform: BuildPlatform)(verbose: Bool)(checkoutAfterUpdate: Bool)(buildAfterUpdate: Bool)(checkoutOptions: CheckoutOptions) -> UpdateOptions {
-		return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, verbose: verbose, checkoutOptions: checkoutOptions)
+	public static func create(configuration: String) -> BuildPlatform -> Bool -> Bool -> Bool -> CheckoutOptions -> UpdateOptions {
+		return { buildPlatform in { verbose in { checkoutAfterUpdate in { buildAfterUpdate in { checkoutOptions in
+			return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, verbose: verbose, checkoutOptions: checkoutOptions)
+		} } } } }
 	}
 
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions, CommandantError<CarthageError>> {


### PR DESCRIPTION
That will be removed in Swift 3.0, so let's avoid to use it.