### PR TITLE
Fix building with transitive dependencies

### DIFF
--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -88,7 +88,7 @@ public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>
 
 	let relevantNodes = Set(nodes.flatMap { Set([$0]).union(transitiveIncomingNodes(graph, node: $0)) })
 
-	return sorted.filter { node in !relevantNodes.contains(node) }
+	return sorted.filter { node in relevantNodes.contains(node) }
 }
 
 /// Returns the set of nodes that the given node in the provided graph has as

--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -70,24 +70,25 @@ public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>
 /// include only the provided set of nodes and their transitively incoming 
 /// nodes (dependencies).
 ///
-/// Returns nil if the provided node is contained within the provided graph or
-/// if the provided graph has a cycle.
+/// If the provided `nodes` set is empty, returns the result of invoking
+/// `topologicalSort()` with the provided graph.
+///
+/// Throws an exception if the provided node(s) are not contained within the 
+/// given graph.
+///
+/// Returns nil if the provided graph has a cycle or is malformed.
 public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>, nodes: Set<Node>) -> [Node]? {
 	guard !nodes.isEmpty else { return topologicalSort(graph) }
 
-	guard nodes.isSubsetOf(Set(graph.keys)) else { return nil }
+	precondition(nodes.isSubsetOf(Set(graph.keys)))
 
 	// Ensure that the graph has no cycles, otherwise determining the set of 
 	// transitive incoming nodes could infinitely recurse.
-	guard let _ = topologicalSort(graph) else { return nil }
+	guard let sorted = topologicalSort(graph) else { return nil }
 
 	let relevantNodes = Set(nodes.flatMap { Set([$0]).union(transitiveIncomingNodes(graph, node: $0)) })
-	let irrelevantNodes = Set(graph.keys).subtract(relevantNodes)
 
-	var filteredGraph = graph
-	irrelevantNodes.forEach { node in filteredGraph.removeValueForKey(node) }
-	
-	return topologicalSort(filteredGraph)
+	return sorted.filter { node in !relevantNodes.contains(node) }
 }
 
 /// Returns the set of nodes that the given node in the provided graph has as

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -557,32 +557,19 @@ public final class Project {
 				return result
 			}
 			.flatMap(.Latest) { (graph: DependencyGraph) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in
-				guard let sortedProjects = topologicalSort(graph) else {
+				let projectsToInclude = Set(graph
+					.map { project, _ in project }
+					.filter { project in dependenciesToInclude?.contains(project.name) ?? false })
+
+				guard let sortedProjects = topologicalSort(graph, nodes: projectsToInclude) else {
 					return SignalProducer(error: .DependencyCycle(graph))
 				}
 
-				let sorted = cartfile.dependencies.sort { left, right in
-					let leftIndex = sortedProjects.indexOf(left.project)
-					let rightIndex = sortedProjects.indexOf(right.project)
-					return leftIndex < rightIndex
-				}
+				let sortedDependencies = cartfile.dependencies
+					.filter { dependency in sortedProjects.contains(dependency.project) }
+					.sort { left, right in sortedProjects.indexOf(left.project) < sortedProjects.indexOf(right.project) }
 
-				guard let dependenciesToInclude = dependenciesToInclude where !dependenciesToInclude.isEmpty else {
-					return SignalProducer(values: sorted)
-				}
-
-				var toInclude = Set(dependenciesToInclude)
-
-				sorted
-					.filter { toInclude.contains($0.project.name) }
-					.forEach { dependency in
-						if let deps = graph[dependency.project] {
-							toInclude.unionInPlace(deps.map { $0.name })
-						}
-					}
-
-				let filtered = sorted.filter { toInclude.contains($0.project.name) }
-				return SignalProducer(values: filtered)
+				return SignalProducer(values: sortedDependencies)
 			}
 	}
 

