### PR TITLE
Fixes #1172, duplicate dependency entries

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -200,7 +200,7 @@ public func ==(lhs: GitHubRepository.Server, rhs: GitHubRepository.Server) -> Bo
 
 extension GitHubRepository: Hashable {
 	public var hashValue: Int {
-		return server.hashValue ^ owner.hashValue ^ name.hashValue
+		return server.hashValue ^ owner.lowercaseString.hashValue ^ name.lowercaseString.hashValue
 	}
 }
 


### PR DESCRIPTION
As reported in #1172 , `carthage` is treating
`github "Owner/Repo"` and
`github "owner/repo"`
as two different dependencies causing duplicated entries in `Cartfile.resolved`.

Fixed it by adding case-insensitive hash generation in `GitHubRepository`