### PR TITLE
Making --no-use-binaries the default

### DIFF
--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -52,7 +52,7 @@ public struct CheckoutOptions: OptionsType {
 		return create
 			<*> m <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 			<*> m <| Option(key: "use-submodules", defaultValue: false, usage: "add dependencies as Git submodules")
-			<*> m <| Option(key: "use-binaries", defaultValue: true, usage: "check out dependency repositories even when prebuilt frameworks exist, disabled if --use-submodules option is present" + useBinariesAddendum)
+			<*> m <| Option(key: "use-binaries", defaultValue: false, usage: "check out dependency repositories even when prebuilt frameworks exist, disabled if --use-submodules option is present" + useBinariesAddendum)
 			<*> ColorOptions.evaluate(m)
 			<*> m <| Option(key: "project-directory", defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")
 	}


### PR DESCRIPTION
Hi,

Unfortunately our team wasn't aware of https://github.com/Carthage/Carthage/issues/924.  Hilarity ensued.

This pull request makes --no-use-binaries the default behavior of Carthage.  This should prevent others from getting bitten quite so hard by Apple's http://www.openradar.me/23551273.