--- a/Source/CarthageKitTests/AlgorithmsSpec.swift
+++ b/Source/CarthageKitTests/AlgorithmsSpec.swift
@@ -130,12 +130,6 @@ class AlgorithmsSpec: QuickSpec {
 
 					expect(sorted).to(beNil())
 				}
-
-				it("should fail when the proivded nodes are not within the graph") {
-					let sorted = topologicalSort(validGraph, nodes: Set(["Unknown Dependency"]))
-
-					expect(sorted).to(beNil())
-				}
 			}
 		}
 	}

--- a/Source/CarthageKitTests/AlgorithmsSpec.swift
+++ b/Source/CarthageKitTests/AlgorithmsSpec.swift
@@ -33,7 +33,29 @@ class AlgorithmsSpec: QuickSpec {
 					"Commandant",
 					"ReactiveCocoa",
 					"ReactiveTask",
-					"Carthage"
+					"Carthage",
+				]
+			}
+		}
+
+		describe("filtered sorting") {
+			it("should only include the provided nodes and their dependencies") {
+				var graph: [String: Set<String>] = [:]
+
+				graph["Argo"] = Set([])
+				graph["Commandant"] = Set(["Result"])
+				graph["PrettyColors"] = Set([])
+				graph["Carthage"] = Set(["Argo", "Commandant", "ReactiveCocoa", "ReactiveTask"])
+				graph["ReactiveCocoa"] = Set(["Result"])
+				graph["ReactiveTask"] = Set(["ReactiveCocoa"])
+				graph["Result"] = Set()
+
+				let sorted = topologicalSort(graph, nodes: Set(["ReactiveTask"]))
+
+				expect(sorted) == [
+					"Result",
+					"ReactiveCocoa",
+					"ReactiveTask",
 				]
 			}
 		}

