### PR TITLE
[carthage] Accept `appletv(os|simulator)` for `--platform` option

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -301,7 +301,7 @@ extension BuildPlatform: ArgumentType {
 		"macOS": .Mac, "Mac": .Mac, "OSX": .Mac, "macosx": .Mac,
 		"iOS": .iOS, "iphoneos": .iOS, "iphonesimulator": .iOS,
 		"watchOS": .watchOS, "watchsimulator": .watchOS,
-		"tvOS": .tvOS, "tvsimulator": .tvOS,
+		"tvOS": .tvOS, "tvsimulator": .tvOS, "appletvos": .tvOS, "appletvsimulator": .tvOS,
 		"all": .All
 	]
 


### PR DESCRIPTION
The possible SDK values we pass to `xcodebuild -sdk` are not `tvos` nor `tvsimulator`.

Maybe we should remove the `"tvsimulator": .tvOS` case?