### PR TITLE
listing possible platform parameters in help for the update command

### DIFF
--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -62,7 +62,7 @@ public struct UpdateOptions: OptionsType {
 	public static func evaluate(m: CommandMode) -> Result<UpdateOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (ignored if --no-build option is present)")
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, 'tvOS', or comma-separated values of the formers except for ‘all’)\n(ignored if --no-build option is present)")
 			<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
 			<*> m <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
 			<*> m <| Option(key: "build", defaultValue: true, usage: "skip the building of dependencies after updating (ignored if --no-checkout option is present)")


### PR DESCRIPTION
Took me some time to find out where the platform parameters are documented (only under help build). 
I hope this helps other users.

Maybe `--platform` should also be explained in the Readme.