### PR TITLE
Use octal notation when specifying permissions for the Caches directory

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -45,7 +45,7 @@ private let CarthageUserCachesURL: NSURL = {
 			}
 		} else {
 			return Result(attempt: {
-				try fileManager.createDirectoryAtURL(dependenciesURL, withIntermediateDirectories: true, attributes: [NSFilePosixPermissions : NSNumber(short:755)])
+				try fileManager.createDirectoryAtURL(dependenciesURL, withIntermediateDirectories: true, attributes: [NSFilePosixPermissions : 0o755])
 				return dependenciesURL
 			})
 		}


### PR DESCRIPTION
Previously the permissions were incorrectly specified as 755 in decimal notation, which resulted in a permissions value of 1363 when converted to octal.

Fixes #842.

~~Weirdly, it appears this also fixes #1072!~~