### PR TITLE
Support multiple frameworks in `archive` command

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -297,7 +297,7 @@ public func buildableSchemesInDirectory(directoryURL: NSURL, withConfiguration c
 
 /// Sends pairs of a scheme and a project, the scheme actually resides in
 /// the project.
-public func schemesToBuildOfProjectLocators(projects: [(ProjectLocator, [String])]) -> SignalProducer<[(String, ProjectLocator)], CarthageError> {
+public func schemesInProjects(projects: [(ProjectLocator, [String])]) -> SignalProducer<[(String, ProjectLocator)], CarthageError> {
 	return SignalProducer(values: projects)
 		.map { (project: ProjectLocator, schemes: [String]) in
 			// Only look for schemes that actually reside in the project
@@ -1268,7 +1268,7 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 			// `.NoSharedFrameworkSchemes`.
 			.filter { projects in !projects.isEmpty }
 			.flatMap(.Merge) { (projects: [(ProjectLocator, [String])]) -> SignalProducer<(String, ProjectLocator), CarthageError> in
-				return schemesToBuildOfProjectLocators(projects)
+				return schemesInProjects(projects)
 					.flatMap(.Merge) { (schemes: [(String, ProjectLocator)]) -> SignalProducer<(String, ProjectLocator), CarthageError> in
 						if !schemes.isEmpty {
 							return .init(values: schemes)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -270,7 +270,7 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 
 /// Finds schemes of projects or workspace, which Carthage should build, found
 /// within the given directory.
-public func buildableSchemesByProjectLocatorInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = []) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
+public func buildableSchemesInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = []) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
 	precondition(directoryURL.fileURL)
 
 	return locateProjectsInDirectory(directoryURL)
@@ -1256,7 +1256,7 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 		// multiple times.
 		let (locatorBuffer, locatorObserver) = SignalProducer<(ProjectLocator, [String]), CarthageError>.buffer()
 
-		buildableSchemesByProjectLocatorInDirectory(directoryURL, withConfiguration: configuration, forPlatforms: platforms)
+		buildableSchemesInDirectory(directoryURL, withConfiguration: configuration, forPlatforms: platforms)
 			.startWithSignal { signal, signalDisposable in
 				disposable += signalDisposable
 				signal.observe(locatorObserver)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -268,7 +268,7 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
 }
 
-/// Finds schemes of projects or workspace, which Carthage should build, found
+/// Finds schemes of projects or workspaces, which Carthage should build, found
 /// within the given directory.
 public func buildableSchemesInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = []) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
 	precondition(directoryURL.fileURL)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -268,6 +268,62 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
 }
 
+/// Finds schemes of projects or workspace, which Carthage should build, found
+/// within the given directory.
+public func buildableSchemesByProjectLocatorInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = []) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
+	precondition(directoryURL.fileURL)
+
+	return locateProjectsInDirectory(directoryURL)
+		.flatMap(.Concat) { project -> SignalProducer<(ProjectLocator, [String]), CarthageError> in
+			return schemesInProject(project)
+				.flatMap(.Merge) { scheme -> SignalProducer<String, CarthageError> in
+					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
+
+					return shouldBuildScheme(buildArguments, platforms)
+						.filter { $0 }
+						.map { _ in scheme }
+				}
+				.collect()
+				.flatMapError { error in
+					if case .NoSharedSchemes = error {
+						return .init(value: [])
+					} else {
+						return .init(error: error)
+					}
+				}
+				.map { (project, $0) }
+		}
+}
+
+/// Sends pairs of a scheme and a project, the scheme actually resides in
+/// the project.
+public func schemesToBuildOfProjectLocators(projects: [(ProjectLocator, [String])]) -> SignalProducer<[(String, ProjectLocator)], CarthageError> {
+	return SignalProducer(values: projects)
+		.map { (project: ProjectLocator, schemes: [String]) in
+			// Only look for schemes that actually reside in the project
+			let containedSchemes = schemes.filter { (scheme: String) -> Bool in
+				if let schemePath = project.fileURL.URLByAppendingPathComponent("xcshareddata/xcschemes/\(scheme).xcscheme").path {
+					return NSFileManager.defaultManager().fileExistsAtPath(schemePath)
+				}
+				return false
+			}
+			return (project, containedSchemes)
+		}
+		.filter { (project: ProjectLocator, schemes: [String]) in
+			switch project {
+			case .ProjectFile where !schemes.isEmpty:
+				return true
+
+			default:
+				return false
+			}
+		}
+		.flatMap(.Concat) { project, schemes in
+			return .init(values: schemes.map { ($0, project) })
+		}
+		.collect()
+}
+
 /// Represents a platform to build for.
 public enum Platform: String {
 	/// Mac OS X.
@@ -1200,28 +1256,7 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 		// multiple times.
 		let (locatorBuffer, locatorObserver) = SignalProducer<(ProjectLocator, [String]), CarthageError>.buffer()
 
-		locateProjectsInDirectory(directoryURL)
-			.flatMap(.Concat) { (project: ProjectLocator) -> SignalProducer<(ProjectLocator, [String]), CarthageError> in
-				return schemesInProject(project)
-					.flatMap(.Merge) { scheme -> SignalProducer<String, CarthageError> in
-						let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
-
-						return shouldBuildScheme(buildArguments, platforms)
-							.filter { $0 }
-							.map { _ in scheme }
-					}
-					.collect()
-					.flatMapError { error in
-						switch error {
-						case .NoSharedSchemes:
-							return SignalProducer(value: [])
-
-						default:
-							return SignalProducer(error: error)
-						}
-					}
-					.map { (project, $0) }
-			}
+		buildableSchemesByProjectLocatorInDirectory(directoryURL, withConfiguration: configuration, forPlatforms: platforms)
 			.startWithSignal { signal, signalDisposable in
 				disposable += signalDisposable
 				signal.observe(locatorObserver)
@@ -1233,35 +1268,12 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 			// `.NoSharedFrameworkSchemes`.
 			.filter { projects in !projects.isEmpty }
 			.flatMap(.Merge) { (projects: [(ProjectLocator, [String])]) -> SignalProducer<(String, ProjectLocator), CarthageError> in
-				return SignalProducer(values: projects)
-					.map { (project: ProjectLocator, schemes: [String]) in
-						// Only look for schemes that actually reside in the project
-						let containedSchemes = schemes.filter { (scheme: String) -> Bool in
-							if let schemePath = project.fileURL.URLByAppendingPathComponent("xcshareddata/xcschemes/\(scheme).xcscheme").path {
-								return NSFileManager.defaultManager().fileExistsAtPath(schemePath)
-							}
-							return false
-						}
-						return (project, containedSchemes)
-					}
-					.filter { (project: ProjectLocator, schemes: [String]) in
-						switch project {
-						case .ProjectFile where !schemes.isEmpty:
-							return true
-
-						default:
-							return false
-						}
-					}
-					.flatMap(.Concat) { project, schemes in
-						return SignalProducer(values: schemes.map { ($0, project) })
-					}
-					.collect()
+				return schemesToBuildOfProjectLocators(projects)
 					.flatMap(.Merge) { (schemes: [(String, ProjectLocator)]) -> SignalProducer<(String, ProjectLocator), CarthageError> in
 						if !schemes.isEmpty {
-							return SignalProducer(values: schemes)
+							return .init(values: schemes)
 						} else {
-							return SignalProducer(error: .NoSharedFrameworkSchemes(.Git(GitURL(directoryURL.path!)), platforms))
+							return .init(error: .NoSharedFrameworkSchemes(.Git(GitURL(directoryURL.path!)), platforms))
 						}
 					}
 			}

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -50,7 +50,7 @@ public struct ArchiveCommand: CommandType {
 			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release", forPlatforms: [])
 				.collect()
 				.flatMap(.Merge) { projects in
-					return schemesToBuildOfProjectLocators(projects)
+					return schemesInProjects(projects)
 						.flatMap(.Merge) { (schemes: [(String, ProjectLocator)]) -> SignalProducer<(String, ProjectLocator), CarthageError> in
 							if !schemes.isEmpty {
 								return .init(values: schemes)

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -70,9 +70,8 @@ public struct ArchiveCommand: CommandType {
 						return .empty
 					}
 				}
-				.skipRepeats()
 				.collect()
-				.map { $0.sort() }
+				.map { Array(Set($0)).sort() }
 		}
 
 		return frameworks.flatMap(.Merge) { frameworks -> SignalProducer<(), CarthageError> in

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -99,7 +99,12 @@ public struct ArchiveCommand: CommandType {
 				})
 				.collect()
 				.flatMap(.Merge) { paths -> SignalProducer<(), CarthageError> in
-					if paths.isEmpty {
+					let foundFrameworks = paths
+						.lazy
+						.map { ($0 as NSString).lastPathComponent }
+						.filter { $0.hasSuffix(".framework") }
+
+					if Set(foundFrameworks) != Set(frameworks) {
 						let error = CarthageError.InvalidArgument(description: "Could not find any copies of \(frameworks.joinWithSeparator(", ")). Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'.")
 						return SignalProducer(error: error)
 					}

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -47,7 +47,7 @@ public struct ArchiveCommand: CommandType {
 			})
 		} else {
 			let directoryURL = NSURL.fileURLWithPath(options.directoryPath, isDirectory: true)
-			frameworks = buildableSchemesByProjectLocatorInDirectory(directoryURL, withConfiguration: "Release", forPlatforms: [])
+			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release", forPlatforms: [])
 				.collect()
 				.flatMap(.Merge) { projects in
 					return schemesToBuildOfProjectLocators(projects)

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -94,7 +94,7 @@ public struct ArchiveCommand: CommandType {
 			.collect()
 			.flatMap(.Merge) { paths -> SignalProducer<(), CarthageError> in
 				if paths.isEmpty {
-					let error = CarthageError.InvalidArgument(description: "Could not find any copies of \(frameworks). Make sure you're in the project’s root and that the frameworks has already been built using 'carthage build --no-skip-current'.")
+					let error = CarthageError.InvalidArgument(description: "Could not find any copies of \(frameworks.joinWithSeparator(", ")). Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'.")
 					return SignalProducer(error: error)
 				}
 

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -57,11 +57,16 @@ public struct ArchiveCommand: CommandType {
 								return .init(error: error)
 							}
 						}
-						.flatMap(.Merge) { scheme -> SignalProducer<String, CarthageError> in
+						.flatMap(.Merge) { scheme -> SignalProducer<BuildSettings, CarthageError> in
 							let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: "Release")
 							return BuildSettings.loadWithArguments(buildArguments)
-								.map { $0.wrapperName.value }
-								.ignoreNil()
+						}
+						.flatMap(.Concat) { settings -> SignalProducer<String, CarthageError> in
+							if let wrapperName = settings.wrapperName.value {
+								return .init(value: wrapperName)
+							} else {
+								return .empty
+							}
 						}
 				}
 				.skipRepeats()


### PR DESCRIPTION
This would be useful for some libraries, for example, which have a Objective-C framework and the corresponding Swift one (e.g. https://github.com/CocoaLumberjack/CocoaLumberjack).

```bash
carthage archive CocoaLumberjack CocoaLumberjackSwift
```