### PR TITLE
when collecting scheme names from xcodebuild -list output,  only cons…

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -254,7 +254,7 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		}
 		.skipWhile { line in !line.hasSuffix("Schemes:") }
 		.skip(1)
-		.takeWhile { line in !line.isEmpty }
+		.takeWhile { line in !line.isEmpty && line.hasPrefix("  ") }
 		// xcodebuild has a bug where xcodebuild -list can sometimes hang
 		// indefinitely on projects that don't share any schemes, so
 		// automatically bail out if it looks like that's happening.


### PR DESCRIPTION
…ider lines that start with at least two spaces


I noticed that due to some plugins I have for xcode, there is noise in the output of xcodebuild --list...

simeon@SimBook:AutoLayoutTools(master) $ xcodebuild -list
2015-12-22 08:40:49.581 xcodebuild[86481:12379480] XcodeFScript: app=xcodebuild
2015-12-22 08:40:49:599 xcodebuild[86481:e0b] BBUncrustifyPlugin Version 2.1.3 loaded
Information about project "AutoLayoutTools":
    Targets:
        AutoLayoutTools
        AutoLayoutToolsTests
        AutoLayoutToolsFramework
        AutoLayoutToolsLibrary

    Build Configurations:
        Debug
        Release

    If no build configuration is specified and -scheme is not passed then "Release" is used.

    Schemes:
        AutoLayoutSandbox
        AutoLayoutToolsFramework
        AutoLayoutToolsLibrary
2015-12-22 16:40:50 +0000 Plugin Console Open With Application: [NSApp mainMenu] returned nil


carthage thinks that last line (2015-12-22 16:40:50 +0000 Plugin Console Open With Application: [NSApp mainMenu] returned nil) is a scheme name and tried to build it, xcodebuild then complains and carthage exits

This commit only considers lines that start with two spaces as scheme names