### PR TITLE
Added troubleshooting solution to ReadMe file (for "Module file was created by an older/newer version of the compiler” compile error).

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Dupe [rdar://23551273](http://www.openradar.me/23551273) if you want Apple to fi
 
 ##### Compile Errors
 
-If, having built & imported the dependencies into the project, you get an error which begins: ```Module file was created by an older (newer) version of the compiler``` ... it may be that Carthage downloaded and used an existing compiled binary from the remote repo.
+If, having built & imported the dependencies into the project, you get an error which begins: ```Module file was created by an older (newer) version of the compiler``` ... it may be that Carthage downloaded and used an existing compiled binary from the remote repo which is not compatible with the local machine.
 
 To force Carthage to compile from source itself for those libraries, append the flag ```--no-use-binaries``` to the ```carthage bootstrap/build/update``` command.  For example: ```carthage bootstrap --no-use-binaries```
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ See [Carthage issue #924](https://github.com/Carthage/Carthage/issues/924) for b
 
 Dupe [rdar://23551273](http://www.openradar.me/23551273) if you want Apple to fix the root cause of this problem.
 
+##### Compile Errors
+
+If, having built & imported the dependencies into the project, you get an error which begins: ```Module file was created by an older (newer) version of the compiler``` ... it may be that Carthage downloaded and used an existing compiled binary from the remote repo.
+
+To force Carthage to compile from source itself for those libraries, append the flag ```--no-use-binaries``` to the ```carthage bootstrap/build/update``` command.  For example: ```carthage bootstrap --no-use-binaries```
+
 ## CarthageKit
 
 Most of the functionality of the `carthage` command line tool is actually encapsulated in a framework named CarthageKit.


### PR DESCRIPTION

> ReadMe: added solution to the (not well-documented) situation where Xcode won't compile because the library binary(s) used a different version of the compiler.

Hi there --

After hours of trying to diagnose a compiler error that prevented dependencies from building in multiple Xcode projects, then spending quite a bit of time investigating whether having two versions of Xcode on the machine (7.3.1 and 8b2) could have been the cause (e.g., by munging the command line tools, which wasn’t the case) … I finally found a StackOverflow solution that fit the situation (http://stackoverflow.com/a/36661798).  [I was about to give up on Carthage altogether when I found this just in time.]

Since Carthage seems to prefer downloading precompiled binaries which may or may not compile in a given user’s project, and Xcode doesn’t know the root cause of the issue … I’d say the ideal solution would be to enable '--no-use-binaries’ by default, thus obviating the issue altogether.  Alternately, there could be a local preference/config setting to declare that preference.  [I never found such a solution in those hours of troubleshooting.]

Or lacking a more proactive solution, I’ve written a caveat for the ReadMe file, which would at least have saved much of the troubleshooting time expended in this case.  (Please feel free to move it where needed in that file.)

Thank you!
