### PR TITLE
Add a timeout for xcodebuild -showBuildSettings

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -59,8 +59,8 @@ public enum CarthageError: ErrorType, Equatable {
 	/// them.
 	case NoSharedSchemes(ProjectLocator, GitHubRepository?)
 
-	/// Timeout whilst running `xcodebuild list` to enumerate shared schemes.
-	case XcodebuildListTimeout(ProjectLocator, GitHubRepository?)
+	/// Timeout whilst running `xcodebuild`
+	case XcodebuildTimeout(ProjectLocator)
 
 	/// A cartfile contains duplicate dependencies, either in itself or across
 	/// other cartfiles.
@@ -225,13 +225,8 @@ extension CarthageError: CustomStringConvertible {
 
 			return description
 
-		case let .XcodebuildListTimeout(project, repository):
-			var description = "Failed to discover shared schemes in project \(project) — either the project does not have any shared schemes, or xcodebuild timed out."
-			if let repository = repository {
-				description += "\n\nIf you believe this to be a project configuration error, please file an issue with the maintainers at \(repository.newIssueURL.absoluteString)"
-			}
-
-			return description
+		case let .XcodebuildTimeout(project):
+			return "xcodebuild timed out while trying to read \(project) 😭"
 			
 		case let .DuplicateDependencies(duplicateDeps):
 			let deps = duplicateDeps.sort() // important to match expected order in test cases

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -264,7 +264,7 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		// xcodebuild has a bug where xcodebuild -list can sometimes hang
 		// indefinitely on projects that don't share any schemes, so
 		// automatically bail out if it looks like that's happening.
-		.timeoutWithError(.XcodebuildListTimeout(project, nil), afterInterval: 60, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
+		.timeoutWithError(.XcodebuildTimeout(project), afterInterval: 60, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) }
 }
 
@@ -1235,9 +1235,6 @@ public func buildDependencyProject(dependency: ProjectIdentifier, _ rootDirector
 
 					case let (.GitHub(repo), .NoSharedSchemes(project, _)):
 						return .NoSharedSchemes(project, repo)
-
-					case let (.GitHub(repo), .XcodebuildListTimeout(project, _)):
-						return .XcodebuildListTimeout(project, repo)
 
 					default:
 						return error

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -584,6 +584,12 @@ public struct BuildSettings {
 		return launchTask(task)
 			.ignoreTaskData()
 			.mapError(CarthageError.TaskError)
+			// xcodebuild has a bug where xcodebuild -showBuildSettings
+			// can sometimes hang indefinitely on projects that don't
+			// share any schemes, so automatically bail out if it looks
+			// like that's happening.
+			.timeoutWithError(.XcodebuildTimeout(arguments.project), afterInterval: 15, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
+			.retry(5)
 			.map { (data: NSData) -> String in
 				return NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))! as String
 			}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -244,8 +244,8 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		// xcodebuild has a bug where xcodebuild -list can sometimes hang
 		// indefinitely on projects that don't share any schemes, so
 		// automatically bail out if it looks like that's happening.
-		.timeoutWithError(.XcodebuildTimeout(project), afterInterval: 10, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
-		.retry(5)
+		.timeoutWithError(.XcodebuildTimeout(project), afterInterval: 60, onScheduler: QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)))
+		.retry(2)
 		.map { (data: NSData) -> String in
 			return NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))! as String
 		}


### PR DESCRIPTION
Fixes #940 for the Xcode 7.3 betas (and presumably all future releases).

Tested by running `carthage bootstrap` with Xcode 7.3b3 with this Cartfile:

```
github "MatthewYork/DateTools"
```