### PR TITLE
Carthage version should display output of git describe

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 				D0E7B63019E9C64500EDBA4D /* Resources */,
 				D0E7B65719E9C7C700EDBA4D /* Extract CLI Tool */,
 				D0AAAB5319FB0960007B24B3 /* Embed Frameworks */,
+				89539B3B1C6BE36C00632A1B /* Update CLI version */,
 			);
 			buildRules = (
 			);
@@ -625,6 +626,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		89539B3B1C6BE36C00632A1B /* Update CLI version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update CLI version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = ". script/update-cli-version";
+			showEnvVarsInLog = 0;
+		};
 		C2265FAB1A4B86AC00158358 /* Check Xcode Version */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -534,13 +534,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D0E7B64919E9C64600EDBA4D /* Build configuration list for PBXNativeTarget "carthage" */;
 			buildPhases = (
+				89539B3B1C6BE36C00632A1B /* Update CLI version */,
 				C2265FAB1A4B86AC00158358 /* Check Xcode Version */,
 				D0E7B62E19E9C64500EDBA4D /* Sources */,
 				D0E7B62F19E9C64500EDBA4D /* Frameworks */,
 				D0E7B63019E9C64500EDBA4D /* Resources */,
 				D0E7B65719E9C7C700EDBA4D /* Extract CLI Tool */,
 				D0AAAB5319FB0960007B24B3 /* Embed Frameworks */,
-				89539B3B1C6BE36C00632A1B /* Update CLI version */,
 			);
 			buildRules = (
 			);

--- a/Source/carthage/Version.swift
+++ b/Source/carthage/Version.swift
@@ -16,7 +16,7 @@ public struct VersionCommand: CommandType {
 	public let function = "Display the current version of Carthage"
 
 	public func run(options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
-		let versionString = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+		let versionString = NSBundle(identifier: CarthageKitBundleIdentifier)?.objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
 		carthage.println(versionString)
 		return .Success(())
 	}

--- a/Source/carthage/Version.swift
+++ b/Source/carthage/Version.swift
@@ -17,8 +17,7 @@ public struct VersionCommand: CommandType {
 
 	public func run(options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
 		let versionString = NSBundle(identifier: CarthageKitBundleIdentifier)?.objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
-		let semVer = SemanticVersion.fromScanner(NSScanner(string: versionString)).value
-		carthage.println(semVer!)
+		carthage.println(versionString)
 		return .Success(())
 	}
 }

--- a/Source/carthage/Version.swift
+++ b/Source/carthage/Version.swift
@@ -16,7 +16,7 @@ public struct VersionCommand: CommandType {
 	public let function = "Display the current version of Carthage"
 
 	public func run(options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
-		let versionString = NSBundle(identifier: CarthageKitBundleIdentifier)?.objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+		let versionString = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
 		carthage.println(versionString)
 		return .Success(())
 	}

--- a/script/update-cli-version
+++ b/script/update-cli-version
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+main()
+{
+    local version=$(git describe --tags)
+    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" Source/carthage/Info.plist
+}
+
+main

--- a/script/update-cli-version
+++ b/script/update-cli-version
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/bin/bash -e
 
 main()
 {
     local version=$(git describe --tags)
-    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" Source/carthage/Info.plist
+    local DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" "$DIR/../Source/CarthageKit/Info.plist"
 }
 
 main

--- a/script/update-cli-version
+++ b/script/update-cli-version
@@ -3,8 +3,7 @@
 main()
 {
     local version=$(git describe --tags)
-    local DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" "$DIR/../Source/CarthageKit/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" "${BUILT_PRODUCTS_DIR}/carthage.app/Contents/Info.plist"
 }
 
 main

--- a/script/update-cli-version
+++ b/script/update-cli-version
@@ -3,7 +3,7 @@
 main()
 {
     local version=$(git describe --tags)
-    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" "${BUILT_PRODUCTS_DIR}/carthage.app/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set CFBundleShortVersionString $version" "${BUILT_PRODUCTS_DIR}/CarthageKit.framework/Resources/Info.plist"
 }
 
 main


### PR DESCRIPTION
Adds a run script command to building the CLI version of carthage that overwrites the `CFBundleShortVersionString` variable in the Info.plist file be equal to the output of `git describe --tags`.

This means that `carthage version` will output something like `0.13-12-g4859c8c` when we're not on a release tag. Building on a release tag will work as expected.

This, unfortunately, will thrash the Info.plist file every time carthage is built.

If/when accepted, this'll complete #1060.