### PR TITLE
Make a simple package manager for Linux as well?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 env:
   global:
     secure: DofNs+Ej7JblkkGMTHOl4XMBfv0EKVvzZU7OOm7U6Hyxu0J0SN6E3s61Q4HUWOBvM3Yrxf+8jpFKI29w69WArmRPpmK6GCaZar8ldUBHNmN3gaeOaGmGyrmnre4hxHjJzc0E3HAmJ03v94HW5JwQzKpIUjxg4dSttJMT6WOmnxE=
-    secure: "EYsCq9/f8w1I0DlHKnE1CPOh6IZ0STwO3obIXfD0Tcf5hR5K5pYElPVIgZwjzeK+4IJUp378n18XYgo9DzzmB24aohsV3V3iMd9kuzQ7Tvhu3XiJhKkZ/mH5nufkQLx2SCt/yu9VrIiviMieDJVeCNdQ/fR9qUhL63+nwGDoZbk="
+    secure: "ehB+3qjRcHR9tCeX9omi69V7XihSdySXVo45GoyqLncCa90tpeLviI+m2XRJn2ajHtrz+iwBaBut6buFpcbCrSOdHsZ5FQb2sGkGprll/Tz8B2XvNRqpQan2eFouO2/SPpOVDurpbqf78KsRSRD6mMNuCS4AfKM/hDnbGUxzCfs="
 before_deploy:
   - brew install hub
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     secure: DofNs+Ej7JblkkGMTHOl4XMBfv0EKVvzZU7OOm7U6Hyxu0J0SN6E3s61Q4HUWOBvM3Yrxf+8jpFKI29w69WArmRPpmK6GCaZar8ldUBHNmN3gaeOaGmGyrmnre4hxHjJzc0E3HAmJ03v94HW5JwQzKpIUjxg4dSttJMT6WOmnxE=
     secure: "ehB+3qjRcHR9tCeX9omi69V7XihSdySXVo45GoyqLncCa90tpeLviI+m2XRJn2ajHtrz+iwBaBut6buFpcbCrSOdHsZ5FQb2sGkGprll/Tz8B2XvNRqpQan2eFouO2/SPpOVDurpbqf78KsRSRD6mMNuCS4AfKM/hDnbGUxzCfs="
 before_deploy:
+  - brew update
   - brew install hub
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
 env:
   global:
     secure: DofNs+Ej7JblkkGMTHOl4XMBfv0EKVvzZU7OOm7U6Hyxu0J0SN6E3s61Q4HUWOBvM3Yrxf+8jpFKI29w69WArmRPpmK6GCaZar8ldUBHNmN3gaeOaGmGyrmnre4hxHjJzc0E3HAmJ03v94HW5JwQzKpIUjxg4dSttJMT6WOmnxE=
+    secure: "IvC9T+m7fLM65e/zK7t2jxsvChD+Kbx1qjHnjhnzfJhlFKu6wHEbtZmMtt9e1qyavbbrFwkNAL8s5xUd9GFKgxSjZETuqhPkggCFhNnfcoTs8JPVyd9OBK8lgN//IGIAcvE33R+vouq7rkVszgLoBcC8SWcDkaWYNy74kvljKew="
 deploy:
   - provider: releases
     api-key:
@@ -24,3 +25,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+  - provider: script
+    script: script/brew-publish
+    on:
+      branch: brew-publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
   global:
     secure: DofNs+Ej7JblkkGMTHOl4XMBfv0EKVvzZU7OOm7U6Hyxu0J0SN6E3s61Q4HUWOBvM3Yrxf+8jpFKI29w69WArmRPpmK6GCaZar8ldUBHNmN3gaeOaGmGyrmnre4hxHjJzc0E3HAmJ03v94HW5JwQzKpIUjxg4dSttJMT6WOmnxE=
     secure: "EYsCq9/f8w1I0DlHKnE1CPOh6IZ0STwO3obIXfD0Tcf5hR5K5pYElPVIgZwjzeK+4IJUp378n18XYgo9DzzmB24aohsV3V3iMd9kuzQ7Tvhu3XiJhKkZ/mH5nufkQLx2SCt/yu9VrIiviMieDJVeCNdQ/fR9qUhL63+nwGDoZbk="
+before_deploy:
+  - brew install hub
 deploy:
   - provider: releases
     api-key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ env:
   global:
     secure: DofNs+Ej7JblkkGMTHOl4XMBfv0EKVvzZU7OOm7U6Hyxu0J0SN6E3s61Q4HUWOBvM3Yrxf+8jpFKI29w69WArmRPpmK6GCaZar8ldUBHNmN3gaeOaGmGyrmnre4hxHjJzc0E3HAmJ03v94HW5JwQzKpIUjxg4dSttJMT6WOmnxE=
 deploy:
