### PR TITLE
Fix crash when repository not found

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -322,14 +322,14 @@ public final class Project {
 		return cloneOrFetchDependency(project, commitish: reference)
 			.flatMap(.Concat) { _ in
 				return resolveTagInRepository(repositoryURL, reference)
-			}
-			.map { _ in
-				// If the reference is an exact tag, resolves it to the tag.
-				return PinnedVersion(reference)
-			}
-			.flatMapError { _ in
-				return resolveReferenceInRepository(repositoryURL, reference)
-					.map(PinnedVersion.init)
+					.map { _ in
+						// If the reference is an exact tag, resolves it to the tag.
+						return PinnedVersion(reference)
+					}
+					.flatMapError { _ in
+						return resolveReferenceInRepository(repositoryURL, reference)
+							.map(PinnedVersion.init)
+					}
 			}
 	}
 


### PR DESCRIPTION
Fixes #1324.

AFAICT this only happens when the repository doesn’t exist (or when you don’t have access to it, in which case it doesn’t appear to exist).