### PR TITLE
Clarifies the error message to the 'expected submodule commit SHA in ls-tree output'

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -370,7 +370,7 @@ public func submoduleSHAForPath(repositoryFileURL: NSURL, _ path: String, revisi
 			if components.count >= 3 {
 				return .Success(String(components[2]))
 			} else {
-				return .Failure(CarthageError.ParseError(description: "expected submodule commit SHA in output of \(task.joinWithSeparator(" ")) but encountered: \(string)"))
+				return .Failure(CarthageError.ParseError(description: "expected submodule commit SHA in output of task (\(task.joinWithSeparator(" "))) but encountered: \(string)"))
 			}
 		}
 }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -361,7 +361,8 @@ private func parseConfigEntries(contents: String, keyPrefix: String = "", keySuf
 /// Determines the SHA that the submodule at the given path is pinned to, in the
 /// revision of the parent repository specified.
 public func submoduleSHAForPath(repositoryFileURL: NSURL, _ path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
-	return launchGitTask([ "ls-tree", "-z", revision, path ], repositoryFileURL: repositoryFileURL)
+	let task = [ "ls-tree", "-z", revision, path ]
+	return launchGitTask(task, repositoryFileURL: repositoryFileURL)
 		.attemptMap { string in
 			// Example:
 			// 160000 commit 083fd81ecf00124cbdaa8f86ef10377737f6325a	External/ObjectiveGit
@@ -369,7 +370,7 @@ public func submoduleSHAForPath(repositoryFileURL: NSURL, _ path: String, revisi
 			if components.count >= 3 {
 				return .Success(String(components[2]))
 			} else {
-				return .Failure(CarthageError.ParseError(description: "expected submodule commit SHA in ls-tree output: \(string)"))
+				return .Failure(CarthageError.ParseError(description: "expected submodule commit SHA in output of \(task.joinWithSeparator(" ")) but encountered: \(string)"))
 			}
 		}
 }


### PR DESCRIPTION
This change clarifies the error message to the dreaded "expected submodule commit SHA in ls-tree output:" error such that you learn what kind of a command gave output that could not be parsed. 

Before this modification there can be a lot of guesswork involved in resolving this error especially if you run `carthage update` on a new project with an existing "legacy" .gitmodules file: I for instance encountered this error with a project with a huge set of existing submodules that I began migrating over to Carthage based dependencies (there were a few weird old submodule dependencies whose brokenness would not be picked up as a build error because they would not result in build errors).