### PR TITLE
Update Nimble to v3.1.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "Quick/Quick" ~> 0.8
-github "Quick/Nimble" ~> 3.0
+github "Quick/Nimble" ~> 3.1
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "thoughtbot/Argo" "v2.2.0"
-github "Quick/Nimble" "v3.0.0"
+github "Quick/Nimble" "v3.1.0"
 github "jdhealy/PrettyColors" "v3.0.0"
 github "Quick/Quick" "v0.8.0"
 github "antitypical/Result" "1.0.1"


### PR DESCRIPTION
https://github.com/Quick/Nimble/releases/tag/v3.1.0