### PR TITLE
Fix dependency resolution when building

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		14A7BF4C1AA811D800C70ABB /* Cartfile in Copy Bundle Resources/DuplicateDependencies */ = {isa = PBXBuildFile; fileRef = 14A7BF471AA810B200C70ABB /* Cartfile */; };
 		14A7BF4D1AA811E600C70ABB /* Cartfile.private in Copy Bundle Resources/DuplicateDependencies */ = {isa = PBXBuildFile; fileRef = 14A7BF481AA810B200C70ABB /* Cartfile.private */; };
+		3A0472F31C782B4000097EC7 /* Algorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0472F21C782B4000097EC7 /* Algorithms.swift */; };
+		3A0472F61C7836EA00097EC7 /* AlgorithmsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0472F41C782D1D00097EC7 /* AlgorithmsSpec.swift */; };
 		5482DAF11A3849D700197FB8 /* CopyFrameworks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5482DAF01A3849D700197FB8 /* CopyFrameworks.swift */; };
 		54911EF31A1D34EC00FFAE5F /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54911EF21A1D34EC00FFAE5F /* Version.swift */; };
 		549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */; };
@@ -149,6 +151,8 @@
 /* Begin PBXFileReference section */
 		14A7BF471AA810B200C70ABB /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Cartfile; path = DuplicateDependencies/Cartfile; sourceTree = "<group>"; };
 		14A7BF481AA810B200C70ABB /* Cartfile.private */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Cartfile.private; path = DuplicateDependencies/Cartfile.private; sourceTree = "<group>"; };
+		3A0472F21C782B4000097EC7 /* Algorithms.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Algorithms.swift; sourceTree = "<group>"; };
+		3A0472F41C782D1D00097EC7 /* AlgorithmsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlgorithmsSpec.swift; sourceTree = "<group>"; };
 		5482DAF01A3849D700197FB8 /* CopyFrameworks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CopyFrameworks.swift; sourceTree = "<group>"; };
 		54911EF21A1D34EC00FFAE5F /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
@@ -412,6 +416,7 @@
 			isa = PBXGroup;
 			children = (
 				D0D1217119E87B05005E4BAA /* CarthageKit.h */,
+				3A0472F21C782B4000097EC7 /* Algorithms.swift */,
 				D069CA231A4E3B2700314A85 /* Archive.swift */,
 				89E80E601C754FFD000F8DCB /* BuildArguments.swift */,
 				D0D1218F19E88A15005E4BAA /* Cartfile.swift */,
@@ -448,6 +453,7 @@
 		D0D1217B19E87B05005E4BAA /* CarthageKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				3A0472F41C782D1D00097EC7 /* AlgorithmsSpec.swift */,
 				D0C6E5731A57040B00A5E3E7 /* ArchiveSpec.swift */,
 				89E80E631C755059000F8DCB /* BuildArgumentsSpec.swift */,
 				D0D121DF19E8999E005E4BAA /* CartfileSpec.swift */,
@@ -693,6 +699,7 @@
 				D0DE89401A0F2CB00030A3EC /* Version.swift in Sources */,
 				89E80E621C755002000F8DCB /* BuildArguments.swift in Sources */,
 				D01F8A5419EA2F1700643E7C /* Xcode.swift in Sources */,
+				3A0472F31C782B4000097EC7 /* Algorithms.swift in Sources */,
 				D0A2025E1B114D1000C71375 /* ProducerQueue.swift in Sources */,
 				D0D1219019E88A15005E4BAA /* Cartfile.swift in Sources */,
 				F603929919EA29F80050A6AF /* Project.swift in Sources */,
@@ -708,6 +715,7 @@
 				D0DE89421A0F2D450030A3EC /* VersionSpec.swift in Sources */,
 				89A8F1781C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift in Sources */,
 				D0DB09A419EA354200234B16 /* XcodeSpec.swift in Sources */,