-  provider: releases
-  api-key:
-    secure: c1fMI4p8oUVGi7SkDLqXpZDhrVVnLWU8J6+rWc3pTMmeNmEGopZpCiiQupHoHXx+Fq3+8R4M2iG0IgfcVTb6q5HD2RH0+q57/p9vcYIlCS8E/1o2BPUHUfH1Poc1vs7VdFpjWFmbm6Twnnffbz3AsELjv3mJyRxR6fUAliwfnWk=
-  file:
-    - Carthage.pkg
-    - CarthageKit.framework.zip
-  skip_cleanup: true
-  on:
-    tags: true
+  - provider: releases
+    api-key:
+      secure: c1fMI4p8oUVGi7SkDLqXpZDhrVVnLWU8J6+rWc3pTMmeNmEGopZpCiiQupHoHXx+Fq3+8R4M2iG0IgfcVTb6q5HD2RH0+q57/p9vcYIlCS8E/1o2BPUHUfH1Poc1vs7VdFpjWFmbm6Twnnffbz3AsELjv3mJyRxR6fUAliwfnWk=
+    file:
+      - Carthage.pkg
+      - CarthageKit.framework.zip
+    skip_cleanup: true
+    on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 env:
   global:
     secure: DofNs+Ej7JblkkGMTHOl4XMBfv0EKVvzZU7OOm7U6Hyxu0J0SN6E3s61Q4HUWOBvM3Yrxf+8jpFKI29w69WArmRPpmK6GCaZar8ldUBHNmN3gaeOaGmGyrmnre4hxHjJzc0E3HAmJ03v94HW5JwQzKpIUjxg4dSttJMT6WOmnxE=
-    secure: "IvC9T+m7fLM65e/zK7t2jxsvChD+Kbx1qjHnjhnzfJhlFKu6wHEbtZmMtt9e1qyavbbrFwkNAL8s5xUd9GFKgxSjZETuqhPkggCFhNnfcoTs8JPVyd9OBK8lgN//IGIAcvE33R+vouq7rkVszgLoBcC8SWcDkaWYNy74kvljKew="
+    secure: "EYsCq9/f8w1I0DlHKnE1CPOh6IZ0STwO3obIXfD0Tcf5hR5K5pYElPVIgZwjzeK+4IJUp378n18XYgo9DzzmB24aohsV3V3iMd9kuzQ7Tvhu3XiJhKkZ/mH5nufkQLx2SCt/yu9VrIiviMieDJVeCNdQ/fR9qUhL63+nwGDoZbk="
 deploy:
   - provider: releases
     api-key:

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -13,6 +13,7 @@ AUTHOR_NAME="Matt Diephouse"
 AUTHOR_EMAIL="matt@diephouse.com"
 BRANCH="$PROJECT-$TAG"
 FORMULA="Library/Formula/carthage.rb"
+GITHUB_USER="mdiep"
 COMMIT_MESSAGE="$PROJECT $TAG"
 PULL_REQUEST_TITLE="$PROJECT $TAG"
 
@@ -24,7 +25,7 @@ cd homebrew
 git remote add upstream https://github.com/homebrew/homebrew.git
 git fetch upstream
 git rebase upstream/master
-git push
+git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew master >/dev/null &2>/dev/null
 
 # 4. Create branch and update formula
 git checkout -b $BRANCH
@@ -34,7 +35,7 @@ git add .
 GIT_COMMITTER_NAME=$AUTHOR_NAME GIT_COMMITTER_EMAIL=$AUTHOR_EMAIL git commit --author="$AUTHOR_NAME <$AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE"
 
 # 5. Publish branch
-git push -u origin $BRANCH
+git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew $BRANCH >/dev/null &2>/dev/null
 
 # 6. Open PR
 hub pull-request -m "$PULL_REQUEST_TITLE"

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -21,7 +21,7 @@ git clone https://github.com/Carthage/homebrew.git homebrew
 cd homebrew
 
 # 3. Update fork from master
-git remote add upstream https://github.com/homebrew/homebrew
+git remote add upstream https://github.com/homebrew/homebrew.git
 git fetch upstream
 git rebase upstream/master
 git push

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -38,4 +38,5 @@ GIT_COMMITTER_NAME=$AUTHOR_NAME GIT_COMMITTER_EMAIL=$AUTHOR_EMAIL git commit --a
 git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git $BRANCH &>/dev/null
 
 # 6. Open PR
