### PR TITLE
Added "clean" to xcodebuild -showBuildSettings to work around rdar://27052195

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -476,7 +476,11 @@ public struct BuildSettings {
 	/// Upon .success, sends one BuildSettings value for each target included in
 	/// the referenced scheme.
 	public static func loadWithArguments(arguments: BuildArguments) -> SignalProducer<BuildSettings, CarthageError> {
-		// Including build action "clean" here, because otherwise Xcode 8 (at least in betas) will hang
+		// xcodebuild (in Xcode 8) has a bug where xcodebuild -showBuildSettings
+		// can hang indefinitely on projects that contain core data models.
+		// rdar://27052195
+		// Including the action "clean" works around this issue, which is further
+		// discussed here: https://forums.developer.apple.com/thread/50372
 		let task = xcodebuildTask(["clean", "-showBuildSettings"], arguments)
 
 		return launchTask(task)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -476,7 +476,8 @@ public struct BuildSettings {
 	/// Upon .success, sends one BuildSettings value for each target included in
 	/// the referenced scheme.
 	public static func loadWithArguments(arguments: BuildArguments) -> SignalProducer<BuildSettings, CarthageError> {
-		let task = xcodebuildTask("-showBuildSettings", arguments)
+		// Including build action "clean" here, because otherwise Xcode 8 (at least in betas) will hang
+		let task = xcodebuildTask(["clean", "-showBuildSettings"], arguments)
 
 		return launchTask(task)
 			.ignoreTaskData()


### PR DESCRIPTION
This is to work around an xcodebuild bug (rdar://27052195; introduced with xcode 8) that causes a complete hang if the target contains a core data model. Further discussion here:

https://forums.developer.apple.com/thread/50372

Credits for workaround to IngmarStein in dev forums