### PR TITLE
Prune git tags on fetch

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -187,10 +187,14 @@ public func cloneRepository(cloneURL: GitURL, _ destinationURL: NSURL, bare: Boo
 public func fetchRepository(repositoryFileURL: NSURL, remoteURL: GitURL? = nil, refspec: String? = nil) -> SignalProducer<String, CarthageError> {
 	precondition(repositoryFileURL.fileURL)
 
-	var arguments = [ "fetch", "--tags", "--prune", "--quiet" ]
+	var arguments = [ "fetch", "--prune", "--quiet" ]
 	if let remoteURL = remoteURL {
 		arguments.append(remoteURL.URLString)
 	}
+
+	// Specify an explict refspec that fetches tags for pruning.
+	// See https://github.com/Carthage/Carthage/issues/1027 and `man git-fetch`.
+	arguments.append("refs/tags/*:refs/tags/*")
 
 	if let refspec = refspec {
 		arguments.append(refspec)


### PR DESCRIPTION
`--prune` option of `man git-fetch` says:

> Tags are not subject to pruning if they are fetched only because of the default tag auto-following or due to a --tags option. However, if tags are fetched due to an explicit refspec (either on the command line or in the remote configuration, for example if the remote was cloned with the --mirror option), then they are also subject to pruning.

Fixes #1027.