### PR TITLE
Add an integration test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: objective-c
 xcode_workspace: Carthage.xcworkspace
 xcode_scheme: carthage
 osx_image: xcode7.2
-before_install: true
+before_install:
+  - brew install bats
 install: true
 git:
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ xcode_scheme: carthage
 osx_image: xcode7.2
 before_install:
   - brew install bats
-  - sudo make install
+  - make install
 install: true
 git:
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ xcode_scheme: carthage
 osx_image: xcode7.2
 before_install:
   - brew install bats
+  - sudo make install
 install: true
 git:
   submodules: false

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ bootstrap:
 
 test: clean bootstrap
 	$(BUILD_TOOL) $(XCODEFLAGS) test
+	bats Source/CarthageIntegration
 
 clean:
 	rm -f "$(OUTPUT_PACKAGE)"

--- a/Source/CarthageIntegration/README.md
+++ b/Source/CarthageIntegration/README.md
@@ -1,5 +1,0 @@
-Hey.
-
-This is intended to be a full integration test for Carthage - using the command line API to ensure that everything behaves correctly.
-
-My intention is for CarthageKitTests to unit test components in CarthageKit, and this provides ensurance that everything actually works.

--- a/Source/CarthageIntegration/README.md
+++ b/Source/CarthageIntegration/README.md
@@ -1,0 +1,5 @@
+Hey.
+
+This is intended to be a full integration test for Carthage - using the command line API to ensure that everything behaves correctly.
+
+My intention is for CarthageKitTests to unit test components in CarthageKit, and this provides ensurance that everything actually works.

