### PR TITLE
Always clean before building

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -224,8 +224,14 @@ public func locateProjectsInDirectory(directoryURL: NSURL) -> SignalProducer<Pro
 
 /// Creates a task description for executing `xcodebuild` with the given
 /// arguments.
+public func xcodebuildTask(tasks: [String], _ buildArguments: BuildArguments) -> Task {
+	return Task("/usr/bin/xcrun", arguments: buildArguments.arguments + tasks)
+}
+
+/// Creates a task description for executing `xcodebuild` with the given
+/// arguments.
 public func xcodebuildTask(task: String, _ buildArguments: BuildArguments) -> Task {
-	return Task("/usr/bin/xcrun", arguments: buildArguments.arguments + [ task ])
+	return xcodebuildTask([task], buildArguments)
 }
 
 /// Sends each scheme found in the given project.
@@ -953,7 +959,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 							argsForBuilding.bitcodeGenerationMode = .Bitcode
 						}
 
-						var buildScheme = xcodebuildTask("build", argsForBuilding)
+						var buildScheme = xcodebuildTask(["clean", "build"], argsForBuilding)
 						buildScheme.workingDirectoryPath = workingDirectoryURL.path!
 
 						return launchTask(buildScheme)


### PR DESCRIPTION
Some types of project changes require a clean to take effect. Typically
this means any change that causes the built product to no longer include
a file/directory it used to include. When building on top of an existing
built product, the old product isn't deleted without cleaning, which
means the resulting built product will still contain the obsolete
file/directory.

If Carthage ever switches to passing a custom derived data path then it
can stop explicitly cleaning (because deleting the derived data
accomplishes the same thing).