### PR TITLE
Skip building for device SDKs on platforms that require bitcode when bitcode is disabled

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -969,8 +969,10 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 			let platform = sdk.platform
 
 			if var sdks = sdksByPlatform[platform] {
-				sdks.append(sdk)
-				sdksByPlatform.updateValue(sdks, forKey: platform)
+				if sdks.indexOf(sdk) == nil {
+					sdks.append(sdk)
+					sdksByPlatform.updateValue(sdks, forKey: platform)
+				}
 			} else {
 				sdksByPlatform[platform] = [ sdk ]
 			}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -964,17 +964,15 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 				}
 				.map { _ in sdk }
 		}
-		.reduce([:]) { (sdksByPlatform: [Platform: [SDK]], sdk: SDK) in
+		.reduce([:]) { (sdksByPlatform: [Platform: Set<SDK>], sdk: SDK) in
 			var sdksByPlatform = sdksByPlatform
 			let platform = sdk.platform
 
 			if var sdks = sdksByPlatform[platform] {
-				if sdks.indexOf(sdk) == nil {
-					sdks.append(sdk)
-					sdksByPlatform.updateValue(sdks, forKey: platform)
-				}
+				sdks.insert(sdk)
+				sdksByPlatform.updateValue(sdks, forKey: platform)
 			} else {
-				sdksByPlatform[platform] = [ sdk ]
+				sdksByPlatform[platform] = Set(arrayLiteral: sdk)
 			}
 
 			return sdksByPlatform
@@ -984,7 +982,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 				fatalError("No SDKs found for scheme \(scheme)")
 			}
 
-			let values = sdksByPlatform.map { ($0, $1) }
+			let values = sdksByPlatform.map { ($0, Array($1)) }
 			return SignalProducer(values: values)
 		}
 		.flatMap(.Concat) { platform, sdks -> SignalProducer<(Platform, [SDK]), CarthageError> in

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -956,10 +956,10 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 
 			return BuildSettings
 				.loadWithArguments(argsForLoading)
-                .filter { settings in
-                    // Filter out SDKs that require bitcode when bitcode is disabled in
-                    // project settings. This is necessary for testing frameworks, which
-                    // must add a User-Defined setting of ENABLE_BITCODE=NO.
+				.filter { settings in
+					// Filter out SDKs that require bitcode when bitcode is disabled in
+					// project settings. This is necessary for testing frameworks, which
+					// must add a User-Defined setting of ENABLE_BITCODE=NO.
 					return settings.bitcodeEnabled.value == true || ![.tvOS, .watchOS].contains(sdk)
 				}
 				.map { _ in sdk }


### PR DESCRIPTION
This is an attempt to get Carthage working for test frameworks like Quick and Nimble on the tvOS platform.

I'm new to ReactiveCocoa so I welcome any advice or suggestions on better ways to hook in this logic. Also, I'm not sure how to set up tests for this change as it looks like the current build tests in `XcodeSpec` all actually trigger real builds. Perhaps once I add `ENABLE_BITCODE=NO` to Quick and Nimble their projects could be used to test this.

Resolves #1268