### PR TITLE
Fix `Unrecognized arguments: -DnouvMtSdbiNmcResg` when running from XCode

### DIFF
--- a/Carthage.xcodeproj/xcshareddata/xcschemes/carthage.xcscheme
+++ b/Carthage.xcodeproj/xcshareddata/xcschemes/carthage.xcscheme
@@ -58,7 +58,7 @@
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable


### PR DESCRIPTION
# Symptoms
Check out the carthage project and open it in Xcode 7.2.1.
When trying to run carthage from XCode (`Cmd+R`), the process fails with the output (in the Xcode console):

`Unrecognized arguments: -DnouvMtSdbiNmcResg`

The `Run` section of the carthage schema in XCode has no such command line argument, in fact it only has `update`.

# Issue analysis

By setting a breakpoint in Commandant and printing out the actual command line arguments, it turns out that there are two extra unexpected arguments passed when running carthage from XCode 7.2.1:

- `-NSDocumentRevisionsDebugMode`
- `YES`

Looking at the string `-DnouvMtSdbiNmcRes`, it turns out it's just an anagram of `-NSDocumentRevisionsDebugMode` with duplicate letters removed. The initial `-` makes Commandant think it's a cluster of flags (as in `tar -xvf`), so it probably reshuffles the flags as the order should not matter and duplicates are ignored.

# Proposed fix

Searching for `-NSDocumentRevisionsDebugMode` on the internet brought me to this discussion https://github.com/philsquared/Catch/issues/230.
As suggested there, setting `debugDocumentVersioning = "NO"` in the schema options seems to solve the issue: the `-NSDocumentRevisionsDebugMode YES` is not passed as an argument anymore and carthage can be run again from Xcode.
