### PR TITLE
Avoid deleting resource when trying to copy to and from the same path

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1269,7 +1269,13 @@ private func stripBinary(binaryURL: NSURL, keepingArchitectures: [String]) -> Si
 public func copyProduct(from: NSURL, _ to: NSURL) -> SignalProducer<NSURL, CarthageError> {
 	return SignalProducer<NSURL, CarthageError>.attempt {
 		let manager = NSFileManager.defaultManager()
-
+		
+		if let path = to.path where
+			manager.fileExistsAtPath(path) &&
+			from.absoluteURL == to.absoluteURL {
+				return .Success(to)
+		}
+		
 		do {
 			try manager.createDirectoryAtURL(to.URLByDeletingLastPathComponent!, withIntermediateDirectories: true, attributes: nil)
 		} catch let error as NSError {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1267,7 +1267,7 @@ private func stripBinary(binaryURL: NSURL, keepingArchitectures: [String]) -> Si
 /// destination folder will be deleted before the copy of the new version.
 ///
 /// If the `from` URL has the same path as the `to` URL, and there is a resource
-/// at the given path, no operation is needed an the returned signal will just
+/// at the given path, no operation is needed and the returned signal will just
 /// send `.success`.
 ///
 /// Returns a signal that will send the URL after copying upon .success.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1263,13 +1263,24 @@ private func stripBinary(binaryURL: NSURL, keepingArchitectures: [String]) -> Si
 }
 
 /// Copies a product into the given folder. The folder will be created if it
-/// does not already exist.
+/// does not already exist, and any pre-existing version of the product in the
+/// destination folder will be deleted before the copy of the new version.
+///
+/// If the `from` URL has the same path as the `to` URL, and there is a resource
+/// at the given path, no operation is needed an the returned signal will just
+/// send `.success`.
 ///
 /// Returns a signal that will send the URL after copying upon .success.
 public func copyProduct(from: NSURL, _ to: NSURL) -> SignalProducer<NSURL, CarthageError> {
 	return SignalProducer<NSURL, CarthageError>.attempt {
 		let manager = NSFileManager.defaultManager()
 		
+		// This signal deletes `to` before it copies `from` over it.
+		// If `from` and `to` point to the same resource, there's no need to perform a copy at all
+		// and deleting `to` will also result in deleting the original resource without copying it.
+		// When `from` and `to` are the same, we can just return success immediately.
+		//
+		// See https://github.com/Carthage/Carthage/pull/1160
 		if let path = to.path where
 			manager.fileExistsAtPath(path) &&
 			from.absoluteURL == to.absoluteURL {
@@ -1284,7 +1295,7 @@ public func copyProduct(from: NSURL, _ to: NSURL) -> SignalProducer<NSURL, Carth
 			// returns NO and NSFileWriteFileExistsError error. So we should
 			// ignore that specific error.
 			//
-			// See https://github.com/Carthage/Carthage/issues/591.
+			// See https://github.com/Carthage/Carthage/issues/591
 			if error.code != NSFileWriteFileExistsError {
 				return .Failure(.WriteFailed(to.URLByDeletingLastPathComponent!, error))
 			}


### PR DESCRIPTION
Symptoms
========
In our project, we use `carthage copy-frameworks` as a `run script` phase in "main" the XCode project, passing as input parameters: `$(SRCROOT)/Carthage/Build/iOS/<famework-name>.framework` with some frameworks that we developed.

In case we want to debug one of the dependent projects within the "main" one,  just drag the dependent project in to the main project and change the parameter to: `$(BUILT_PRODUCTS_DIR)/<framework-name>.framework`

This causes the script to pick up the locally built copy of the framework with minimal effort (no need to use submodules) and we can then debug the locally built version of the framework.

This behaviour was broken when switching to carthage version 0.11. It was working fine in 0.10.
When setting the input parameter as `$(BUILT_PRODUCTS_DIR)/<framework-name>.framework`, the `carthage copy-framework` fails with the error:

```
Failed to write to /Users/marcoconti/Library/Developer/Xcode/DerivedData/xxxxxx-cqshunxcinsexugiloscmawayfwb/Build/Products/Debug-iphonesimulator/<name>.framework.dSYM: Error Domain=NSCocoaErrorDomain Code=260 "The file “<name>.framework.dSYM” couldn’t be opened because there is no such file." UserInfo=0x7fb0b9eddb50 {NSFilePath=/Users/marcoconti/Library/Developer/Xcode/DerivedData/xxxxx-cqshunxcinsexugiloscmawayfwb/Build/Products/Debug-iphonesimulator/<name>.framework.dSYM, NSUnderlyingError=0x7fb0b9e2b730 "The operation couldn’t be completed. No such file or directory"}
```

Inspecting the folder, it looks like the `dSYM` folder is deleted during the execution of `carthage copy-framework`

TL;DR
--------
When passing  `$(BUILT_PRODUCTS_DIR)/<framework-name>.framework` to `carthage copy-frameworks`, carthage deletes the `dSYM` folder instead of copying it. It then throws an error because it can't find the folder.

Issue analysis
=======

The function `copyProduct(from:to:)` in [`XCode.swift`](https://github.com/Carthage/Carthage/blob/0cab93f46b7b10c7164c6ba61c898ac49b5629c3/Source/CarthageKit/Xcode.swift#L1269) was previously performing the following operations:
- create the "to" directory, if needed
- remove "to"
- copy "from" to "to"

In case from and to point to the same resource, the result is that the resource is deleted and not copied.

Proposed fix
===========
Add an early successful return in `copyProduct` if `from` and `to` point to the same resource and the `to` resource exists.

I tested this by invoking the modified carthage from our project, and the script now completes.
