### PR TITLE
Use `NSURL.URLByStandardizingPath` in `NSURL.hasSubdirectory` extension

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -295,7 +295,15 @@ extension NSURL {
 	}
 
 	public func hasSubdirectory(possibleSubdirectory: NSURL) -> Bool {
-		if scheme == possibleSubdirectory.scheme, let path = self.pathComponents, otherPath = possibleSubdirectory.pathComponents where path.count <= otherPath.count {
+		let standardizedSelf = self.URLByStandardizingPath ?? self
+		let standardizedOther = possibleSubdirectory.URLByStandardizingPath ?? possibleSubdirectory
+
+		if
+			scheme == standardizedOther.scheme,
+			let path = standardizedSelf.pathComponents,
+			let otherPath = standardizedOther.pathComponents
+			where path.count <= otherPath.count
+		{
 			return Array(otherPath[path.indices]) == path
 		}
 		return false

--- a/Source/CarthageKitTests/FrameworkExtensionsSpec.swift
+++ b/Source/CarthageKitTests/FrameworkExtensionsSpec.swift
@@ -20,6 +20,26 @@ class FrameworkExtensionsSpec: QuickSpec {
 				expect(subject.hasSubdirectory(distantSub)) == true
 				expect(subject.hasSubdirectory(unrelatedDirectory)) == false
 			}
+
+			context("`hasSubdirectory` with /tmp and /private/tmp") {
+				let baseName = "/tmp/CarthageKitTests-NSURL-hasSubdirectory"
+				let parentDirUnderTmp = NSURL(fileURLWithPath: baseName)
+				let childDirUnderPrivateTmp = NSURL(fileURLWithPath: "/private\(baseName)/foo")
+
+				beforeEach {
+					_ = try? NSFileManager.defaultManager()
+						.createDirectoryAtURL(childDirUnderPrivateTmp, withIntermediateDirectories: true, attributes: nil)
+				}
+
+				afterEach {
+					_ = try? NSFileManager.defaultManager()
+						.removeItemAtURL(parentDirUnderTmp)
+				}
+
+				it("should resolve the difference between /tmp and /private/tmp") {
+					expect(parentDirUnderTmp.hasSubdirectory(childDirUnderPrivateTmp)) == true
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This should be a simpler solution for the issue described in #1431.

https://developer.apple.com/reference/foundation/nsurl/1414302-standardizingpath

> - Expand an initial tilde expression using stringByExpandingTildeInPath.
> - Reduce empty components and references to the current directory (that is, the sequences “//” and “/./”) to single path separators.
> - In absolute paths only, resolve references to the parent directory (that is, the component “..”) to the real parent directory if possible using stringByResolvingSymlinksInPath, which consults the file system to resolve each potential symbolic link.
>     In relative paths, because symbolic links can’t be resolved, references to the parent directory are left in place.
> - **Remove an initial component of “/private” from the path if the result still indicates an existing file or directory (checked by consulting the file system).**
