### PR TITLE
#1148 - Add CARTHAGE_PATH env var with executable path

### DIFF
--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -31,9 +31,7 @@ registry.register(VersionCommand())
 let helpCommand = HelpCommand(registry: registry)
 registry.register(helpCommand)
 
-if let executableURL = NSBundle.mainBundle().executableURL
-	where executableURL.lastPathComponent?.caseInsensitiveCompare("carthage") == .OrderedSame,
-	let carthagePath = executableURL.path {
+if let carthagePath = NSBundle.mainBundle().executableURL?.path {
 	setenv("CARTHAGE_PATH", "\(carthagePath)",0)
 }
 

--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -31,6 +31,12 @@ registry.register(VersionCommand())
 let helpCommand = HelpCommand(registry: registry)
 registry.register(helpCommand)
 
+if let executableURL = NSBundle.mainBundle().executableURL
+	where executableURL.lastPathComponent?.caseInsensitiveCompare("carthage") == .OrderedSame,
+	let carthagePath = executableURL.path {
+	setenv("CARTHAGE_PATH", "\(carthagePath)",0)
+}
+
 registry.main(defaultVerb: helpCommand.verb) { error in
 	fputs(error.description + "\n", stderr)
 }


### PR DESCRIPTION
Per @schwa's request (#1148) and @kballard's idea this adds a $CARTHAGE environment variable which is set to the path of the currently running carthage executable so that the build can:
- know it is running under carthage
- call copy-frameworks, etc with the same version of carthage if desired.