### PR TITLE
Add `CARTHAGE` build setting to xcodebuild arguments

### DIFF
--- a/Source/CarthageKit/BuildArguments.swift
+++ b/Source/CarthageKit/BuildArguments.swift
@@ -87,6 +87,8 @@ public struct BuildArguments {
 		// Disable code signing requirement for all builds
 		// Frameworks get signed in the copy-frameworks action
 		args += [ "CODE_SIGNING_REQUIRED=NO", "CODE_SIGN_IDENTITY=" ]
+		
+		args += [ "CARTHAGE=YES" ]
 
 		return args
 	}

--- a/Source/CarthageKitTests/BuildArgumentsSpec.swift
+++ b/Source/CarthageKitTests/BuildArgumentsSpec.swift
@@ -11,7 +11,8 @@ class BuildArgumentsSpec: QuickSpec {
 
 				let codeSignArguments = [
 					"CODE_SIGNING_REQUIRED=NO",
-					"CODE_SIGN_IDENTITY="
+					"CODE_SIGN_IDENTITY=",
+					"CARTHAGE=YES"
 				]
 
 				context("when configured with a workspace") {


### PR DESCRIPTION
Adding a build setting `CARTHAGE` makes it possible for framework projects to detect when they are being built by Carthage, as requested in #1148