### PR TITLE
Add Instruction for tvOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
 1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder and build each one.
 1. On your application targets’ “General” settings tab, in the “Embedded Binaries” section, drag and drop each framework you want to use from the [Carthage/Build][] folder on disk.
 
-##### If you're building for iOS (for tvOS, read `iOS` as `tvOS`)
+##### If you're building for iOS, tvOS, or watchOS
 
 1. Create a [Cartfile][] that lists the frameworks you’d like to use in your project.
 1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder, then build each one.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once you have Carthage [installed](#installing-carthage), you can begin adding f
 1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder and build each one.
 1. On your application targets’ “General” settings tab, in the “Embedded Binaries” section, drag and drop each framework you want to use from the [Carthage/Build][] folder on disk.
 
-##### If you're building for iOS
+##### If you're building for iOS (for tvOS, read `iOS` as `tvOS`)
 
 1. Create a [Cartfile][] that lists the frameworks you’d like to use in your project.
 1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder, then build each one.


### PR DESCRIPTION
This is what I'm doing when installing library via carthage to tvOS apps.
I'm not sure tvOS has apple submission bug, but seems like Xcode cannot resolve dependencies correctly unless you set `carthage copy-framework` Run Script Phase.