### PR TITLE
Default project directory to relative path "."

### DIFF
--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -28,7 +28,7 @@ public struct ArchiveCommand: CommandType {
 		public static func evaluate(m: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
 			return create
 				<*> m <| Option(key: "output", defaultValue: nil, usage: "the path at which to create the zip file (or blank to infer it from the first one of the framework names)")
-				<*> m <| Option(key: "project-directory", defaultValue: NSFileManager.defaultManager().currentDirectoryPath, usage: "the directory containing the Carthage project")
+				<*> m <| Option(key: "project-directory", defaultValue: ".", usage: "the directory containing the Carthage project")
 				<*> ColorOptions.evaluate(m)
 				<*> m <| Argument(defaultValue: [], usage: "the names of the built frameworks to archive without any extension (or blank to pick up the frameworks in the current project built by `--no-skip-current`)")
 		}


### PR DESCRIPTION
When creating framework archive as described in README.md: `carthage archive` full path from the root is recorded into the zip archive, which causes Carthage not to recognize archived framework upon installation.
The workaround is to use `--project-directory .` option, which causes relative paths to be recorded instead.
I've tracked down the issue to the default value of the `project-directory` being set to absolute path to current working directory via `NSFileManager.defaultManager().currentDirectoryPath` which causes all shell commands which use it to use absolute paths, zip in particular.

* `carthage version`: 0.17.2 (and HEAD too)
* `xcodebuild -version`: Xcode 7.3.1 Build version 7D1014
* Are you using `--no-build`? no
* Are you using `--no-use-binaries`? no
* Are you using `--use-submodules`? no

**Carthage Output**
```
 alex@Alexanders-MacBook-Pro-2 ~/P/stylight-ios-lib-2  $ carthage archive                                        2.17.1 
*** Found /Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework
*** Found /Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM
*** Found /Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/184D2C0E-E4A3-3864-9E69-36944768535D.bcsymbolmap
*** Found /Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/39E41894-040D-3404-8C2E-43132EF439B4.bcsymbolmap
*** Created StylightKit2.framework.zip
 alex@Alexanders-MacBook-Pro-2 ~/P/stylight-ios-lib-2  $ unzip -l StylightKit2.framework.zip                     2.17.1 
Archive:  StylightKit2.framework.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/
        0  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Headers/
      517  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Headers/StylightKit.h
    32194  08-24-16 15:58   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Headers/StylightKit2-Swift.h
      756  08-24-16 15:58   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Info.plist
        0  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/
       68  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/module.modulemap
        0  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/
      532  08-24-16 15:58   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/arm.swiftdoc
  1841612  08-24-16 15:58   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/arm.swiftmodule
      532  08-24-16 15:58   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/arm64.swiftdoc
  1821600  08-24-16 15:58   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/arm64.swiftmodule
      532  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/i386.swiftdoc
  1841736  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/i386.swiftmodule
      532  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/x86_64.swiftdoc
  1821748  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/Modules/StylightKit2.swiftmodule/x86_64.swiftmodule
 14176488  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework/StylightKit2
        0  07-01-16 22:40   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM/
        0  07-01-16 22:40   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM/Contents/
      654  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM/Contents/Info.plist
        0  07-01-16 22:40   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM/Contents/Resources/
        0  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM/Contents/Resources/DWARF/
 18026810  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/StylightKit2.framework.dSYM/Contents/Resources/DWARF/StylightKit2
   530862  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/184D2C0E-E4A3-3864-9E69-36944768535D.bcsymbolmap
   530955  08-24-16 15:59   Users/alex/Projects/stylight-ios-lib-2/Carthage/Build/iOS/39E41894-040D-3404-8C2E-43132EF439B4.bcsymbolmap
 --------                   -------
 40628128                   25 files
```
