### PR TITLE
Fix to https://github.com/Carthage/Carthage/issues/1292

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -253,7 +253,7 @@ extension CarthageError: CustomStringConvertible {
 			return "GitHub API request failed: \(message)"
 			
 		case let .UnresolvedDependencies(names):
-			return "No entry found for dependencies \(names.joinWithSeparator(", ")) in Cartfile.resolved – please run `carthage update` if the dependency is contained in the project's Cartfile."
+			return "No entry found for \(names.count > 1 ? "dependencies" : "dependency") \(names.joinWithSeparator(", ")) in Cartfile.resolved – please run `carthage update` if the dependency is contained in the project's Cartfile."
 
 		case let .TaskError(taskError):
 			return taskError.description

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -30,6 +30,9 @@ public enum CarthageError: ErrorType, Equatable {
 	/// No existent version could be found to satisfy the version specifier for
 	/// a dependency.
 	case RequiredVersionNotFound(ProjectIdentifier, VersionSpecifier)
+	
+	// No entry could be found in Cartfile.resolved for a dependency with this name.
+	case UnresolvedDependency(String)
 
 	/// Failed to check out a repository.
 	case RepositoryCheckoutFailed(workingDirectoryURL: NSURL, reason: String, underlyingError: NSError?)
@@ -248,6 +251,9 @@ extension CarthageError: CustomStringConvertible {
 
 		case let .GitHubAPIRequestFailed(message):
 			return "GitHub API request failed: \(message)"
+			
+		case let .UnresolvedDependency(name):
+			return "No entry found for dependency \(name) in Cartfile.resolved – please run `carthage update` if the dependency is contained in the project's Cartfile."
 
 		case let .TaskError(taskError):
 			return taskError.description

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -32,7 +32,7 @@ public enum CarthageError: ErrorType, Equatable {
 	case RequiredVersionNotFound(ProjectIdentifier, VersionSpecifier)
 	
 	// No entry could be found in Cartfile.resolved for a dependency with this name.
-	case UnresolvedDependency(String)
+	case UnresolvedDependencies([String])
 
 	/// Failed to check out a repository.
 	case RepositoryCheckoutFailed(workingDirectoryURL: NSURL, reason: String, underlyingError: NSError?)
@@ -252,8 +252,8 @@ extension CarthageError: CustomStringConvertible {
 		case let .GitHubAPIRequestFailed(message):
 			return "GitHub API request failed: \(message)"
 			
-		case let .UnresolvedDependency(name):
-			return "No entry found for dependency \(name) in Cartfile.resolved – please run `carthage update` if the dependency is contained in the project's Cartfile."
+		case let .UnresolvedDependencies(names):
+			return "No entry found for dependencies \(names.joinWithSeparator(", ")) in Cartfile.resolved – please run `carthage update` if the dependency is contained in the project's Cartfile."
 
 		case let .TaskError(taskError):
 			return taskError.description

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -29,23 +29,21 @@ public struct BootstrapCommand: CommandType {
 				
 				let checkDependencies: SignalProducer<(), CarthageError>
 				if let depsToUpdate = options.dependenciesToUpdate {
-					checkDependencies =
-						project
+					checkDependencies = project
 						.loadResolvedCartfile()
 						.flatMap(.Concat) { resolvedCartfile -> SignalProducer<(), CarthageError> in
-							let resolvedDependencyNames = resolvedCartfile.dependencies.map { $0.project.name }
-							let unresolvedDependencyNames = Set(depsToUpdate).subtract(resolvedDependencyNames)
+							let resolvedDependencyNames = resolvedCartfile.dependencies.map { $0.project.name.lowercaseString }
+							let unresolvedDependencyNames = Set(depsToUpdate.map { $0.lowercaseString }).subtract(resolvedDependencyNames)
 							
 							if !unresolvedDependencyNames.isEmpty {
-								return SignalProducer<(), CarthageError>(error:.UnresolvedDependencies([String](unresolvedDependencyNames).sort()))
+								return SignalProducer(error: .UnresolvedDependencies(unresolvedDependencyNames.sort()))
 							}
-							
 							return .empty
 						}
-					}
-					else {
-						checkDependencies = .empty
-					}
+				}
+				else {
+					checkDependencies = .empty
+				}
 				
 				let checkoutDependencies: SignalProducer<(), CarthageError>
 				if options.checkoutAfterUpdate {

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -31,12 +31,9 @@ public struct BootstrapCommand: CommandType {
 					let resolvedCartfileContents = try! String(contentsOfURL: project.resolvedCartfileURL, encoding: NSUTF8StringEncoding)
 					let resolvedCartfile = ResolvedCartfile.fromString(resolvedCartfileContents).value!
 					
-					let resolvedDependencyNames = Set<String>(resolvedCartfile.dependencies.map { $0.project.name })
-					let updatedDependencyNames = Set<String>(depsToUpdate)
-					let unresolvedDependencyNames = updatedDependencyNames.subtract(resolvedDependencyNames)
-					
-					if unresolvedDependencyNames.count > 0 {
-						return SignalProducer<(), CarthageError>(error: CarthageError.UnresolvedDependencies([String](unresolvedDependencyNames).sort()))
+					let resolvedDependencyNames = resolvedCartfile.dependencies.map { $0.project.name }
+					if !Set(depsToUpdate).subtract(resolvedDependencyNames).isEmpty {
+						return SignalProducer<(), CarthageError>(error: CarthageError.UnresolvedDependencies([String](unresolvedDependencyNames).sort())
 					}
 				}
 				


### PR DESCRIPTION
I'm not very sure if this fits your house style and whether I've missed something obvious, but here's an attempted fix to #1292. 

Also some shortcuts taken to force unwrap where some suitable errors should be thrown instead (on failing to read a string from Cartfile.resolved or to parse it into a ResolvedCartfile), wasn't sure what the intended style for such error cases is.