### PR TITLE
Determine the build order when building the dependencies in Cartfile.resolved

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		88ED56D619ECE34900CBF5C4 /* Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88ED56D519ECE34900CBF5C4 /* Git.swift */; };
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
+		CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */ = {isa = PBXBuildFile; fileRef = CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */; };
 		D00105061A8EA74E0059D0A0 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00105051A8EA74E0059D0A0 /* Archive.swift */; };
 		D00CCE321A20783A00109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; };
 		D00CCE331A20784800109F8C /* Commandant.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -152,6 +153,7 @@
 		88ED56D519ECE34900CBF5C4 /* Git.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Git.swift; sourceTree = "<group>"; };
 		98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-bash-completion"; sourceTree = "<group>"; };
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
+		CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestResolvedCartfile.resolved; sourceTree = "<group>"; };
 		D00105051A8EA74E0059D0A0 /* Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
 		D00CCE311A20783A00109F8C /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D012AD0F1AF9843700EE91DA /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -454,6 +456,7 @@
 				D0D1217D19E87B05005E4BAA /* Info.plist */,
 				D0AAAB5419FB1062007B24B3 /* TestCartfile */,
 				D0F551DB1A0D71AB0093311F /* TestCartfile.resolved */,
+				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
 				D04A39811A2F72FB000C5604 /* EmbeddedFrameworksCartfile */,
 				D04A397F1A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile */,
 			);
@@ -594,6 +597,7 @@
 				D0F551DC1A0D71AB0093311F /* TestCartfile.resolved in Resources */,
 				D04A39821A2F72FB000C5604 /* EmbeddedFrameworksCartfile in Resources */,
 				D0C6E5761A57042100A5E3E7 /* CartfilePrivateOnly.zip in Resources */,
