### PR TITLE
Add --no-clean option to update and build commands

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -17,6 +17,7 @@ public struct BuildCommand: CommandType {
 	public struct Options: OptionsType {
 		public let configuration: String
 		public let buildPlatform: BuildPlatform
+		public let clean: Bool
 		public let toolchain: String?
 		public let derivedDataPath: String?
 		public let skipCurrent: Bool
@@ -25,17 +26,18 @@ public struct BuildCommand: CommandType {
 		public let directoryPath: String
 		public let dependenciesToBuild: [String]?
 
-		public static func create(configuration: String) -> BuildPlatform -> String? -> String? -> Bool -> ColorOptions -> Bool -> String -> [String] -> Options {
-			return { buildPlatform in { toolchain in { derivedDataPath in { skipCurrent in { colorOptions in { verbose in { directoryPath in { dependenciesToBuild in
+		public static func create(configuration: String) -> BuildPlatform -> Bool -> String? -> String? -> Bool -> ColorOptions -> Bool -> String -> [String] -> Options {
+			return { buildPlatform in { clean in { toolchain in { derivedDataPath in { skipCurrent in { colorOptions in { verbose in { directoryPath in { dependenciesToBuild in
 				let dependenciesToBuild: [String]? = dependenciesToBuild.isEmpty ? nil : dependenciesToBuild
-				return self.init(configuration: configuration, buildPlatform: buildPlatform, toolchain: toolchain, derivedDataPath: derivedDataPath, skipCurrent: skipCurrent, colorOptions: colorOptions, verbose: verbose, directoryPath: directoryPath, dependenciesToBuild: dependenciesToBuild)
-			} } } } } } } }
+				return self.init(configuration: configuration, buildPlatform: buildPlatform, clean: clean, toolchain: toolchain, derivedDataPath: derivedDataPath, skipCurrent: skipCurrent, colorOptions: colorOptions, verbose: verbose, directoryPath: directoryPath, dependenciesToBuild: dependenciesToBuild)
+				} } } } } } } } }
 		}
 
 		public static func evaluate(m: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
 			return create
 				<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build")
 				<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, 'tvOS', or comma-separated values of the formers except for ‘all’)")
+				<*> m <| Option(key: "clean", defaultValue: true, usage: "don't clean before build")
 				<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 				<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 				<*> m <| Option(key: "skip-current", defaultValue: true, usage: "don't skip building the Carthage project (in addition to its dependencies)")
@@ -45,7 +47,7 @@ public struct BuildCommand: CommandType {
 				<*> m <| Argument(defaultValue: [], usage: "the dependency names to build")
 		}
 	}
-	
+
 	public let verb = "build"
 	public let function = "Build the project's dependencies"
 
@@ -149,13 +151,13 @@ public struct BuildCommand: CommandType {
 				}
 			}
 			.flatMap(.Merge) { project in
-				return project.buildCheckedOutDependenciesWithConfiguration(options.configuration, dependenciesToBuild: options.dependenciesToBuild, forPlatforms: options.buildPlatform.platforms, toolchain: options.toolchain, derivedDataPath: options.derivedDataPath)
+				return project.buildCheckedOutDependenciesWithConfiguration(options.configuration, dependenciesToBuild: options.dependenciesToBuild, forPlatforms: options.buildPlatform.platforms, toolchain: options.toolchain, clean: options.clean, derivedDataPath: options.derivedDataPath)
 			}
 
 		if options.skipCurrent {
 			return buildProducer
 		} else {
-			let currentProducers = buildInDirectory(directoryURL, withConfiguration: options.configuration, platforms: options.buildPlatform.platforms, toolchain: options.toolchain, derivedDataPath: options.derivedDataPath)
+			let currentProducers = buildInDirectory(directoryURL, withConfiguration: options.configuration, platforms: options.buildPlatform.platforms, toolchain: options.toolchain, clean: options.clean, derivedDataPath: options.derivedDataPath)
 				.flatMapError { error -> SignalProducer<BuildSchemeProducer, CarthageError> in
 					switch error {
 					case let .NoSharedFrameworkSchemes(project, _):

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -18,6 +18,7 @@ public struct UpdateCommand: CommandType {
 		public let buildAfterUpdate: Bool
 		public let configuration: String
 		public let buildPlatform: BuildPlatform
+		public let clean: Bool
 		public let toolchain: String?
 		public let derivedDataPath: String?
 		public let verbose: Bool
@@ -26,7 +27,7 @@ public struct UpdateCommand: CommandType {
 
 		/// The build options corresponding to these options.
 		public var buildOptions: BuildCommand.Options {
-			return BuildCommand.Options(configuration: configuration, buildPlatform: buildPlatform, toolchain: toolchain, derivedDataPath: derivedDataPath, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath, dependenciesToBuild: dependenciesToUpdate)
+			return BuildCommand.Options(configuration: configuration, buildPlatform: buildPlatform, clean: clean, toolchain: toolchain, derivedDataPath: derivedDataPath, skipCurrent: true, colorOptions: checkoutOptions.colorOptions, verbose: verbose, directoryPath: checkoutOptions.directoryPath, dependenciesToBuild: dependenciesToUpdate)
 		}
 
 		/// If `checkoutAfterUpdate` and `buildAfterUpdate` are both true, this will
@@ -41,16 +42,17 @@ public struct UpdateCommand: CommandType {
 			}
 		}
 
-		public static func create(configuration: String) -> BuildPlatform -> String? -> String? -> Bool -> Bool -> Bool -> CheckoutCommand.Options -> Options {
-			return { buildPlatform in { toolchain in { derivedDataPath in { verbose in { checkoutAfterUpdate in { buildAfterUpdate in { checkoutOptions in
-				return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, toolchain: toolchain, derivedDataPath: derivedDataPath, verbose: verbose, checkoutOptions: checkoutOptions, dependenciesToUpdate: checkoutOptions.dependenciesToCheckout)
-			} } } } } } }
+		public static func create(configuration: String) -> BuildPlatform -> Bool -> String? -> String? -> Bool -> Bool -> Bool -> CheckoutCommand.Options -> Options {
+			return { buildPlatform in { clean in { toolchain in { derivedDataPath in { verbose in { checkoutAfterUpdate in { buildAfterUpdate in { checkoutOptions in
+				return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, configuration: configuration, buildPlatform: buildPlatform, clean: clean, toolchain: toolchain, derivedDataPath: derivedDataPath, verbose: verbose, checkoutOptions: checkoutOptions, dependenciesToUpdate: checkoutOptions.dependenciesToCheckout)
+				} } } } } } } }
 		}
 
 		public static func evaluate(m: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
 			return create
 				<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build (ignored if --no-build option is present)")
 				<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, 'tvOS', or comma-separated values of the formers except for ‘all’)\n(ignored if --no-build option is present)")
+				<*> m <| Option(key: "clean", defaultValue: true, usage: "don't clean before build (ignored if --no-build option is present)")
 				<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 				<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 				<*> m <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
@@ -72,14 +74,14 @@ public struct UpdateCommand: CommandType {
 				})
 		}
 	}
-	
+
 	public let verb = "update"
 	public let function = "Update and rebuild the project's dependencies"
 
 	public func run(options: Options) -> Result<(), CarthageError> {
 		return options.loadProject()
 			.flatMap(.Merge) { project -> SignalProducer<(), CarthageError> in
-				
+
 				let checkDependencies: SignalProducer<(), CarthageError>
 				if let depsToUpdate = options.dependenciesToUpdate {
 					checkDependencies = project
@@ -87,7 +89,7 @@ public struct UpdateCommand: CommandType {
 						.flatMap(.Concat) { cartfile -> SignalProducer<(), CarthageError> in
 							let dependencyNames = cartfile.dependencies.map { $0.project.name.lowercaseString }
 							let unknownDependencyNames = Set(depsToUpdate.map { $0.lowercaseString }).subtract(dependencyNames)
-							
+
 							if !unknownDependencyNames.isEmpty {
 								return SignalProducer(error: .UnknownDependencies(unknownDependencyNames.sort()))
 							}
@@ -96,12 +98,12 @@ public struct UpdateCommand: CommandType {
 				} else {
 					checkDependencies = .empty
 				}
-				
+
 				let updateDependencies = project.updateDependencies(
 					shouldCheckout: options.checkoutAfterUpdate,
 					dependenciesToUpdate: options.dependenciesToUpdate
 				)
-				
+
 				return checkDependencies.then(updateDependencies)
 			}
 			.then(options.buildProducer)


### PR DESCRIPTION
Added to speed up build and update commands allows for incremental builds rather than a full clean and rebuild each time. Default behaviour is as before.

We are using carthage to manage a number of internal components and update frequently and hence the desire to have this option added as time for full rebuilds under Carthage is excessive when regular part of development process.