### PR TITLE
Fix how tags are listed.

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -235,7 +235,7 @@ public func fetchRepository(repositoryFileURL: NSURL, remoteURL: GitURL? = nil, 
 
 /// Sends each tag found in the given Git repository.
 public func listTags(repositoryFileURL: NSURL) -> SignalProducer<String, CarthageError> {
-	return launchGitTask([ "tag" ], repositoryFileURL: repositoryFileURL)
+	return launchGitTask([ "tag", "--column=never" ], repositoryFileURL: repositoryFileURL)
 		.flatMap(.Concat) { (allTags: String) -> SignalProducer<String, CarthageError> in
 			return SignalProducer { observer, disposable in
 				allTags.enumerateSubstringsInRange(allTags.characters.indices, options: [ .ByLines, .Reverse ]) { line, substringRange, enclosingRange, stop in


### PR DESCRIPTION
* `carthage version`: `0.16.2`
* `xcodebuild -version`: 
```
Xcode 7.3.1
Build version 7D1014
```
* Are you using `--no-build`? *No*
* Are you using `--no-use-binaries`? *Yes*
* Are you using `--use-submodules`? *No*

**Cartfile**
```
github "Alamofire/Alamofire" ~> 3.4
```

**Carthage Output**
```
*** Fetching Alamofire
*** Checking out Alamofire at "1.2.0         2.0.0-beta.3  3.1.0         3.3.1"
*** Fetching Alamofire
A shell task (/usr/bin/env git checkout --quiet --force 1.2.0         2.0.0-beta.3  3.1.0         3.3.1) failed with exit code 1:
error: pathspec '1.2.0         2.0.0-beta.3  3.1.0         3.3.1' did not match any file(s) known to git.
```

---

This is happening because the command intended to list all of the tags doesn't
take into account the possibility of the end user's setting (that being
`column.ui` set to `always`). 

Example with `git tag` and vanilla options:

```bash
$ git tag
v1
v2
v3
```

Example with `git tag` and `column.ui = always`:
```bash
$ git tag
v1  v2  v3
```

Example with `git tag --column=never` and `column.ui = always`:
```bash
$ git tag --column=never
v1
v2
v3
```

Oddly enough, this all worked fine when I just ran to update `Alamofire`
by itself:

```bash
$ carthage update Alamofire
*** Fetching Alamofire
*** Checking out Alamofire at "3.4.2"
*** Building scheme "Alamofire watchOS" in Alamofire.xcworkspace
```