### PR TITLE
Cleanup Resolver

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -42,7 +42,7 @@ internal func combineDictionaries<K, V>(lhs: [K: V], rhs: [K: V]) -> [K: V] {
 extension SignalType {
 	/// Sends each value that occurs on `signal` combined with each value that
 	/// occurs on `otherSignal` (repeats included).
-	internal func permuteWith<U>(otherSignal: Signal<U, Error>) -> Signal<(Value, U), Error> {
+	private func permuteWith<U>(otherSignal: Signal<U, Error>) -> Signal<(Value, U), Error> {
 		return Signal { observer in
 			let lock = NSLock()
 			lock.name = "org.carthage.CarthageKit.permuteWith"
@@ -122,7 +122,7 @@ extension SignalType {
 extension SignalProducerType {
 	/// Sends each value that occurs on `producer` combined with each value that
 	/// occurs on `otherProducer` (repeats included).
-	internal func permuteWith<U>(otherProducer: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
+	private func permuteWith<U>(otherProducer: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
 		return lift(Signal.permuteWith)(otherProducer)
 	}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -296,6 +296,14 @@ public final class Project {
 				}
 			}
 			.startOnQueue(cachedVersionsQueue)
+			.collect()
+			.flatMap(.Concat) { versions -> SignalProducer<PinnedVersion, CarthageError> in
+				if versions.isEmpty {
+					return SignalProducer(error: CarthageError.TaggedVersionNotFound(project))
+				}
+				
+				return SignalProducer(values: versions)
+			}
 	}
 	
 	/// Loads the Cartfile for the given dependency, at the given version.

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -299,7 +299,7 @@ public final class Project {
 			.collect()
 			.flatMap(.Concat) { versions -> SignalProducer<PinnedVersion, CarthageError> in
 				if versions.isEmpty {
-					return SignalProducer(error: CarthageError.TaggedVersionNotFound(project))
+					return SignalProducer(error: .TaggedVersionNotFound(project))
 				}
 				
 				return SignalProducer(values: versions)

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -421,7 +421,7 @@ extension DependencyGraph: CustomStringConvertible {
 private func mergeGraphs
 	<Collection: CollectionType where Collection.Generator.Element == DependencyGraph>
 	(graphs: Collection) -> Result<DependencyGraph, CarthageError> {
-	precondition(graphs.count > 0)
+	precondition(!graphs.isEmpty)
 	
 	var result: Result<DependencyGraph, CarthageError> = .Success(graphs.first!)
 

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -100,7 +100,7 @@ public struct Resolver {
 
 		return SignalProducer(values: cartfile.dependencies)
 			.map { dependency -> SignalProducer<DependencyNode, CarthageError> in
-				let allowedVersions = SignalProducer<String?, CarthageError>.attempt {
+				return SignalProducer<String?, CarthageError>.attempt {
 						switch dependency.version {
 						case let .GitReference(refName):
 							return .Success(refName)
@@ -125,8 +125,6 @@ public struct Resolver {
 							}
 							.filter { dependency.version.satisfiedBy($0) }
 					}
-
-				return allowedVersions
 					.startOn(scheduler)
 					.observeOn(scheduler)
 					.map { DependencyNode(project: dependency.project, proposedVersion: $0, versionSpecifier: dependency.version) }

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -99,15 +99,8 @@ public struct Resolver {
 							return self.resolvedGitReference(dependency.project, refName)
 						}
 
-						return self.versionsForDependency(dependency.project)
-							.collect()
-							.flatMap(.Merge) { nodes -> SignalProducer<PinnedVersion, CarthageError> in
-								if nodes.isEmpty {
-									return SignalProducer(error: CarthageError.TaggedVersionNotFound(dependency.project))
-								} else {
-									return SignalProducer(values: nodes)
-								}
-							}
+						return self
+							.versionsForDependency(dependency.project)
 							.filter { dependency.version.satisfiedBy($0) }
 					}
 					.startOn(scheduler)

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -131,9 +131,8 @@ public struct Resolver {
 						}
 					}
 			}
-			.collect()
 			.observeOn(scheduler)
-			.flatMap(.Concat) { nodeProducers in permutations(nodeProducers) }
+			.permute()
 	}
 
 	/// Sends all possible permutations of `inputGraph` oriented around the
@@ -201,9 +200,8 @@ public struct Resolver {
 				return SignalProducer(values: nodes)
 					// Each producer represents all evaluations of one subtree.
 					.map { node in self.graphsForDependenciesOfNode(node, basedOnGraph: graph) }
-					.collect()
 					.observeOn(scheduler)
-					.flatMap(.Concat) { graphProducers in permutations(graphProducers) }
+					.permute()
 					.flatMap(.Concat) { graphs -> SignalProducer<Event<DependencyGraph, CarthageError>, CarthageError> in
 						let mergedGraphs = SignalProducer(values: graphs)
 							.scan(Result<DependencyGraph, CarthageError>.Success(inputGraph)) { result, nextGraph in

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -93,17 +93,9 @@ public struct Resolver {
 
 		return SignalProducer(values: cartfile.dependencies)
 			.map { dependency -> SignalProducer<DependencyNode, CarthageError> in
-				return SignalProducer<String?, CarthageError>.attempt {
-						switch dependency.version {
-						case let .GitReference(refName):
-							return .Success(refName)
-
-						default:
-							return .Success(nil)
-						}
-					}
-					.flatMap(.Concat) { refName -> SignalProducer<PinnedVersion, CarthageError> in
-						if let refName = refName {
+				return SignalProducer(value: dependency)
+					.flatMap(.Concat) { dependency -> SignalProducer<PinnedVersion, CarthageError> in
+						if case let .GitReference(refName) = dependency.version {
 							return self.resolvedGitReference(dependency.project, refName)
 						}
 

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -164,6 +164,7 @@ public struct Resolver {
 			.flatMap(.Concat) { (nodes: [DependencyNode]) in
 				return self
 					.graphsForNodes(nodes, dependencyOf: dependencyOf, basedOnGraph: inputGraph)
+					.materialize()
 					.promoteErrors(CarthageError.self)
 			}
 			// Pass through resolution errors only if we never got
@@ -176,7 +177,7 @@ public struct Resolver {
 	/// the specified node (or as a root otherwise).
 	///
 	/// This is a helper method, and not meant to be called from outside.
-	private func graphsForNodes(nodes: [DependencyNode], dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<Event<DependencyGraph, CarthageError>, NoError> {
+	private func graphsForNodes(nodes: [DependencyNode], dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
 		let scheduler = QueueScheduler(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), name: "org.carthage.CarthageKit.Resolver.graphsForNodes")
 		
 		return SignalProducer<(DependencyGraph, [DependencyNode]), CarthageError>
@@ -219,7 +220,6 @@ public struct Resolver {
 					// a valid graph.
 					.dematerializeErrorsIfEmpty()
 			}
-			.materialize()
 	}
 }
 


### PR DESCRIPTION
As a first step towards #1081, I cleaned up `Resolver`. I found the existing structure hard to read and understand. This should make it easier to alter to prevent unnecessary fetching.