### PR TITLE
Restore `var` bindings

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -500,8 +500,7 @@ public final class Project {
 				let workingDirectoryURL = self.directoryURL.URLByAppendingPathComponent(project.relativePath, isDirectory: true)
 				var submodule: Submodule?
 				
-				if let foundSubmodule = submodulesByPath[project.relativePath] {
-					var foundSubmodule = foundSubmodule
+				if var foundSubmodule = submodulesByPath[project.relativePath] {
 					foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
 					foundSubmodule.SHA = revision
 					submodule = foundSubmodule

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -344,8 +344,7 @@ private struct DependencyGraph: Equatable {
 
 			// Add a nested dependency to the list of its ancestor.
 			let edgesCopy = edges
-			for (ancestor, itsDependencies) in edgesCopy {
-				var itsDependencies = itsDependencies
+			for (ancestor, var itsDependencies) in edgesCopy {
 				if itsDependencies.contains(dependencyOf) {
 					itsDependencies.insert(node)
 					edges[ancestor] = itsDependencies

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1045,8 +1045,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 			var sdksByPlatform = sdksByPlatform
 			let platform = sdk.platform
 
-			if let sdks = sdksByPlatform[platform] {
-				var sdks = sdks
+			if var sdks = sdksByPlatform[platform] {
 				sdks.append(sdk)
 				sdksByPlatform.updateValue(sdks, forKey: platform)
 			} else {


### PR DESCRIPTION
This was removed in #998.

The conclusion of SE-00003 is changed to keep `var` bindings in Swift 3: https://github.com/apple/swift-evolution/blob/faff3215518b71965499b5b5be3475e0be850a01/proposals/0003-remove-var-parameters.md