+sleep 5 # Don't race with the push
 hub pull-request -m "$PULL_REQUEST_TITLE"

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Usage: script/brew-publish
+#
+# Publish an updated formula to Homebrew.
+
+set -e
+
+# 1. Get the tag and SHA
+PROJECT=carthage
+TAG="0.10"
+SHA=$(git show-ref -s --tags $TAG)
+AUTHOR_NAME="Matt Diephouse"
+AUTHOR_EMAIL="matt@diephouse.com"
+BRANCH="$PROJECT-$TAG"
+FORMULA="Library/Formula/carthage.rb"
+COMMIT_MESSAGE="$PROJECT $TAG"
+PULL_REQUEST_TITLE="$PROJECT $TAG"
+
+# 2. Clone homebrew fork
+git clone https://github.com/Carthage/homebrew
+cd homebrew
+
+# 3. Update fork from master
+git remote add upstream https://github.com/homebrew/homebrew
+git fetch upstream
+git rebase upstream/master
+git push
+
+# 4. Create branch and update formula
+git checkout -b $BRANCH
+perl -pi -e "s/:tag => \".+?\"/:tag => \"$TAG\"/" $FORMULA
+perl -pi -e "s/:revision => \".+?\"/:revision => \"$SHA\"/" $FORMULA
+git add .
+GIT_COMMITTER_NAME=$AUTHOR_NAME GIT_COMMITTER_EMAIL=$AUTHOR_EMAIL git commit --author="$AUTHOR_NAME <$AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE"
+
+# 5. Publish branch
+git push -u origin $BRANCH
+
+# 6. Open PR
+hub pull-request -m "$PULL_REQUEST_TITLE"

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -25,7 +25,7 @@ cd homebrew
 git remote add upstream https://github.com/homebrew/homebrew.git
 git fetch upstream
 git rebase upstream/master
-git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew master >/dev/null &2>/dev/null
+git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git master >/dev/null &2>/dev/null
 
 # 4. Create branch and update formula
 git checkout -b $BRANCH
@@ -35,7 +35,7 @@ git add .
 GIT_COMMITTER_NAME=$AUTHOR_NAME GIT_COMMITTER_EMAIL=$AUTHOR_EMAIL git commit --author="$AUTHOR_NAME <$AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE"
 
 # 5. Publish branch
-git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew $BRANCH >/dev/null &2>/dev/null
+git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git $BRANCH >/dev/null &2>/dev/null
 
 # 6. Open PR
 hub pull-request -m "$PULL_REQUEST_TITLE"

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -25,7 +25,7 @@ cd homebrew
 git remote add upstream https://github.com/homebrew/homebrew.git
 git fetch upstream
 git rebase upstream/master
-git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git master >/dev/null &2>/dev/null
+git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git master &>/dev/null
 
 # 4. Create branch and update formula
 git checkout -b $BRANCH
@@ -35,7 +35,7 @@ git add .
 GIT_COMMITTER_NAME=$AUTHOR_NAME GIT_COMMITTER_EMAIL=$AUTHOR_EMAIL git commit --author="$AUTHOR_NAME <$AUTHOR_EMAIL>" -m "$COMMIT_MESSAGE"
 
 # 5. Publish branch
-git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git $BRANCH >/dev/null &2>/dev/null
+git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git $BRANCH &>/dev/null
 
 # 6. Open PR
 hub pull-request -m "$PULL_REQUEST_TITLE"

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -38,5 +38,4 @@ GIT_COMMITTER_NAME=$AUTHOR_NAME GIT_COMMITTER_EMAIL=$AUTHOR_EMAIL git commit --a
 git push -f -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/Carthage/homebrew.git $BRANCH &>/dev/null
 
 # 6. Open PR
-sleep 5 # Don't race with the push
-hub pull-request -m "$PULL_REQUEST_TITLE"
+hub pull-request -m "$PULL_REQUEST_TITLE" -b "master" -h "$BRANCH"

--- a/script/brew-publish
+++ b/script/brew-publish
@@ -17,7 +17,7 @@ COMMIT_MESSAGE="$PROJECT $TAG"
 PULL_REQUEST_TITLE="$PROJECT $TAG"
 
 # 2. Clone homebrew fork
-git clone https://github.com/Carthage/homebrew
+git clone https://github.com/Carthage/homebrew.git homebrew
 cd homebrew
 
 # 3. Update fork from master


### PR DESCRIPTION
Carthage performs much better than the native swift package manager with Xcode. So, why not create the same experience on Linux?
The implementation could be just like on OS X: Carthage just do the work of compiling, providing the user a compiled framework. And the IDE or editor plugins could help to integrate it.
For Linux compatibility, Carthage can create a specific format of package definition. There could a automatic tool to generate description from Xcode build schemes.