### PR TITLE
Fixes issue with archive command trying to include xctest files

### DIFF
--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -64,14 +64,14 @@ public struct ArchiveCommand: CommandType {
 					return BuildSettings.loadWithArguments(buildArguments)
 				}
 				.flatMap(.Concat) { settings -> SignalProducer<String, CarthageError> in
-					if let wrapperName = settings.wrapperName.value {
+					if let wrapperName = settings.wrapperName.value where settings.productType.value == .Framework {
 						return .init(value: wrapperName)
 					} else {
 						return .empty
 					}
 				}
 				.collect()
-				.map { Array(Set($0.filter{ $0.hasSuffix(".framework") })).sort() }
+				.map { Array(Set($0)).sort() }
 		}
 
 		return frameworks.flatMap(.Merge) { frameworks -> SignalProducer<(), CarthageError> in

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -71,7 +71,7 @@ public struct ArchiveCommand: CommandType {
 					}
 				}
 				.collect()
-				.map { Array(Set($0)).sort() }
+				.map { Array(Set($0.filter{ $0.hasSuffix(".framework") })).sort() }
 		}
 
 		return frameworks.flatMap(.Merge) { frameworks -> SignalProducer<(), CarthageError> in


### PR DESCRIPTION
When running the archive command on projects with test targets that have "Run" enabled in the build scheme, as below:

![Issue](http://i.imgur.com/13FSg38.png)

This error is shown:
Could not find any copies of SnapKit OSX Tests.xctest, SnapKit iOS Tests.xctest, SnapKit.framework. Make sure you're in the project’s root and that the frameworks have already been built using 'carthage build --no-skip-current'.

Apart from SnapKit this issue is happening on PromiseKit as well.

This fix adds a filter to filter out anything that is not a framework.