### PR TITLE
Fix parsing scp syntax in GitURL

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		89A8F1781C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */; };
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
+		CDA0B6CA1C468E67006C499C /* GitSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA0B6C91C468E67006C499C /* GitSpec.swift */; };
 		CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */ = {isa = PBXBuildFile; fileRef = CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */; };
 		D00105061A8EA74E0059D0A0 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00105051A8EA74E0059D0A0 /* Archive.swift */; };
 		D00CCE321A20783A00109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE311A20783A00109F8C /* Commandant.framework */; };
@@ -158,6 +159,7 @@
 		89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameworkExtensionsSpec.swift; sourceTree = "<group>"; };
 		98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-bash-completion"; sourceTree = "<group>"; };
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
+		CDA0B6C91C468E67006C499C /* GitSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitSpec.swift; sourceTree = "<group>"; };
 		CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestResolvedCartfile.resolved; sourceTree = "<group>"; };
 		D00105051A8EA74E0059D0A0 /* Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
 		D00CCE311A20783A00109F8C /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -442,6 +444,7 @@
 				D0C6E5731A57040B00A5E3E7 /* ArchiveSpec.swift */,
 				D0D121DF19E8999E005E4BAA /* CartfileSpec.swift */,
 				89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */,
+				CDA0B6C91C468E67006C499C /* GitSpec.swift */,
 				549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */,
 				D01D82DC1A10B01D00F0DD94 /* ResolverSpec.swift */,
 				D0DE89411A0F2D450030A3EC /* VersionSpec.swift */,
@@ -697,6 +700,7 @@
 				D0C6E5741A57040B00A5E3E7 /* ArchiveSpec.swift in Sources */,
 				549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */,
 				D01D82DD1A10B01D00F0DD94 /* ResolverSpec.swift in Sources */,
+				CDA0B6CA1C468E67006C499C /* GitSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -25,9 +25,8 @@ public struct GitURL: Equatable {
 	private var normalizedURLString: String {
 		let parsedURL: NSURL? = NSURL(string: URLString)
 
-		if let parsedURL = parsedURL {
+		if let parsedURL = parsedURL, host = parsedURL.host {
 			// Normal, valid URL.
-			let host = parsedURL.host ?? ""
 			let path = stripGitSuffix(parsedURL.path ?? "")
 			return "\(host)\(path)"
 		} else if URLString.hasPrefix("/") {
@@ -38,13 +37,13 @@ public struct GitURL: Equatable {
 			var strippedURLString = URLString
 
 			if let index = strippedURLString.characters.indexOf("@") {
-				strippedURLString.removeRange(Range(start: strippedURLString.startIndex, end: index))
+				strippedURLString.removeRange(strippedURLString.startIndex...index)
 			}
 
 			var host = ""
 			if let index = strippedURLString.characters.indexOf(":") {
-				host = strippedURLString[Range(start: strippedURLString.startIndex, end: index.predecessor())]
-				strippedURLString.removeRange(Range(start: strippedURLString.startIndex, end: index))
+				host = strippedURLString[strippedURLString.startIndex..<index]
+				strippedURLString.removeRange(strippedURLString.startIndex...index)
 			}
 
 			var path = strippedURLString

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -46,7 +46,7 @@ public struct GitURL: Equatable {
 				strippedURLString.removeRange(strippedURLString.startIndex...index)
 			}
 
-			var path = strippedURLString
+			var path = stripGitSuffix(strippedURLString)
 			if !path.hasPrefix("/") {
 				// This probably isn't strictly legit, but we'll have a forward
 				// slash for other URL types.

--- a/Source/CarthageKitTests/GitSpec.swift
+++ b/Source/CarthageKitTests/GitSpec.swift
@@ -1,0 +1,32 @@
+//
+//  GitSpec.swift
+//  Carthage
+//
+//  Created by Syo Ikeda on 1/13/16.
+//  Copyright © 2016 Carthage. All rights reserved.
+//
+
+import CarthageKit
+import Foundation
+import Nimble
+import Quick
+
+class GitSpec: QuickSpec {
+	override func spec() {
+		describe("GitURL") {
+			describe("normalizedURLString") {
+				it("should parse normal URL") {
+					expect(GitURL("https://github.com/antitypical/Result.git")) == GitURL("https://user:password@github.com/antitypical/Result")
+				}
+
+				it("should parse local path") {
+					expect(GitURL("/path/to/git/repo.git")) == GitURL("/path/to/git/repo")
+				}
+
+				it("should parse scp syntax") {
+					expect(GitURL("git@github.com:antitypical/Result.git")) == GitURL("github.com:antitypical/Result")
+				}
+			}
+		}
+	}
+}

--- a/Source/CarthageKitTests/GitSpec.swift
+++ b/Source/CarthageKitTests/GitSpec.swift
@@ -16,7 +16,7 @@ class GitSpec: QuickSpec {
 		describe("GitURL") {
 			describe("normalizedURLString") {
 				it("should parse normal URL") {
-					expect(GitURL("https://github.com/antitypical/Result.git")) == GitURL("https://user:password@github.com/antitypical/Result")
+					expect(GitURL("https://github.com/antitypical/Result.git")) == GitURL("https://user:password@github.com:443/antitypical/Result")
 				}
 
 				it("should parse local path") {


### PR DESCRIPTION
Fixes #1012. This does not implement the request:

> I think such URLs should have either current logged-in username or "git" by default.

but you can clone or fetch the repo if you have the following entry in your `~/.ssh/config`:

```
Host github.com
  User git
```

/cc @inamiy