### PR TITLE
Configured stdout to always flush the buffer at the end of each line

### DIFF
--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -13,6 +13,8 @@ import ReactiveCocoa
 import ReactiveTask
 import Result
 
+setlinebuf(stdout)
+
 guard ensureGitVersion().first()?.value == true else {
 	fputs("Carthage requires git \(CarthageRequiredGitVersion) or later.\n", stderr)
 	exit(EXIT_FAILURE)


### PR DESCRIPTION
Fixes [#1438](https://github.com/Carthage/Carthage/issues/1438)

The change makes `printf` flush it's buffer for every new line. This is standard behaviour when it runs in TTY, but when output is file or pipe, then the buffer mode changes to block buffering.

The solution tested and it works, but probably, calling `setlinebuf` in the beginning of `main.swift` is not the best idea. If you point out the right place for it, I can easily fix that.

Looking forward for any feedback.