--- a/Source/CarthageKitTests/AlgorithmsSpec.swift
+++ b/Source/CarthageKitTests/AlgorithmsSpec.swift
@@ -12,19 +12,31 @@ import Quick
 
 class AlgorithmsSpec: QuickSpec {
 	override func spec() {
+		typealias Graph = [String: Set<String>]
+
+		var validGraph: Graph = [:]
+		var cycleGraph: Graph = [:]
+		var malformedGraph: Graph = [:]
+
+		beforeEach {
+			validGraph["Argo"] = Set([])
+			validGraph["Commandant"] = Set(["Result"])
+			validGraph["PrettyColors"] = Set([])
+			validGraph["Carthage"] = Set(["Argo", "Commandant", "PrettyColors", "ReactiveCocoa", "ReactiveTask"])
+			validGraph["ReactiveCocoa"] = Set(["Result"])
+			validGraph["ReactiveTask"] = Set(["ReactiveCocoa"])
+			validGraph["Result"] = Set()
+
+			cycleGraph["A"] = Set(["B"])
+			cycleGraph["B"] = Set(["C"])
+			cycleGraph["C"] = Set(["A"])
+
+			malformedGraph["A"] = Set(["B"])
+		}
+
 		describe("sorting") {
 			it("should sort first by dependency and second by comparability") {
-				var graph: [String: Set<String>] = [:]
-
-				graph["Argo"] = Set([])
-				graph["Commandant"] = Set(["Result"])
-				graph["PrettyColors"] = Set([])
-				graph["Carthage"] = Set(["Argo", "Commandant", "ReactiveCocoa", "ReactiveTask"])
-				graph["ReactiveCocoa"] = Set(["Result"])
-				graph["ReactiveTask"] = Set(["ReactiveCocoa"])
-				graph["Result"] = Set()
-
-				let sorted = topologicalSort(graph)
+				let sorted = topologicalSort(validGraph)
 
 				expect(sorted) == [
 					"Argo",
@@ -36,54 +48,95 @@ class AlgorithmsSpec: QuickSpec {
 					"Carthage",
 				]
 			}
-		}
 
-		describe("filtered sorting") {
-			it("should only include the provided nodes and their dependencies") {
-				var graph: [String: Set<String>] = [:]
+			context("when filtering") {
+				it("should only include the provided node and its transitive dependencies") {
+					let sorted = topologicalSort(validGraph, nodes: Set(["ReactiveTask"]))
 
-				graph["Argo"] = Set([])
-				graph["Commandant"] = Set(["Result"])
-				graph["PrettyColors"] = Set([])
-				graph["Carthage"] = Set(["Argo", "Commandant", "ReactiveCocoa", "ReactiveTask"])
-				graph["ReactiveCocoa"] = Set(["Result"])
-				graph["ReactiveTask"] = Set(["ReactiveCocoa"])
-				graph["Result"] = Set()
+					expect(sorted) == [
+						"Result",
+						"ReactiveCocoa",
+						"ReactiveTask",
+					]
+				}
 
-				let sorted = topologicalSort(graph, nodes: Set(["ReactiveTask"]))
+				it("should only include provided nodes and their transitive dependencies") {
+					let sorted = topologicalSort(validGraph, nodes: Set(["ReactiveTask", "Commandant"]))
 
-				expect(sorted) == [
-					"Result",
-					"ReactiveCocoa",
-					"ReactiveTask",
-				]
+					expect(sorted) == [
+						"Result",
+						"Commandant",
+						"ReactiveCocoa",
+						"ReactiveTask",
+					]
+				}
+
+				it("should only include provided nodes and their transitive dependencies") {
+					let sorted = topologicalSort(validGraph, nodes: Set(["Carthage"]))
+
+					expect(sorted) == [
+						"Argo",
+						"PrettyColors",
+						"Result",
+						"Commandant",
+						"ReactiveCocoa",
+						"ReactiveTask",
+						"Carthage",
+					]
+				}
+
+				it("should perform a topological sort on the provided graph when the set is empty") {
+					let sorted = topologicalSort(validGraph, nodes: Set())
+
+					expect(sorted) == [
+						"Argo",
+						"PrettyColors",
+						"Result",
+						"Commandant",
+						"ReactiveCocoa",
+						"ReactiveTask",
+						"Carthage",
+					]
+				}
 			}
 		}
 
 		describe("cycles") {
-			it("should fail when there is a cycle in the input graph", closure: {
-				var graph: [String: Set<String>] = [:]
-
-				graph["A"] = Set(["B"])
-				graph["B"] = Set(["C"])
-				graph["C"] = Set(["A"])
-
-				let sorted = topologicalSort(graph)
+			it("should fail when there is a cycle in the input graph") {
+				let sorted = topologicalSort(cycleGraph)
 
 				expect(sorted).to(beNil())
-			})
+			}
+
+			context("when filtering") {
+				it("should fail when there is a cycle in the input graph") {
+					let sorted = topologicalSort(cycleGraph, nodes: Set(["B"]))
+
+					expect(sorted).to(beNil())
+				}
+			}
 		}
 
 		describe("malformed inputs") {
-			it("should fail when the input graph is missing nodes", closure: {
-				var graph: [String: Set<String>] = [:]
-
-				graph["A"] = Set(["B"])
-
-				let sorted = topologicalSort(graph)
+			it("should fail when the input graph is missing nodes") {
+				let sorted = topologicalSort(malformedGraph)
 
 				expect(sorted).to(beNil())
-			})
+			}
+
+			context("when filtering") {
+				it("should fail when the input graph is missing nodes") {
+					let sorted = topologicalSort(malformedGraph, nodes: Set(["A"]))
+
+					expect(sorted).to(beNil())
+				}
+
+				it("should fail when the proivded nodes are not within the graph") {
+					let sorted = topologicalSort(validGraph, nodes: Set(["Unknown Dependency"]))
+
+					expect(sorted).to(beNil())
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Currently, deep transitive dependencies are not built first before a dependency when it is specified to the build command. This occurs when you specify a specific set of dependencies to the "build" command.

An example would be `carthage build A`, where `A` depends on `B` depends on `C`. I have observed that `C` is not always built before `B`.