### PR TITLE
Increase xcodebuild list timeout

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -226,7 +226,7 @@ extension CarthageError: CustomStringConvertible {
 			return description
 
 		case let .XcodebuildListTimeout(project, repository):
-			var description = "Failed to discover shared schemes in project \(project)—either the project does not have any shared schemes, or xcodebuild never returned"
+			var description = "Failed to discover shared schemes in project \(project) — either the project does not have any shared schemes, or xcodebuild timed out."
 			if let repository = repository {
 				description += "\n\nIf you believe this to be a project configuration error, please file an issue with the maintainers at \(repository.newIssueURL.absoluteString)"
 			}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -264,7 +264,7 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		// xcodebuild has a bug where xcodebuild -list can sometimes hang
 		// indefinitely on projects that don't share any schemes, so
 		// automatically bail out if it looks like that's happening.
-		.timeoutWithError(.XcodebuildListTimeout(project, nil), afterInterval: 15, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
+		.timeoutWithError(.XcodebuildListTimeout(project, nil), afterInterval: 60, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
 }
 


### PR DESCRIPTION
On my old and very slow Mac 'carthage update' fails with a Cartfile that has RxSwift among its dependencies because 'xcodebuild -list' times out, increasing the interval to 60 enables it to continue building.

The error message 
```
Failed to discover shared schemes in project Rx.xcworkspace—either the project does not have any shared schemes, or xcodebuild never returned
```
 was also a bit confusing to me, I think the proposed message tweak saying that 'xcodebuild timed out' is more clear about what has happened.