+				3A0472F61C7836EA00097EC7 /* AlgorithmsSpec.swift in Sources */,
 				D0C6E5741A57040B00A5E3E7 /* ArchiveSpec.swift in Sources */,
 				549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */,
 				D01D82DD1A10B01D00F0DD94 /* ResolverSpec.swift in Sources */,

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -35,8 +35,7 @@
 /// Nodes that are equal from a topological perspective are sorted by the
 /// strict total order as defined by `Comparable`.
 public func topologicalSort<Node: Comparable>(var graph: Dictionary<Node, Set<Node>>) -> [Node]? {
-	var queue = graph
-		.filter { _, incomingEdges in incomingEdges.isEmpty }
+	var queue = graph.filter { _, incomingEdges in incomingEdges.isEmpty }
 		.map { node, _ in node }
 
 	queue.forEach { node in graph.removeValueForKey(node) }
@@ -51,7 +50,6 @@ public func topologicalSort<Node: Comparable>(var graph: Dictionary<Node, Set<No
 
 		for (node, incomingEdges) in graph where incomingEdges.contains(lastNode) {
 			let filteredIncomingEdges = incomingEdges.subtract([lastNode])
-
 			graph[node] = filteredIncomingEdges
 
 			if filteredIncomingEdges.isEmpty {

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -34,11 +34,13 @@
 ///
 /// Nodes that are equal from a topological perspective are sorted by the
 /// strict total order as defined by `Comparable`.
-public func topologicalSort<Node: Comparable>(var graph: Dictionary<Node, Set<Node>>) -> [Node]? {
-	var queue = graph.filter { _, incomingEdges in incomingEdges.isEmpty }
+public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>) -> [Node]? {
+	var queue = graph
+		.filter { _, incomingEdges in incomingEdges.isEmpty }
 		.map { node, _ in node }
 
-	queue.forEach { node in graph.removeValueForKey(node) }
+	var workingGraph = graph
+	queue.forEach { node in workingGraph.removeValueForKey(node) }
 
 	var sorted: [Node] = []
 
@@ -48,16 +50,16 @@ public func topologicalSort<Node: Comparable>(var graph: Dictionary<Node, Set<No
 		let lastNode = queue.removeLast()
 		sorted.append(lastNode)
 
-		for (node, incomingEdges) in graph where incomingEdges.contains(lastNode) {
+		for (node, incomingEdges) in workingGraph where incomingEdges.contains(lastNode) {
 			let filteredIncomingEdges = incomingEdges.subtract([lastNode])
-			graph[node] = filteredIncomingEdges
+			workingGraph[node] = filteredIncomingEdges
 
 			if filteredIncomingEdges.isEmpty {
 				queue.append(node)
-				graph.removeValueForKey(node)
+				workingGraph.removeValueForKey(node)
 			}
 		}
 	}
 
-	return graph.isEmpty ? sorted : nil
+	return workingGraph.isEmpty ? sorted : nil
 }

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -1,0 +1,65 @@
+//
+//  Algorithms.swift
+//  Carthage
+//
+//  Created by Eric Horacek on 2/19/16.
+//  Copyright © 2016 Carthage. All rights reserved.
+//
+
+/// Returns an array containing the topologically sorted nodes of the provided
+/// directed graph, or nil if the graph contains a cycle or is malformed.
+///
+/// The sort is performed using
+/// [Khan's Algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn.27s_algorithm).
+///
+/// The provided graph should be encoded as a dictionary where:
+/// - The keys are the nodes of the graph
+/// - The values are the set of nodes that the key node has a incoming edge from
+///
+/// For example, the following graph:
+/// ```
+/// A ◀─── B
+/// ▲      ▲
+/// │      │
+/// C ◀─── D
+/// ```
+/// should be encoded as:
+/// ```
+/// [ A: Set([B, C]), B: Set([D]), C: Set([D]), D: Set() ]
+/// ```
+/// and would be sorted as:
+/// ```
+/// [D, B, C, A]
+/// ```
+///
+/// Nodes that are equal from a topological perspective are sorted by the
+/// strict total order as defined by `Comparable`.
+public func topologicalSort<Node: Comparable>(var edges: Dictionary<Node, Set<Node>>) -> [Node]? {
+	var queue: [Node] = edges
+		.filter { _, edges in edges.isEmpty }
+		.map { node, _ in node }
+
+	queue.forEach { node in edges.removeValueForKey(node) }
+
+	var sorted: [Node] = []
+
+	while !queue.isEmpty {
+		queue.sortInPlace(>)
+
+		let lastNode = queue.removeLast()
+		sorted.append(lastNode)
+
+		for (node, inEdges) in edges {
+			guard inEdges.contains(lastNode) else { continue }
+
+			let filteredInEdges = inEdges.subtract([lastNode])
+			edges[node] = filteredInEdges
+
+			guard filteredInEdges.isEmpty else { continue }
+			queue.append(node)
+			edges.removeValueForKey(node)
+		}
+	}
+
+	return edges.isEmpty ? sorted : nil
+}

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -18,10 +18,10 @@
 ///
 /// For example, the following graph:
 /// ```
-/// A ◀─── B
-/// ▲      ▲
-/// │      │
-/// C ◀─── D
+/// A<--B
+/// ^   ^
+/// |   |
+/// C<--D
 /// ```
 /// should be encoded as:
 /// ```

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -35,27 +35,29 @@
 /// Nodes that are equal from a topological perspective are sorted by the
 /// strict total order as defined by `Comparable`.
 public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>) -> [Node]? {
-	var queue = graph
+	// Maintain a list of nodes with no incoming edges (sources).
+	var sources = graph
 		.filter { _, incomingEdges in incomingEdges.isEmpty }
 		.map { node, _ in node }
 
+	// Maintain a working graph with all sources removed.
 	var workingGraph = graph
-	queue.forEach { node in workingGraph.removeValueForKey(node) }
+	sources.forEach { node in workingGraph.removeValueForKey(node) }
 
 	var sorted: [Node] = []
 
-	while !queue.isEmpty {
-		queue.sortInPlace(>)
+	while !sources.isEmpty {
+		sources.sortInPlace(>)
 
-		let lastNode = queue.removeLast()
-		sorted.append(lastNode)
+		let lastSource = sources.removeLast()
+		sorted.append(lastSource)
 
-		for (node, var incomingEdges) in workingGraph where incomingEdges.contains(lastNode) {
-			incomingEdges.remove(lastNode)
+		for (node, var incomingEdges) in workingGraph where incomingEdges.contains(lastSource) {
+			incomingEdges.remove(lastSource)
 			workingGraph[node] = incomingEdges
 
 			if incomingEdges.isEmpty {
-				queue.append(node)
+				sources.append(node)
 				workingGraph.removeValueForKey(node)
 			}
 		}

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -50,11 +50,11 @@ public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>
 		let lastNode = queue.removeLast()
 		sorted.append(lastNode)
 
-		for (node, incomingEdges) in workingGraph where incomingEdges.contains(lastNode) {
-			let filteredIncomingEdges = incomingEdges.subtract([lastNode])
-			workingGraph[node] = filteredIncomingEdges
+		for (node, var incomingEdges) in workingGraph where incomingEdges.contains(lastNode) {
+			incomingEdges.remove(lastNode)
+			workingGraph[node] = incomingEdges
 
-			if filteredIncomingEdges.isEmpty {
+			if incomingEdges.isEmpty {
 				queue.append(node)
 				workingGraph.removeValueForKey(node)
 			}

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -18,10 +18,10 @@
 ///
 /// For example, the following graph:
 /// ```
-/// A<--B
-/// ^   ^
-/// |   |
-/// C<--D
+/// A <-- B
+/// ^     ^
+/// |     |
+/// C <-- D
 /// ```
 /// should be encoded as:
 /// ```
@@ -34,12 +34,12 @@
 ///
 /// Nodes that are equal from a topological perspective are sorted by the
 /// strict total order as defined by `Comparable`.
-public func topologicalSort<Node: Comparable>(var edges: Dictionary<Node, Set<Node>>) -> [Node]? {
-	var queue: [Node] = edges
-		.filter { _, edges in edges.isEmpty }
+public func topologicalSort<Node: Comparable>(var graph: Dictionary<Node, Set<Node>>) -> [Node]? {
+	var queue = graph
+		.filter { _, incomingEdges in incomingEdges.isEmpty }
 		.map { node, _ in node }
 
-	queue.forEach { node in edges.removeValueForKey(node) }
+	queue.forEach { node in graph.removeValueForKey(node) }
 
 	var sorted: [Node] = []
 
@@ -49,17 +49,17 @@ public func topologicalSort<Node: Comparable>(var edges: Dictionary<Node, Set<No
 		let lastNode = queue.removeLast()
 		sorted.append(lastNode)
 
-		for (node, inEdges) in edges {
-			guard inEdges.contains(lastNode) else { continue }
+		for (node, incomingEdges) in graph where incomingEdges.contains(lastNode) {
+			let filteredIncomingEdges = incomingEdges.subtract([lastNode])
 
-			let filteredInEdges = inEdges.subtract([lastNode])
-			edges[node] = filteredInEdges
+			graph[node] = filteredIncomingEdges
 
-			guard filteredInEdges.isEmpty else { continue }
-			queue.append(node)
-			edges.removeValueForKey(node)
+			if filteredIncomingEdges.isEmpty {
+				queue.append(node)
+				graph.removeValueForKey(node)
+			}
 		}
 	}
 
-	return edges.isEmpty ? sorted : nil
+	return graph.isEmpty ? sorted : nil
 }

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -173,7 +173,7 @@ extension ResolvedCartfile: CustomStringConvertible {
 }
 
 /// Uniquely identifies a project that can be used as a dependency.
-public enum ProjectIdentifier: Equatable {
+public enum ProjectIdentifier: Comparable {
 	/// A repository hosted on GitHub.com.
 	case GitHub(GitHubRepository)
 
@@ -209,6 +209,10 @@ public func ==(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
 	default:
 		return false
 	}
+}
+
+public func <(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
+	return lhs.name < rhs.name
 }
 
 extension ProjectIdentifier: Hashable {

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -212,7 +212,7 @@ public func ==(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
 }
 
 public func <(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
-	return lhs.name < rhs.name
+	return lhs.name.caseInsensitiveCompare(rhs.name) == NSComparisonResult.OrderedAscending
 }
 
 extension ProjectIdentifier: Hashable {

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -65,6 +65,9 @@ public enum CarthageError: ErrorType, Equatable {
 	/// A cartfile contains duplicate dependencies, either in itself or across
 	/// other cartfiles.
 	case DuplicateDependencies([DuplicateDependency])
+
+	// There was a cycle between dependencies.
+	case DependencyCycle(String)
 	
 	/// A request to the GitHub API failed due to authentication or rate-limiting.
 	case GitHubAPIRequestFailed(String)

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -66,8 +66,8 @@ public enum CarthageError: ErrorType, Equatable {
 	/// other cartfiles.
 	case DuplicateDependencies([DuplicateDependency])
 
-	// There was a cycle between dependencies.
-	case DependencyCycle(String)
+	// There was a cycle between dependencies in the associated graph.
+	case DependencyCycle([ProjectIdentifier: Set<ProjectIdentifier>])
 	
 	/// A request to the GitHub API failed due to authentication or rate-limiting.
 	case GitHubAPIRequestFailed(String)
@@ -238,7 +238,20 @@ extension CarthageError: CustomStringConvertible {
 				}
 
 			return "The following dependencies are duplicates:\(deps)"
-		
+
+		case let .DependencyCycle(graph):
+			let prettyGraph = graph
+				.map { (project, dependencies) in
+					let prettyDependencies = dependencies
+						.map { $0.name }
+						.joinWithSeparator(", ")
+
+					return "\(project.name): \(prettyDependencies)"
+				}
+				.joinWithSeparator("\n")
+
+			return "The dependency graph contained a cycle :\(prettyGraph)"
+
 		case let .GitHubAPIRequestFailed(message):
 			return "GitHub API request failed: \(message)"
 

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -250,7 +250,7 @@ extension CarthageError: CustomStringConvertible {
 				}
 				.joinWithSeparator("\n")
 
-			return "The dependency graph contained a cycle :\(prettyGraph)"
+			return "The dependency graph contained a cycle:\n\(prettyGraph)"
 
 		case let .GitHubAPIRequestFailed(message):
 			return "GitHub API request failed: \(message)"

--- a/Source/CarthageKitTests/AlgorithmsSpec.swift
+++ b/Source/CarthageKitTests/AlgorithmsSpec.swift
@@ -1,0 +1,67 @@
+//
+//  AlgorithmsSpec.swift
+//  Carthage
+//
+//  Created by Eric Horacek on 2/19/16.
+//  Copyright © 2016 Carthage. All rights reserved.
+//
+
+import CarthageKit
+import Nimble
+import Quick
+
+class AlgorithmsSpec: QuickSpec {
+	override func spec() {
+		describe("sorting") {
+			it("should sort first by dependency and second by comparability") {
+				var graph: [String: Set<String>] = [:]
+
+				graph["Argo"] = Set([])
+				graph["Commandant"] = Set(["Result"])
+				graph["PrettyColors"] = Set([])
+				graph["Carthage"] = Set(["Argo", "Commandant", "ReactiveCocoa", "ReactiveTask"])
+				graph["ReactiveCocoa"] = Set(["Result"])
+				graph["ReactiveTask"] = Set(["ReactiveCocoa"])
+				graph["Result"] = Set()
+
+				let sorted = topologicalSort(graph)
+
+				expect(sorted) == [
+					"Argo",
+					"PrettyColors",
+					"Result",
+					"Commandant",
+					"ReactiveCocoa",
+					"ReactiveTask",
+					"Carthage"
+				]
+			}
+		}
+
+		describe("cycles") {
+			it("should fail when there is a cycle in the input graph", closure: {
+				var graph: [String: Set<String>] = [:]
+
+				graph["A"] = Set(["B"])
+				graph["B"] = Set(["C"])
+				graph["C"] = Set(["A"])
+
+				let sorted = topologicalSort(graph)
+
+				expect(sorted).to(beNil())
+			})
+		}
+
+		describe("malformed inputs") {
+			it("should fail when the input graph is missing nodes", closure: {
+				var graph: [String: Set<String>] = [:]
+
+				graph["A"] = Set(["B"])
+
+				let sorted = topologicalSort(graph)
+
+				expect(sorted).to(beNil())
+			})
+		}
+	}
+}


### PR DESCRIPTION
As of #1100,  the `build` command uses a comparison sort to resolve ordering of dependencies to build. That change resulted in frameworks being built out of order in significantly complex dependency graphs, causing "module not found" errors.

To resolve this, [Kahn's topological sort](https://en.wikipedia.org/wiki/Topological_sorting) is used in place of a comparison sort to ensure that the dependency graph is built in the correct order.

In our project with 43 unique dependencies (including transitive dependencies), this change fixed "module not found" errors when using the build command in the most recent release. Additionally, since this is a generic algorithm, it can be easily tested (assuming there is a reasonable place to put it). It would appear #1100 removed the previous tests around build order.

This PR has some open questions:
- Is there another place to put the generic topological sort algorithm?
- Is it reasonable to fail out the `build` command when a cycle is detected during a topological sort?