--- a/Source/CarthageIntegration/archive.bats
+++ b/Source/CarthageIntegration/archive.bats
@@ -12,13 +12,13 @@ teardown() {
 }
 
 @test "carthage archive errors unless carthage build --no-skip-current has been run" {
-    run /tmp/Carthage.dst/usr/local/bin/carthage archive
+    run carthage archive
     [ "$status" -eq 1 ]
     [ "$output" = "Could not find any copies of Ra.framework. Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'." ]
 }
 
 @test "carthage archive after carthage build --no-skip-current produces a zipped framework of all frameworks" {
-    run /tmp/Carthage.dst/usr/local/bin/carthage build --no-skip-current
+    run carthage build --no-skip-current
     [ "$status" -eq 0 ]
     run carthage archive
     [ "$status" -eq 0 ]

--- a/Source/CarthageIntegration/archive.bats
+++ b/Source/CarthageIntegration/archive.bats
@@ -1,25 +1,26 @@
 #!/usr/bin/env bats
 
-@test "carthage archive errors unless carthage build --no-skip-current has been run" {
-    pushd $BATS_TMPDIR
+setup() {
+    cd $BATS_TMPDIR
     rm -rf Ra
-    git clone https://github.com/younata/Ra.git >&2
+    git clone https://github.com/younata/Ra.git
     cd Ra
+}
+
+teardown() {
+    cd $BATS_TEST_DIRNAME
+}
+
+@test "carthage archive errors unless carthage build --no-skip-current has been run" {
     run carthage archive
     [ "$status" -eq 1 ]
     [ "$output" = "Could not find any copies of Ra.framework. Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'." ]
-    popd
 }
 
 @test "carthage archive after carthage build --no-skip-current produces a zipped framework of all frameworks" {
-    pushd $BATS_TMPDIR
-    rm -rf Ra
-    git clone https://github.com/younata/Ra.git >&2
-    cd Ra
     run carthage build --no-skip-current
     [ "$status" -eq 0 ]
     run carthage archive
     [ "$status" -eq 0 ]
     [ -e Ra.framework.zip ]
-    popd
 }

--- a/Source/CarthageIntegration/archive.bats
+++ b/Source/CarthageIntegration/archive.bats
@@ -12,15 +12,21 @@ teardown() {
 }
 
 @test "carthage archive errors unless carthage build --no-skip-current has been run" {
-    run carthage archive
+    run /tmp/Carthage.dst/usr/local/bin/carthage archive
     [ "$status" -eq 1 ]
     [ "$output" = "Could not find any copies of Ra.framework. Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'." ]
 }
 
 @test "carthage archive after carthage build --no-skip-current produces a zipped framework of all frameworks" {
-    run carthage build --no-skip-current
+    run /tmp/Carthage.dst/usr/local/bin/carthage build --no-skip-current
     [ "$status" -eq 0 ]
     run carthage archive
     [ "$status" -eq 0 ]
     [ -e Ra.framework.zip ]
 }
+
+build_carthage() {
+    make installables >&2
+}
+
+build_carthage

--- a/Source/CarthageIntegration/archive.bats
+++ b/Source/CarthageIntegration/archive.bats
@@ -24,9 +24,3 @@ teardown() {
     [ "$status" -eq 0 ]
     [ -e Ra.framework.zip ]
 }
-
-build_carthage() {
-    make installables >&2
-}
-
-build_carthage

--- a/Source/CarthageIntegration/archive.bats
+++ b/Source/CarthageIntegration/archive.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+@test "carthage archive errors unless carthage build --no-skip-current has been run" {
+    pushd $BATS_TMPDIR
+    rm -rf Ra
+    git clone https://github.com/younata/Ra.git >&2
+    cd Ra
+    run carthage archive
+    [ "$status" -eq 1 ]
+    [ "$output" = "Could not find any copies of Ra.framework. Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'." ]
+    popd
+}
+
+@test "carthage archive after carthage build --no-skip-current produces a zipped framework of all frameworks" {
+    pushd $BATS_TMPDIR
+    rm -rf Ra
+    git clone https://github.com/younata/Ra.git >&2
+    cd Ra
+    run carthage build --no-skip-current
+    [ "$status" -eq 0 ]
+    run carthage archive
+    [ "$status" -eq 0 ]
+    [ -e Ra.framework.zip ]
+    popd
+}

--- a/Source/CarthageIntegration/update.bats
+++ b/Source/CarthageIntegration/update.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+setup() {
+    cd $BATS_TMPDIR
+    rm -rf Ra
+    git clone https://github.com/younata/Ra.git
+    cd Ra
+}
+
+teardown() {
+    cd $BATS_TEST_DIRNAME
+}
+
+@test "carthage update builds everything" {
+    run carthage update --no-use-binaries
+    [ "$status" -eq 0 ]
+    [ -e Carthage/Build/iOS/Quick.framework ]
+    [ -e Carthage/Build/iOS/Nimble.framework ]
+    [ -e Carthage/Build/Mac/Quick.framework ]
+    [ -e Carthage/Build/Mac/Nimble.framework ]
+    [ -e Carthage/Build/tvOS/Quick.framework ]
+    [ -e Carthage/Build/tvOS/Nimble.framework ]
+    [ -e Carthage/Build/watchOS/Quick.framework ]
+    [ -e Carthage/Build/watchOS/Nimble.framework ]
+}

--- a/Source/CarthageIntegration/update.bats
+++ b/Source/CarthageIntegration/update.bats
@@ -12,14 +12,8 @@ teardown() {
 }
 
 @test "carthage update builds everything" {
-    run carthage update --no-use-binaries
+    run carthage update --platform mac --no-use-binaries
     [ "$status" -eq 0 ]
-    [ -e Carthage/Build/iOS/Quick.framework ]
-    [ -e Carthage/Build/iOS/Nimble.framework ]
     [ -e Carthage/Build/Mac/Quick.framework ]
     [ -e Carthage/Build/Mac/Nimble.framework ]
-    [ -e Carthage/Build/tvOS/Quick.framework ]
-    [ -e Carthage/Build/tvOS/Nimble.framework ]
-    [ -e Carthage/Build/watchOS/Quick.framework ]
-    [ -e Carthage/Build/watchOS/Nimble.framework ]
 }


### PR DESCRIPTION
Adds an integration test suite that uses [bats](https://github.com/sstephenson/bats) to test the carthage CLI.

Currently only tests archive, have plans to test others.

If you'd rather not promote Ra, then feel free to suggest some other repo.