### PR TITLE
Update Quick to v0.9.1

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "thoughtbot/Argo" "v2.2.0"
 github "Quick/Nimble" "v3.1.0"
 github "jdhealy/PrettyColors" "v3.0.0"
-github "Quick/Quick" "v0.9.0"
+github "Quick/Quick" "v0.9.1"
 github "antitypical/Result" "1.0.2"
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
 github "Carthage/Commandant" "0.8.3"


### PR DESCRIPTION
https://github.com/Quick/Quick/releases/tag/v0.9.1