### PR TITLE
Redundant update fetches

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -904,6 +904,10 @@ public func cloneOrFetchProject(project: ProjectIdentifier, preferHTTPS: Bool, d
 				.flatMap(.Merge) { isRepository -> SignalProducer<(ProjectEvent?, NSURL), CarthageError> in
 					if isRepository {
 						let fetchProducer: () -> SignalProducer<(ProjectEvent?, NSURL), CarthageError> = {
+							guard FetchCache.needsFetch(forURL: remoteURL) else {
+								return SignalProducer(value: (nil, repositoryURL))
+							}
+
 							return SignalProducer(value: (.Fetching(project), repositoryURL))
 								.concat(fetchRepository(repositoryURL, remoteURL: remoteURL, refspec: "+refs/heads/*:refs/heads/*").then(.empty))
 						}


### PR DESCRIPTION
I don't believe there's an issue that tracks this. This is my attempt to reduce the amount of times we fetch a dependency.

This started occurring with the fix for #1202 (which was needed because I caused a regression for branches in my previous fetch optimization =/ )

What this change does is write out a custom config to the cache repo that specifies the last time carthage itself ran a fetch. Then we skip fetching if it occurred within the last minute. This avoids adding any state to Carthage in case of long running CarthageKit usage, but still optimizes the majority of cases where we're just looping through the dependencies and fetching them all during resolution.

The other approach I thought of that could be more accurate, but would require a lot more plumbing through the system, would be to maintain state, but only created at the point where the calls originate, e.g., a 'fetchedProjects' array that gets propagated through all the calls. I avoided this approach since it seemed like a lot of code change just to close up a 60 second window that likely wouldn't be hit,  but putting that alternative out there.

 