### PR TITLE
Improve error messaging around malformed dependency graphs

### DIFF
--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -70,8 +70,8 @@ public enum CarthageError: ErrorType, Equatable {
 	/// other cartfiles.
 	case DuplicateDependencies([DuplicateDependency])
 
-	// There was a cycle between dependencies in the associated graph.
-	case DependencyCycle([ProjectIdentifier: Set<ProjectIdentifier>])
+	/// The associated graph was either malformed or contained a cycle.
+	case MalformedDependencyGraph([ProjectIdentifier: Set<ProjectIdentifier>])
 	
 	/// A request to the GitHub API failed.
 	case GitHubAPIRequestFailed(Client.Error)
@@ -236,7 +236,7 @@ extension CarthageError: CustomStringConvertible {
 
 			return "The following dependencies are duplicates:\(deps)"
 
-		case let .DependencyCycle(graph):
+		case let .MalformedDependencyGraph(graph):
 			let prettyGraph = graph
 				.map { (project, dependencies) in
 					let prettyDependencies = dependencies
@@ -247,7 +247,7 @@ extension CarthageError: CustomStringConvertible {
 				}
 				.joinWithSeparator("\n")
 
-			return "The dependency graph contained a cycle:\n\(prettyGraph)"
+			return "The dependency graph was either malformed or contained a cycle:\n\(prettyGraph)"
 
 		case let .GitHubAPIRequestFailed(message):
 			return "GitHub API request failed: \(message)"

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -608,7 +608,7 @@ public final class Project {
 					.filter { project in dependenciesToInclude?.contains(project.name) ?? false })
 
 				guard let sortedProjects = topologicalSort(graph, nodes: projectsToInclude) else {
-					return SignalProducer(error: .DependencyCycle(graph))
+					return SignalProducer(error: .MalformedDependencyGraph(graph))
 				}
 
 				let sortedDependencies = cartfile.dependencies


### PR DESCRIPTION
Ref #1328

This should hopefully help out with some confusion caused by malformed dependency graphs being reported as having cycles.