### PR TITLE
Fix CI steps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ It is possible to use travis-ci in order to build and upload your tagged release
 	    - FRAMEWORK_NAME=<THIS_IS_A_PLACEHOLDER_REPLACE_ME>
 	before_install:
 	  - brew update
-	  - brew install carthage
+	  - brew outdated carthage || brew upgrade carthage
 	before_script:
 	  # bootstrap the dependencies for the project
 	  # you can remove if you don't have dependencies


### PR DESCRIPTION
TravisCI updated their VMs and `brew install carthage` now fails with error: "already installed".
I changed this to `brew outdated carthage || brew upgrade carthage`, so it will try to update only if carthage is outdated and no error will be produced.