+				CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -270,14 +270,18 @@ public struct Dependency<V: VersionType>: Equatable {
 	/// The version(s) that are required to satisfy this dependency.
 	public var version: V
 
-	public init(project: ProjectIdentifier, version: V) {
+	/// The dependencies of this dependency.
+	public let dependencies: Set<ProjectIdentifier>
+
+	public init(project: ProjectIdentifier, version: V, dependencies: Set<ProjectIdentifier> = []) {
 		self.project = project
 		self.version = version
+		self.dependencies = dependencies
 	}
 
 	/// Maps over the `version` in the receiver.
 	public func map<W: VersionType>(f: V -> W) -> Dependency<W> {
-		return Dependency<W>(project: project, version: f(version))
+		return Dependency<W>(project: project, version: f(version), dependencies: dependencies)
 	}
 }
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -561,8 +561,10 @@ public final class Project {
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
 	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, forPlatforms platforms: Set<Platform>, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+		let resolver = Resolver(versionsForDependency: versionsForProject, cartfileForDependency: cartfileForDependency, resolvedGitReference: resolvedGitReference)
+
 		return loadResolvedCartfile()
-			.flatMap(.Merge) { resolvedCartfile in SignalProducer(values: resolvedCartfile.dependencies) }
+			.flatMap(.Merge) { resolvedCartfile in resolver.resolveDependenciesInResolvedCartfile(resolvedCartfile) }
 			.flatMap(.Concat) { dependency -> SignalProducer<BuildSchemeProducer, CarthageError> in
 				let dependencyPath = self.directoryURL.URLByAppendingPathComponent(dependency.project.relativePath, isDirectory: true).path!
 				if !NSFileManager.defaultManager().fileExistsAtPath(dependencyPath) {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -561,7 +561,15 @@ public final class Project {
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
 	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, forPlatforms platforms: Set<Platform>, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
-		let resolver = Resolver(versionsForDependency: versionsForProject, cartfileForDependency: cartfileForDependency, resolvedGitReference: resolvedGitReference)
+		let resolver = Resolver(
+			versionsForDependency: versionsForProject,
+			cartfileForDependency: cartfileForDependency,
+			resolvedGitReference: { _, refName in
+				// This could be OK since the dependencies should be fully
+				// resolved already.
+				return SignalProducer(value: PinnedVersion(refName))
+			}
+		)
 
 		return loadResolvedCartfile()
 			.flatMap(.Merge) { resolvedCartfile in resolver.resolveDependenciesInResolvedCartfile(resolvedCartfile) }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -565,8 +565,7 @@ public final class Project {
 			versionsForDependency: versionsForProject,
 			cartfileForDependency: cartfileForDependency,
 			resolvedGitReference: { _, refName in
-				// This could be OK since the dependencies should be fully
-				// resolved already.
+				// Dependencies should be fully resolved already.
 				return SignalProducer(value: PinnedVersion(refName))
 			}
 		)

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -34,12 +34,12 @@ public struct Resolver {
 	/// specified in the given Cartfile, and all nested dependencies thereof.
 	///
 	/// Sends each recursive dependency with its resolved version, in the
-	/// alphabetical order of its project name.
+	/// lexical order of its project name.
 	public func resolveDependenciesInCartfile(cartfile: Cartfile) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
 		return resolveDependenciesFromNodePermutations(nodePermutationsForCartfile(cartfile))
 			.flatMap(.Merge) { graph -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in
 				let sortedNodes = graph.allNodes.sort { lhs, rhs in
-					return lhs.project.name < rhs.project.name
+					return lhs.project.name.caseInsensitiveCompare(rhs.project.name) != .OrderedDescending
 				}
 				return SignalProducer(values: sortedNodes)
 					.map { node in

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -34,7 +34,7 @@ public struct Resolver {
 	/// specified in the given Cartfile, and all nested dependencies thereof.
 	///
 	/// Sends each recursive dependency with its resolved version, in the
-	/// lexical order of its project name.
+	/// lexicographical order of its project name.
 	public func resolveDependenciesInCartfile(cartfile: Cartfile) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
 		return resolveDependenciesFromNodePermutations(nodePermutationsForCartfile(cartfile))
 			.flatMap(.Merge) { graph -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -33,10 +33,46 @@ public struct Resolver {
 	/// Attempts to determine the latest valid version to use for each dependency
 	/// specified in the given Cartfile, and all nested dependencies thereof.
 	///
-	/// Sends each recursive dependency with its resolved version, in the order
-	/// that they should be built.
+	/// Sends each recursive dependency with its resolved version, in the
+	/// alphabetical order of its project name.
 	public func resolveDependenciesInCartfile(cartfile: Cartfile) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
-		return nodePermutationsForCartfile(cartfile)
+		return resolveDependenciesFromNodePermutations(nodePermutationsForCartfile(cartfile))
+			.flatMap(.Merge) { graph -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in
+				let sortedNodes = graph.allNodes.sort { lhs, rhs in
+					return lhs.project.name < rhs.project.name
+				}
+				return SignalProducer(values: sortedNodes)
+					.map { node in
+						node.dependencies = graph.edges[node] ?? []
+						return node.dependencyVersion
+					}
+			}
+	}
+
+	/// Attempts to determine the build order for the resolved dependencies.
+	///
+	/// Sends each recursive dependency with its already resolved version, in the
+	/// order that they should be built.
+	public func resolveDependenciesInResolvedCartfile(resolvedCartfile: ResolvedCartfile) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
+		let nodes = resolvedCartfile.dependencies.map {
+			DependencyNode(
+				project: $0.project,
+				proposedVersion: $0.version,
+				versionSpecifier: .GitReference($0.version.commitish)
+			)
+		}
+		return resolveDependenciesFromNodePermutations(SignalProducer(value: nodes))
+			.flatMap(.Merge) { graph -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in
+				return SignalProducer(values: graph.orderedNodes)
+					.map { node in
+						node.dependencies = graph.edges[node] ?? []
+						return node.dependencyVersion
+					}
+			}
+	}
+
+	private func resolveDependenciesFromNodePermutations(permutationsProducer: SignalProducer<[DependencyNode], CarthageError>) -> SignalProducer<DependencyGraph, CarthageError> {
+		return permutationsProducer
 			.flatMap(.Concat) { rootNodes -> SignalProducer<Event<DependencyGraph, CarthageError>, CarthageError> in
 				return self.graphPermutationsForEachNode(rootNodes, dependencyOf: nil, basedOnGraph: DependencyGraph())
 					.promoteErrors(CarthageError.self)
@@ -46,10 +82,6 @@ public struct Resolver {
 			.dematerializeErrorsIfEmpty()
 			.take(1)
 			.observeOn(QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), name: "org.carthage.CarthageKit.Resolver.resolveDependencesInCartfile"))
-			.flatMap(.Merge) { graph -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in
-				return SignalProducer(values: graph.orderedNodes)
-					.map { node in node.dependencyVersion }
-			}
 	}
 
 	/// Sends all permutations of valid DependencyNodes, corresponding to the
@@ -395,9 +427,12 @@ private class DependencyNode: Comparable {
 	/// become more stringent.
 	var versionSpecifier: VersionSpecifier
 
+	/// The dependencies of this node.
+	var dependencies: Set<DependencyNode> = []
+
 	/// A Dependency equivalent to this node.
 	var dependencyVersion: Dependency<PinnedVersion> {
-		return Dependency(project: project, version: proposedVersion)
+		return Dependency(project: project, version: proposedVersion, dependencies: Set(dependencies.map { $0.project }))
 	}
 
 	init(project: ProjectIdentifier, proposedVersion: PinnedVersion, versionSpecifier: VersionSpecifier) {

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -57,9 +57,8 @@ class ResolverSpec: QuickSpec {
 			let resolver = Resolver(
 				versionsForDependency: self.versionsForDependency,
 				cartfileForDependency: self.cartfileForDependency,
-				resolvedGitReference: { _, gitRef -> SignalProducer<PinnedVersion, CarthageError> in
-					return .init(value: PinnedVersion(gitRef))
-				})
+				resolvedGitReference: { _, refName in SignalProducer(value: PinnedVersion(refName)) }
+			)
 
 			let testCartfile: ResolvedCartfile = self.loadTestCartfile("TestResolvedCartfile", withExtension: "resolved")
 			let dependencies = self.orderedDependencies(resolver, fromCartfile: testCartfile)

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -40,15 +40,15 @@ class ResolverSpec: QuickSpec {
 
 			var generator = dependencies.generate()
 
-			// Dependencies should be listed in build order.
-			expect(generator.next()).to(equal([ "Mantle": PinnedVersion("1.3.0") ]))
+			// Dependencies should be listed in lexical order of its project name.
 			expect(generator.next()).to(equal([ "git-error-translations": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "git-error-translations2": PinnedVersion("8ff4393ede2ca86d5a78edaf62b3a14d90bffab9") ]))
 			expect(generator.next()).to(equal([ "ios-charts": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "libextobjc": PinnedVersion("0.4.1") ]))
-			expect(generator.next()).to(equal([ "xcconfigs": PinnedVersion("1.3.0") ]))
+			expect(generator.next()).to(equal([ "Mantle": PinnedVersion("1.3.0") ]))
 			expect(generator.next()).to(equal([ "objc-build-scripts": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "ReactiveCocoa": PinnedVersion("3.0.0") ]))
+			expect(generator.next()).to(equal([ "xcconfigs": PinnedVersion("1.3.0") ]))
 		}
 
 		it("should correctly order transitive dependencies") {
@@ -84,11 +84,11 @@ class ResolverSpec: QuickSpec {
 
 			var generator = dependencies.generate()
 
-			// Dependencies should be listed in build order.
+			// Dependencies should be listed in lexical order of its project name.
 			expect(generator.next()).to(equal([ "Alamofire": PinnedVersion("1.1.2") ]))
+			expect(generator.next()).to(equal([ "EmbeddedFrameworks": PinnedVersion("1.0.0") ]))
 			expect(generator.next()).to(equal([ "Swell": PinnedVersion("1.0.0") ]))
 			expect(generator.next()).to(equal([ "SwiftyJSON": PinnedVersion("2.1.2") ]))
-			expect(generator.next()).to(equal([ "EmbeddedFrameworks": PinnedVersion("1.0.0") ]))
 		}
 	}
 

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -40,7 +40,8 @@ class ResolverSpec: QuickSpec {
 
 			var generator = dependencies.generate()
 
-			// Dependencies should be listed in lexical order of its project name.
+			// Dependencies should be listed in lexicographical order of its 
+			// project name.
 			expect(generator.next()).to(equal([ "git-error-translations": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "git-error-translations2": PinnedVersion("8ff4393ede2ca86d5a78edaf62b3a14d90bffab9") ]))
 			expect(generator.next()).to(equal([ "ios-charts": PinnedVersion("3.0.0") ]))
@@ -84,7 +85,8 @@ class ResolverSpec: QuickSpec {
 
 			var generator = dependencies.generate()
 
-			// Dependencies should be listed in lexical order of its project name.
+			// Dependencies should be listed in lexicographical order of its
+			// project name.
 			expect(generator.next()).to(equal([ "Alamofire": PinnedVersion("1.1.2") ]))
 			expect(generator.next()).to(equal([ "EmbeddedFrameworks": PinnedVersion("1.0.0") ]))
 			expect(generator.next()).to(equal([ "Swell": PinnedVersion("1.0.0") ]))

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -42,16 +42,15 @@ class ResolverSpec: QuickSpec {
 
 			var generator = dependencies.generate()
 
-			// Dependencies should be listed in lexicographical order of its 
-			// project name.
+			// Dependencies should be listed in build order.
+			expect(generator.next()).to(equal([ "Mantle": PinnedVersion("1.3.0") ]))
 			expect(generator.next()).to(equal([ "git-error-translations": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "git-error-translations2": PinnedVersion("8ff4393ede2ca86d5a78edaf62b3a14d90bffab9") ]))
 			expect(generator.next()).to(equal([ "ios-charts": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "libextobjc": PinnedVersion("0.4.1") ]))
-			expect(generator.next()).to(equal([ "Mantle": PinnedVersion("1.3.0") ]))
+			expect(generator.next()).to(equal([ "xcconfigs": PinnedVersion("1.3.0") ]))
 			expect(generator.next()).to(equal([ "objc-build-scripts": PinnedVersion("3.0.0") ]))
 			expect(generator.next()).to(equal([ "ReactiveCocoa": PinnedVersion("3.0.0") ]))
-			expect(generator.next()).to(equal([ "xcconfigs": PinnedVersion("1.3.0") ]))
 		}
 
 		it("should sort dependencies from Cartfile.resolved in build order") {
@@ -113,12 +112,11 @@ class ResolverSpec: QuickSpec {
 
 			var generator = dependencies.generate()
 
-			// Dependencies should be listed in lexicographical order of its
-			// project name.
+			// Dependencies should be listed in build order.
 			expect(generator.next()).to(equal([ "Alamofire": PinnedVersion("1.1.2") ]))
-			expect(generator.next()).to(equal([ "EmbeddedFrameworks": PinnedVersion("1.0.0") ]))
 			expect(generator.next()).to(equal([ "Swell": PinnedVersion("1.0.0") ]))
 			expect(generator.next()).to(equal([ "SwiftyJSON": PinnedVersion("2.1.2") ]))
+			expect(generator.next()).to(equal([ "EmbeddedFrameworks": PinnedVersion("1.0.0") ]))
 		}
 	}
 

--- a/Source/CarthageKitTests/TestResolvedCartfile.resolved
+++ b/Source/CarthageKitTests/TestResolvedCartfile.resolved
@@ -1,0 +1,8 @@
+github "https://enterprise.local/ghe/desktop/git-error-translations" "3.0.0"
+git "https://enterprise.local/desktop/git-error-translations2.git" "8ff4393ede2ca86d5a78edaf62b3a14d90bffab9"
+github "danielgindi/ios-charts.git" "3.0.0"
+github "jspahrsummers/libextobjc" "0.4.1"
+github "Mantle/Mantle" "1.3.0"
+github "jspahrsummers/objc-build-scripts" "3.0.0"
+github "ReactiveCocoa/ReactiveCocoa" "3.0.0"
+github "jspahrsummers/xcconfigs" "1.3.0"


### PR DESCRIPTION
~~The build order is not preserved in `Cartfile.resolved` now.~~

Trying to fix #717 based on the discussion: https://github.com/Carthage/Carthage/issues/717#issuecomment-135501479
