### PR TITLE
[WIP] Inject instances of NSURLSession in GitHub.swift

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		89A8F1781C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */; };
 		89E80E621C755002000F8DCB /* BuildArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E80E601C754FFD000F8DCB /* BuildArguments.swift */; };
 		89E80E641C755059000F8DCB /* BuildArgumentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E80E631C755059000F8DCB /* BuildArgumentsSpec.swift */; };
+		89E80E661C755B3D000F8DCB /* GitHubSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E80E651C755B3D000F8DCB /* GitHubSpec.swift */; };
+		89E80E691C755C1B000F8DCB /* FakeURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E80E681C755C1B000F8DCB /* FakeURLSession.swift */; };
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
 		CD7F22441C67649F00B018A9 /* TestCartfileProposedVersion in Resources */ = {isa = PBXBuildFile; fileRef = CD7F22431C67649F00B018A9 /* TestCartfileProposedVersion */; };
@@ -166,6 +168,8 @@
 		89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameworkExtensionsSpec.swift; sourceTree = "<group>"; };
 		89E80E601C754FFD000F8DCB /* BuildArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArguments.swift; sourceTree = "<group>"; };
 		89E80E631C755059000F8DCB /* BuildArgumentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArgumentsSpec.swift; sourceTree = "<group>"; };
+		89E80E651C755B3D000F8DCB /* GitHubSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSpec.swift; sourceTree = "<group>"; };
+		89E80E681C755C1B000F8DCB /* FakeURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeURLSession.swift; sourceTree = "<group>"; };
 		98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-bash-completion"; sourceTree = "<group>"; };
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
 		CD7F22431C67649F00B018A9 /* TestCartfileProposedVersion */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestCartfileProposedVersion; sourceTree = "<group>"; };
@@ -287,6 +291,14 @@
 				5499CA971A2394B700783309 /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		89E80E671C755BEB000F8DCB /* Fakes */ = {
+			isa = PBXGroup;
+			children = (
+				89E80E681C755C1B000F8DCB /* FakeURLSession.swift */,
+			);
+			path = Fakes;
 			sourceTree = "<group>";
 		};
 		98400F591BD24DC5008C5DDE /* Scripts */ = {
@@ -459,10 +471,12 @@
 				D0D121DF19E8999E005E4BAA /* CartfileSpec.swift */,
 				89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */,
 				CDA0B6C91C468E67006C499C /* GitSpec.swift */,
+				89E80E651C755B3D000F8DCB /* GitHubSpec.swift */,
 				549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */,
 				D01D82DC1A10B01D00F0DD94 /* ResolverSpec.swift */,
 				D0DE89411A0F2D450030A3EC /* VersionSpec.swift */,
 				D0DB09A319EA354200234B16 /* XcodeSpec.swift */,
+				89E80E671C755BEB000F8DCB /* Fakes */,
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 			);
 			name = CarthageKitTests;
@@ -732,11 +746,13 @@
 				89A8F1781C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift in Sources */,
 				D0DB09A419EA354200234B16 /* XcodeSpec.swift in Sources */,
 				3A0472F61C7836EA00097EC7 /* AlgorithmsSpec.swift in Sources */,
+				89E80E661C755B3D000F8DCB /* GitHubSpec.swift in Sources */,
 				D0C6E5741A57040B00A5E3E7 /* ArchiveSpec.swift in Sources */,
 				549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */,
 				D01D82DD1A10B01D00F0DD94 /* ResolverSpec.swift in Sources */,
 				CDA0B6CA1C468E67006C499C /* GitSpec.swift in Sources */,
 				89E80E641C755059000F8DCB /* BuildArgumentsSpec.swift in Sources */,
