### PR TITLE
Minor fixes for #1154

### DIFF
--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -18,6 +18,10 @@ guard ensureGitVersion().first()?.value == true else {
 	exit(EXIT_FAILURE)
 }
 
+if let carthagePath = NSBundle.mainBundle().executablePath {
+	setenv("CARTHAGE_PATH", carthagePath, 0)
+}
+
 let registry = CommandRegistry<CarthageError>()
 registry.register(ArchiveCommand())
 registry.register(BootstrapCommand())
@@ -30,10 +34,6 @@ registry.register(VersionCommand())
 
 let helpCommand = HelpCommand(registry: registry)
 registry.register(helpCommand)
-
-if let carthagePath = NSBundle.mainBundle().executableURL?.path {
-	setenv("CARTHAGE_PATH", "\(carthagePath)",0)
-}
 
 registry.main(defaultVerb: helpCommand.verb) { error in
 	fputs(error.description + "\n", stderr)


### PR DESCRIPTION
- Use `NSBundle.executablePath` over `executableURL?.path`
- Pass `carthagePath` directly to `setenv`
- Add a missing space after comma