### PR TITLE
Update ReadMe to add note about @loader_path/Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Using Carthage for the dependencies of any arbitrary target is fairly similar to
 
 Because unit test targets are missing the “Linked Frameworks and Libraries” section in their “General” settings tab, you must instead drag the [built frameworks][Carthage/Build] to the “Link Binaries With Libraries” build phase.
 
+In the Test target under the "Build Settings" tab, add `@loader_path/Frameworks` to the "Runpath Search Paths" if it isn't already present.
+
 In rare cases, you may want to also copy each dependency into the build product (e.g., to embed dependencies within the outer framework, or make sure dependencies are present in a test bundle). To do this, create a new “Copy Files” build phase with the “Frameworks” destination, then add the framework reference there as well.
 
 ### Upgrading frameworks


### PR DESCRIPTION
This path must be present for Carthage to load frameworks in unit test targets, but may not be present in older projects.

I discovered this while using Carthage to add libraries to the unit test target here:
https://github.com/wikimedia/wikipedia-ios/pull/695