+				89E80E691C755C1B000F8DCB /* FakeURLSession.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -428,7 +428,8 @@ public final class Project {
 	/// Sends the URL to each downloaded zip, after it has been moved to a
 	/// less temporary location.
 	private func downloadMatchingBinariesForProject(project: ProjectIdentifier, atRevision revision: String, fromRepository repository: GitHubRepository, withAuthorizationHeaderValue authorizationHeaderValue: String?) -> SignalProducer<NSURL, CarthageError> {
-		return releaseForTag(revision, repository, authorizationHeaderValue)
+		let urlSession = NSURLSession.sharedSession()
+		return releaseForTag(revision, repository, authorizationHeaderValue, urlSession)
 			.filter(binaryFrameworksCanBeProvidedByRelease)
 			.flatMapError { error in
 				switch error {
@@ -454,7 +455,7 @@ public final class Project {
 						if NSFileManager.defaultManager().fileExistsAtPath(fileURL.path!) {
 							return SignalProducer(value: fileURL)
 						} else {
-							return downloadAsset(asset, authorizationHeaderValue)
+							return downloadAsset(asset, authorizationHeaderValue, urlSession)
 								.flatMap(.Concat) { downloadURL in cacheDownloadedBinary(downloadURL, toURL: fileURL) }
 						}
 					}

--- a/Source/CarthageKitTests/Fakes/FakeURLSession.swift
+++ b/Source/CarthageKitTests/Fakes/FakeURLSession.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+final class FakeDownloadTask: NSURLSessionDownloadTask {
+	var started = false
+	override func resume() {
+		self.started = true
+	}
+
+	var cancelled = false
+	override func cancel() {
+		self.cancelled = true
+	}
+}
+
+final class FakeDataTask: NSURLSessionDataTask {
+	var started = false
+	override func resume() {
+		self.started = true
+	}
+
+	var cancelled = false
+	override func cancel() {
+		self.cancelled = true
+	}
+}
+
+final class FakeURLSession: NSURLSession {
+	var downloadTaskWithRequestArgs: [(NSURLRequest, (NSURL?, NSURLResponse?, NSError?) -> Void, FakeDownloadTask)] = []
+	override func downloadTaskWithRequest(request: NSURLRequest, completionHandler: (NSURL?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDownloadTask {
+		let downloadTask = FakeDownloadTask()
+		self.downloadTaskWithRequestArgs.append((request, completionHandler, downloadTask))
+		return downloadTask
+	}
+
+	var dataTaskWithRequestArgs: [(NSURLRequest, (NSData?, NSURLResponse?, NSError?) -> Void, FakeDataTask)] = []
+	override func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {
+		let dataTask = FakeDataTask()
+		dataTaskWithRequestArgs.append((request, completionHandler, dataTask))
+		return dataTask
+	}
+}

--- a/Source/CarthageKitTests/GitHubSpec.swift
+++ b/Source/CarthageKitTests/GitHubSpec.swift
@@ -1,0 +1,216 @@
+import Quick
+import Nimble
+import Result
+import ReactiveCocoa
+import CarthageKit
+
+class GitHubSpec: QuickSpec {
+	override func spec() {
+
+		describe("releaseForTag:repository:authorizationHeaderValue:urlSession:") {
+			it("makes a request to the specified server") {
+				let gitHubEnterpriseRepository = GitHubRepository(server: GitHubRepository.Server.Enterprise(scheme: "https", hostname: "example.com"), owner: "Carthage", name: "Carthage")
+
+				let urlSession = FakeURLSession()
+				_ = releaseForTag("v1.0.0", gitHubEnterpriseRepository, "example", urlSession).start()
+
+				expect(urlSession.dataTaskWithRequestArgs.count) == 1
+				let (request, _, task) = urlSession.dataTaskWithRequestArgs[0]
+
+				expect(task.started) == true
+				expect(request.URL) == NSURL(string: "https://example.com/api/v3/repos/Carthage/Carthage/releases/tags/v1.0.0")
+				expect(request.valueForHTTPHeaderField("Accept")) == "application/vnd.github.v3+json"
+				expect(request.valueForHTTPHeaderField("User-Agent")) == "CarthageKit-unknown/unknown"
+				expect(request.valueForHTTPHeaderField("Authorization")) == "example"
+			}
+
+			describe("for a standard github repo") {
+				let gitHubRepository = GitHubRepository(owner: "Example", name: "Carthage")
+
+				var releaseProducer: SignalProducer<GitHubRelease, CarthageError>!
+				var urlSession: FakeURLSession!
+				var events: [Event<GitHubRelease, CarthageError>] = []
+
+				beforeEach {
+					urlSession = FakeURLSession()
+					releaseProducer = releaseForTag("v1.0.0", gitHubRepository, "example", urlSession)
+
+					events = []
+					releaseProducer.on(event: { event in
+						events.append(event)
+					}).start()
+				}
+
+				it("makes a request to github") {
+					expect(urlSession.dataTaskWithRequestArgs.count) == 1
+					let (request, _, task) = urlSession.dataTaskWithRequestArgs[0]
+
+					expect(task.started) == true
+					expect(request.URL) == NSURL(string: "https://api.github.com/repos/Example/Carthage/releases/tags/v1.0.0")
+					expect(request.valueForHTTPHeaderField("Accept")) == "application/vnd.github.v3+json"
+					expect(request.valueForHTTPHeaderField("User-Agent")) == "CarthageKit-unknown/unknown"
+					expect(request.valueForHTTPHeaderField("Authorization")) == "example"
+				}
+
+				context("when the request succeeds") {
+					it("returns a GitHubRelease object when given a valid GitHubRelease dictionary data") {
+						let (request, completion, _) = urlSession.dataTaskWithRequestArgs[0]
+
+						let responseDictionary = [
+							"id": 1,
+							"name": "example release",
+							"tag_name": "v1.0.0",
+							"draft": false,
+							"prerelease": false,
+							"assets": [
+								[
+									"id": 2,
+									"name": "example asset",
+									"content_type": "text/text",
+									"url": "https://example.com/asset"
+								]
+							]
+						]
+						let data = try? NSJSONSerialization.dataWithJSONObject(responseDictionary, options: [])
+						let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
+						completion(data, response, nil)
+
+						let asset = GitHubRelease.Asset(ID: 2, name: "example asset", contentType: "text/text", URL: NSURL(string: "https://example.com/asset")!)
+						let release = GitHubRelease(ID: 1, name: "example release", tag: "v1.0.0", draft: false, prerelease: false, assets: [asset])
+
+						expect(events.count) == 2
+						expect(events[0].error).to(beNil())
+						expect(events[0].value) == release
+						expect(events[1] == Event.Completed) == true
+					}
+
+					it("returns nothing when given a valid json object, but not decodeable to a GitHubRelease object") {
+						let (request, completion, _) = urlSession.dataTaskWithRequestArgs[0]
+
+						let data = "{}".dataUsingEncoding(NSUTF8StringEncoding)
+						let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
+						completion(data, response, nil)
+
+						expect(events.count) == 1
+						expect(events[0] == Event.Completed) == true
+					}
+
+					it("returns an error when not given a valid json object") {
+						let (request, completion, _) = urlSession.dataTaskWithRequestArgs[0]
+
+						let data = "example string".dataUsingEncoding(NSUTF8StringEncoding)
+						let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
+						completion(data, response, nil)
+
+						expect(events.count) == 1
+						expect(events[0].value).to(beNil())
+						expect(events[0].error) == CarthageError.ParseError(description: "Invalid JSON in releases for tag v1.0.0")
+					}
+				}
+
+				context("when the request fails") {
+					context("with a 400 or 500 level error that is not a 404") {
+						it("returns a parse error if it cannot parse the error message json") {
+							let (request, completion, _) = urlSession.dataTaskWithRequestArgs[0]
+
+							let data = "example string".dataUsingEncoding(NSUTF8StringEncoding)
+							let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 401, HTTPVersion: nil, headerFields: nil)
+							let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+							completion(data, response, error)
+
+							expect(events.count) == 1
+							expect(events[0].value).to(beNil())
+							expect(events[0].error) == CarthageError.GitHubAPIRequestFailed("Parse error: Invalid JSON in API error response 'example string'")
+						}
+
+						it("returns a network error when not given a data object") {
+							let (request, completion, _) = urlSession.dataTaskWithRequestArgs[0]
+
+							let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 401, HTTPVersion: nil, headerFields: nil)
+							let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+							completion(nil, response, error)
+
+							expect(events.count) == 1
+							expect(events[0].value).to(beNil())
+							expect(events[0].error) == CarthageError.NetworkError(error)
+						}
+					}
+
+					context("with a 404 error") {
+						it("returns a network error") {
+							let (request, completion, _) = urlSession.dataTaskWithRequestArgs[0]
+
+							let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 404, HTTPVersion: nil, headerFields: nil)
+							let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+							completion(nil, response, error)
+
+							expect(events.count) == 1
+							expect(events[0].value).to(beNil())
+							expect(events[0].error) == CarthageError.NetworkError(error)
+						}
+					}
+				}
+			}
+		}
+
+		describe("downloadAsset:authorizationHeaderValue:urlSession:") {
+			var releaseProducer: SignalProducer<NSURL, CarthageError>!
+			var urlSession: FakeURLSession!
+			var events: [Event<NSURL, CarthageError>] = []
+
+			let URL = NSURL(string: "https://example.com/asset")!
+
+			beforeEach {
+				urlSession = FakeURLSession()
+				let asset = GitHubRelease.Asset(ID: 0, name: "example", contentType: "text/text", URL: URL)
+				releaseProducer = downloadAsset(asset, "example", urlSession)
+
+				events = []
+				releaseProducer.on(event: { event in
+					events.append(event)
+				}).start()
+			}
+
+			it("makes a download request to the url") {
+				expect(urlSession.downloadTaskWithRequestArgs.count) == 1
+				let (request, _, task) = urlSession.downloadTaskWithRequestArgs[0]
+
+				expect(task.started) == true
+				expect(request.URL) == URL
+				expect(request.valueForHTTPHeaderField("Accept")) == "application/octet-stream"
+				expect(request.valueForHTTPHeaderField("User-Agent")) == "CarthageKit-unknown/unknown"
+				expect(request.valueForHTTPHeaderField("Authorization")) == "example"
+			}
+
+			context("when the download succeeds") {
+				it("successfully returns a local URL that was downloaded") {
+					let (request, completion, _) = urlSession.downloadTaskWithRequestArgs[0]
+
+					let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 404, HTTPVersion: nil, headerFields: nil)
+					let downloadedURL = NSURL(string: "file:///Foo/Bar/file")!
+
+					completion(downloadedURL, response, nil)
+
+					expect(events.count) == 2
+					expect(events[0].error).to(beNil())
+					expect(events[0].value) == downloadedURL
+					expect(events[1] == Event.Completed) == true
+				}
+			}
+
+			context("when the download fails") {
+				it("returns a network error") {
+					let (request, completion, _) = urlSession.downloadTaskWithRequestArgs[0]
+
+					let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 404, HTTPVersion: nil, headerFields: nil)
+					let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+					completion(nil, response, error)
+
+					expect(events.count) == 1
+					expect(events[0].value).to(beNil())
+					expect(events[0].error) == CarthageError.NetworkError(error)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Also test our calls to the network using a faked-out network interface.

I found a bit of unused code while doing this. `fetchAllPages()` in GitHub.swift is only called twice - recursively in `fetchAllPages()`, and in `releaseForTag()`. According to the github api v3 docs, `GET /repos/:owner/:repo/releases/tags/:tag` (the underlying url in `releaseForTag()`) won't ever page. So, unless I'm mistaken, the logic to recursively fetch additional pages is entirely unnecessary. Removing it, however, is outside the scope of this pull request.

Anyway, this is another pull request meant to clean up the code, improve test coverage, and improve test runtime. It doesn't do the last (the only major improvements to the test runtime will come when I can fake out all calls to xcodebuild), but it certainly does the previous two.