### PR TITLE
[copy-frameworks] Ignore frameworks that do not support the current build architecture

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -68,7 +68,7 @@ private func shouldIgnoreFramework(framework: NSURL, validArchitectures: [String
 		}
 		.map { remainingArchitectures in
 			// If removing the useless architectures results in an empty fat file, wat means that the framework does not have a binary for the given architecture, ignore the framework.
-			remainingArchitectures.count == 0
+			remainingArchitectures.isEmpty
 		}
 }
 


### PR DESCRIPTION
I have a (dynamic)framework that wraps static libs, but these binaries are not build for the simulator. It turns out that lipo throws an error if the result is an empty binary, in the copy-frameworks command. In this pr i added a function `shouldIgnoreFramework` that checks if the framework does support any of the valid architectures and if that returns false the i print a warning and the framework will be ignored.