### PR TITLE
Ensure that we handle symbolic links correctly when filtering file paths for projects/workspaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Unless you’re specifically improving something about the command-line experien
 After checkout, you can run the following command from the cloned directory, and then open the workspace in Xcode:
 
 ```bash
-./script/bootstrap
+make bootstrap
 ```
 
 Then, to install your development copy of Carthage (and any local changes you've made) on your system, and test with your own repos:


### PR DESCRIPTION
Carthage’s behavior w/regards to locating projects/workspaces was dependent on the location of the directory the repository was cloned into.

In particular, with macs, if you clone a repository under the /tmp folder, that in fact is a symbolic link to /private/tmp, and will result in incorrect behavior when Carthage attempts to elide paths.

The crux of the problem was the usage of NSFileManager enumeration in locateProjectsInDirectory in conjuction with exclusion paths returned from invoking git commands.
The NSFileManager paths begin with “/private/tmp” while the git commands produce paths that begin with “/tmp”.

The cleanest solution is to use NSFileManager functionality (getRelationship), that tells us correctly if a path is indeed a child of another even in the case of symlinks.

The carthage NSURL extension (hasSubdirectory) does not correctly handle said cases, and it’s really not the appropriate approach in these instances.

FYI, we noticed this bug with several of our customers, as we place the customers' repositories under /tmp, while customers obviously would place them under their home directory.

The tickets often would ask us why there were unable to reproduce the issues mentioned above, and this is why.