### PR TITLE
Add `--toolchain` option

### DIFF
--- a/Source/CarthageKit/BuildArguments.swift
+++ b/Source/CarthageKit/BuildArguments.swift
@@ -14,6 +14,9 @@ public struct BuildArguments {
 
 	/// The platform SDK to build for.
 	public var sdk: SDK?
+	
+	/// The Swift toolchain to use.
+	public var toolchain: String?
 
 	/// The run destination to try building for.
 	public var destination: String?
@@ -28,12 +31,13 @@ public struct BuildArguments {
 	/// The build setting whether full bitcode should be embedded in the binary.
 	public var bitcodeGenerationMode: BitcodeGenerationMode? = nil
 
-	public init(project: ProjectLocator, scheme: String? = nil, configuration: String? = nil, derivedDataPath: String? = nil, sdk: SDK? = nil) {
+	public init(project: ProjectLocator, scheme: String? = nil, configuration: String? = nil, derivedDataPath: String? = nil, sdk: SDK? = nil, toolchain: String?) {
 		self.project = project
 		self.scheme = scheme
 		self.configuration = configuration
 		self.derivedDataPath = derivedDataPath
 		self.sdk = sdk
+		self.toolchain = toolchain
 	}
 
 	/// The `xcodebuild` invocation corresponding to the receiver.
@@ -70,6 +74,10 @@ public struct BuildArguments {
 			if sdk != .MacOSX {
 				args += [ "-sdk", sdk.rawValue ]
 			}
+		}
+		
+		if let toolchain = toolchain {
+			args += [ "-toolchain", toolchain ]
 		}
 
 		if let destination = destination {

--- a/Source/CarthageKit/BuildArguments.swift
+++ b/Source/CarthageKit/BuildArguments.swift
@@ -31,7 +31,7 @@ public struct BuildArguments {
 	/// The build setting whether full bitcode should be embedded in the binary.
 	public var bitcodeGenerationMode: BitcodeGenerationMode? = nil
 
-	public init(project: ProjectLocator, scheme: String? = nil, configuration: String? = nil, derivedDataPath: String? = nil, sdk: SDK? = nil, toolchain: String?) {
+	public init(project: ProjectLocator, scheme: String? = nil, configuration: String? = nil, derivedDataPath: String? = nil, sdk: SDK? = nil, toolchain: String? = nil) {
 		self.project = project
 		self.scheme = scheme
 		self.configuration = configuration

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -671,7 +671,7 @@ public final class Project {
 	/// optionally they are limited by the given list of dependency names.
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
-	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, dependenciesToBuild: [String]? = nil, forPlatforms platforms: Set<Platform>, derivedDataPath: String?, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	public func buildCheckedOutDependenciesWithConfiguration(configuration: String, dependenciesToBuild: [String]? = nil, forPlatforms platforms: Set<Platform>, toolchain: String?, derivedDataPath: String?, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 		return loadResolvedCartfile()
 			.flatMap(.Merge) { resolvedCartfile in
 				return self.buildOrderForResolvedCartfile(resolvedCartfile, dependenciesToInclude: dependenciesToBuild)
@@ -682,7 +682,7 @@ public final class Project {
 					return .empty
 				}
 
-				return buildDependencyProject(dependency.project, self.directoryURL, withConfiguration: configuration, platforms: platforms, derivedDataPath: derivedDataPath, sdkFilter: sdkFilter)
+				return buildDependencyProject(dependency.project, self.directoryURL, withConfiguration: configuration, platforms: platforms, toolchain: toolchain, derivedDataPath: derivedDataPath, sdkFilter: sdkFilter)
 					.flatMapError { error in
 						switch error {
 						case .NoSharedFrameworkSchemes:

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1084,7 +1084,7 @@ public typealias BuildSchemeProducer = SignalProducer<TaskEvent<(ProjectLocator,
 /// places its build product into the root directory given.
 ///
 /// Returns producers in the same format as buildInDirectory().
-public func buildDependencyProject(dependency: ProjectIdentifier, _ rootDirectoryURL: NSURL, withConfiguration configuration: String, platforms: Set<Platform> = [], toolchain: String?, derivedDataPath: String? = nil, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+public func buildDependencyProject(dependency: ProjectIdentifier, _ rootDirectoryURL: NSURL, withConfiguration configuration: String, platforms: Set<Platform> = [], toolchain: String? = nil, derivedDataPath: String? = nil, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 	let rootBinariesURL = rootDirectoryURL.URLByAppendingPathComponent(CarthageBinariesFolderPath, isDirectory: true).URLByResolvingSymlinksInPath!
 	let rawDependencyURL = rootDirectoryURL.URLByAppendingPathComponent(dependency.relativePath, isDirectory: true)
 	let dependencyURL = rawDependencyURL.URLByResolvingSymlinksInPath!
@@ -1171,7 +1171,7 @@ public func buildDependencyProject(dependency: ProjectIdentifier, _ rootDirector
 ///
 /// Returns a signal of all standard output from `xcodebuild`, and a
 /// signal-of-signals representing each scheme being built.
-public func buildInDirectory(directoryURL: NSURL, withConfiguration configuration: String, platforms: Set<Platform> = [], toolchain: String?, derivedDataPath: String? = nil, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+public func buildInDirectory(directoryURL: NSURL, withConfiguration configuration: String, platforms: Set<Platform> = [], toolchain: String? = nil, derivedDataPath: String? = nil, sdkFilter: SDKFilterCallback = { .Success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 	precondition(directoryURL.fileURL)
 
 	return SignalProducer { observer, disposable in

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -136,7 +136,7 @@ public func xcodebuildTask(task: String, _ buildArguments: BuildArguments) -> Ta
 
 /// Sends each scheme found in the given project.
 public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, CarthageError> {
-	let task = xcodebuildTask("-list", BuildArguments(project: project, toolchain: nil))
+	let task = xcodebuildTask("-list", BuildArguments(project: project))
 
 	return launchTask(task)
 		.ignoreTaskData()
@@ -171,14 +171,14 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 
 /// Finds schemes of projects or workspaces, which Carthage should build, found
 /// within the given directory.
-public func buildableSchemesInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = [], toolchain: String?) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
+public func buildableSchemesInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = []) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
 	precondition(directoryURL.fileURL)
 
 	return locateProjectsInDirectory(directoryURL)
 		.flatMap(.Concat) { project -> SignalProducer<(ProjectLocator, [String]), CarthageError> in
 			return schemesInProject(project)
 				.flatMap(.Merge) { scheme -> SignalProducer<String, CarthageError> in
-					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration, toolchain: toolchain)
+					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
 
 					return shouldBuildScheme(buildArguments, platforms)
 						.filter { $0 }
@@ -545,7 +545,7 @@ public struct BuildSettings {
 	/// If an SDK is unrecognized or could not be determined, an error will be
 	/// sent on the returned signal.
 	public static func SDKsForScheme(scheme: String, inProject project: ProjectLocator) -> SignalProducer<SDK, CarthageError> {
-		return loadWithArguments(BuildArguments(project: project, scheme: scheme, toolchain: nil))
+		return loadWithArguments(BuildArguments(project: project, scheme: scheme))
 			.take(1)
 			.flatMap(.Merge) { $0.buildSDKs }
 	}
@@ -1177,7 +1177,7 @@ public func buildInDirectory(directoryURL: NSURL, withConfiguration configuratio
 	return SignalProducer { observer, disposable in
 		// Use SignalProducer.replayLazily to avoid enumerating the given directory
 		// multiple times.
-		let locator = buildableSchemesInDirectory(directoryURL, withConfiguration: configuration, forPlatforms: platforms, toolchain: toolchain)
+		let locator = buildableSchemesInDirectory(directoryURL, withConfiguration: configuration, forPlatforms: platforms)
 			.replayLazily(Int.max)
 
 		locator

--- a/Source/CarthageKitTests/BuildArgumentsSpec.swift
+++ b/Source/CarthageKitTests/BuildArgumentsSpec.swift
@@ -59,6 +59,10 @@ class BuildArgumentsSpec: QuickSpec {
 			itCreatesBuildArguments("includes empty derived data path", arguments: []) { (inout subject: BuildArguments) in
 				subject.derivedDataPath = ""
 			}
+			
+			itCreatesBuildArguments("includes the the toolchain", arguments: ["-toolchain", "org.swift.3020160509a"]) { (inout subject: BuildArguments) in
+				subject.toolchain = "org.swift.3020160509a"
+			}
 
 			describe("specifying the sdk") {
 				for sdk in SDK.allSDKs.subtract([.MacOSX]) {

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -14,19 +14,21 @@ import ReactiveCocoa
 
 public struct ArchiveCommand: CommandType {
 	public struct Options: OptionsType {
+		public let toolchain: String?
 		public let outputPath: String?
 		public let directoryPath: String
 		public let colorOptions: ColorOptions
 		public let frameworkNames: [String]
 
-		static func create(outputPath: String?) -> String -> ColorOptions -> [String] -> Options {
-			return { directoryPath in { colorOptions in { frameworkNames in
-				return self.init(outputPath: outputPath, directoryPath: directoryPath, colorOptions: colorOptions, frameworkNames: frameworkNames)
-			} } }
+		static func create(outputPath: String?) -> String? -> String -> ColorOptions -> [String] -> Options {
+			return { toolchain in { directoryPath in { colorOptions in { frameworkNames in
+				return self.init(toolchain: toolchain, outputPath: outputPath, directoryPath: directoryPath, colorOptions: colorOptions, frameworkNames: frameworkNames)
+			} } } }
 		}
 
 		public static func evaluate(m: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
 			return create
+				<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 				<*> m <| Option(key: "output", defaultValue: nil, usage: "the path at which to create the zip file (or blank to infer it from the first one of the framework names)")
 				<*> m <| Option(key: "project-directory", defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")
 				<*> ColorOptions.evaluate(m)
@@ -47,7 +49,7 @@ public struct ArchiveCommand: CommandType {
 			})
 		} else {
 			let directoryURL = NSURL.fileURLWithPath(options.directoryPath, isDirectory: true)
-			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release", forPlatforms: [])
+			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release", forPlatforms: [], toolchain: options.toolchain)
 				.collect()
 				.flatMap(.Merge) { projects in
 					return schemesInProjects(projects)
@@ -60,7 +62,7 @@ public struct ArchiveCommand: CommandType {
 						}
 				}
 				.flatMap(.Merge) { scheme, project -> SignalProducer<BuildSettings, CarthageError> in
-					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: "Release")
+					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: "Release", toolchain: nil)
 					return BuildSettings.loadWithArguments(buildArguments)
 				}
 				.flatMap(.Concat) { settings -> SignalProducer<String, CarthageError> in

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -17,6 +17,7 @@ public struct BuildCommand: CommandType {
 	public struct Options: OptionsType {
 		public let configuration: String
 		public let buildPlatform: BuildPlatform
+		public let toolchain: String?
 		public let derivedDataPath: String?
 		public let skipCurrent: Bool
 		public let colorOptions: ColorOptions
@@ -24,17 +25,18 @@ public struct BuildCommand: CommandType {
 		public let directoryPath: String
 		public let dependenciesToBuild: [String]?
 
-		public static func create(configuration: String) -> BuildPlatform -> String? -> Bool -> ColorOptions -> Bool -> String -> [String] -> Options {
-			return { buildPlatform in { derivedDataPath in { skipCurrent in { colorOptions in { verbose in { directoryPath in { dependenciesToBuild in
+		public static func create(configuration: String) -> BuildPlatform -> String? -> String? -> Bool -> ColorOptions -> Bool -> String -> [String] -> Options {
+			return { buildPlatform in { toolchain in { derivedDataPath in { skipCurrent in { colorOptions in { verbose in { directoryPath in { dependenciesToBuild in
 				let dependenciesToBuild: [String]? = dependenciesToBuild.isEmpty ? nil : dependenciesToBuild
-				return self.init(configuration: configuration, buildPlatform: buildPlatform, derivedDataPath: derivedDataPath, skipCurrent: skipCurrent, colorOptions: colorOptions, verbose: verbose, directoryPath: directoryPath, dependenciesToBuild: dependenciesToBuild)
-			} } } } } } }
+				return self.init(configuration: configuration, buildPlatform: buildPlatform, toolchain: toolchain, derivedDataPath: derivedDataPath, skipCurrent: skipCurrent, colorOptions: colorOptions, verbose: verbose, directoryPath: directoryPath, dependenciesToBuild: dependenciesToBuild)
+			} } } } } } } }
 		}
 
 		public static func evaluate(m: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
 			return create
 				<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build")
 				<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, 'tvOS', or comma-separated values of the formers except for ‘all’)")
+				<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 				<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 				<*> m <| Option(key: "skip-current", defaultValue: true, usage: "don't skip building the Carthage project (in addition to its dependencies)")
 				<*> ColorOptions.evaluate(m)
@@ -147,13 +149,13 @@ public struct BuildCommand: CommandType {
 				}
 			}
 			.flatMap(.Merge) { project in
-				return project.buildCheckedOutDependenciesWithConfiguration(options.configuration, dependenciesToBuild: options.dependenciesToBuild, forPlatforms: options.buildPlatform.platforms, derivedDataPath: options.derivedDataPath)
+				return project.buildCheckedOutDependenciesWithConfiguration(options.configuration, dependenciesToBuild: options.dependenciesToBuild, forPlatforms: options.buildPlatform.platforms, toolchain: options.toolchain, derivedDataPath: options.derivedDataPath)
 			}
 
 		if options.skipCurrent {
 			return buildProducer
 		} else {
-			let currentProducers = buildInDirectory(directoryURL, withConfiguration: options.configuration, platforms: options.buildPlatform.platforms, derivedDataPath: options.derivedDataPath)
+			let currentProducers = buildInDirectory(directoryURL, withConfiguration: options.configuration, platforms: options.buildPlatform.platforms, toolchain: options.toolchain, derivedDataPath: options.derivedDataPath)
 				.flatMapError { error -> SignalProducer<BuildSchemeProducer, CarthageError> in
 					switch error {
 					case let .NoSharedFrameworkSchemes(project, _):

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -18,6 +18,7 @@ public struct UpdateCommand: CommandType {
 		public let buildAfterUpdate: Bool
 		public let configuration: String
 		public let buildPlatform: BuildPlatform
+		public let toolchain: String?
 		public let derivedDataPath: String?
 		public let verbose: Bool
 		public let checkoutOptions: CheckoutCommand.Options
@@ -25,7 +26,7 @@ public struct UpdateCommand: CommandType {
 
 		/// The build options corresponding to these options.
 		public var buildOptions: BuildCommand.Options {
-			return BuildCommand.Options(configuration: configuration, buildPlatform: buildPlatform, derivedDataPath: derivedDataPath, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath, dependenciesToBuild: dependenciesToUpdate)
+			return BuildCommand.Options(configuration: configuration, buildPlatform: buildPlatform, toolchain: toolchain, derivedDataPath: derivedDataPath, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath, dependenciesToBuild: dependenciesToUpdate)
 		}
 
 		/// If `checkoutAfterUpdate` and `buildAfterUpdate` are both true, this will
@@ -40,16 +41,17 @@ public struct UpdateCommand: CommandType {
 			}
 		}
 
-		public static func create(configuration: String) -> BuildPlatform -> String? -> Bool -> Bool -> Bool -> CheckoutCommand.Options -> Options {
-			return { buildPlatform in { derivedDataPath in { verbose in { checkoutAfterUpdate in { buildAfterUpdate in { checkoutOptions in
-				return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, derivedDataPath: derivedDataPath, verbose: verbose, checkoutOptions: checkoutOptions, dependenciesToUpdate: checkoutOptions.dependenciesToCheckout)
-			} } } } } }
+		public static func create(configuration: String) -> BuildPlatform -> String? -> String? -> Bool -> Bool -> Bool -> CheckoutCommand.Options -> Options {
+			return { buildPlatform in { toolchain in { derivedDataPath in { verbose in { checkoutAfterUpdate in { buildAfterUpdate in { checkoutOptions in
+				return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, toolchain: toolchain, derivedDataPath: derivedDataPath, verbose: verbose, checkoutOptions: checkoutOptions, dependenciesToUpdate: checkoutOptions.dependenciesToCheckout)
+			} } } } } } }
 		}
 
 		public static func evaluate(m: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
 			return create
 				<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
 				<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, 'tvOS', or comma-separated values of the formers except for ‘all’)\n(ignored if --no-build option is present)")
+				<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 				<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 				<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
 				<*> m <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")


### PR DESCRIPTION
Adds the ability to specify a custom Swift toolchain via a `--toolchain` option on the `build`, `update`, and `archive` commands.

E.g.: `carthage build --toolchain org.swift.3020160509a`

**Todo**
- [x] Make toolchain parameter default to `nil` where desired
- [x] tests?


**Resolves issue** #1039 