### PR TITLE
Replace quotation with apostrophe

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -27,7 +27,7 @@ extension BuildOptions: OptionsType {
 	public static func evaluate(m: CommandMode, addendum: String) -> Result<BuildOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build" + addendum)
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of 'all’, 'Mac’, 'iOS’, 'watchOS’, 'tvOS', or comma-separated values of the formers except for 'all’)" + addendum)
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of 'all', 'Mac', 'iOS', 'watchOS', 'tvOS', or comma-separated values of the formers except for 'all')" + addendum)
 			<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 			<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 	}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -27,7 +27,7 @@ extension BuildOptions: OptionsType {
 	public static func evaluate(m: CommandMode, addendum: String) -> Result<BuildOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build" + addendum)
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of ‘all’, ‘Mac’, ‘iOS’, ‘watchOS’, 'tvOS', or comma-separated values of the formers except for ‘all’)" + addendum)
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of 'all’, 'Mac’, 'iOS’, 'watchOS’, 'tvOS', or comma-separated values of the formers except for 'all’)" + addendum)
 			<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 			<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 	}

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -92,6 +92,6 @@ public struct ColorOptions: OptionsType {
 	
 	public static func evaluate(m: CommandMode) -> Result<ColorOptions, CommandantError<CarthageError>> {
 		return create
-			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply color and terminal formatting (one of ‘auto’, ‘always’, or ‘never’)")
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply color and terminal formatting (one of 'auto’, 'always’, or 'never’)")
 	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -92,6 +92,6 @@ public struct ColorOptions: OptionsType {
 	
 	public static func evaluate(m: CommandMode) -> Result<ColorOptions, CommandantError<CarthageError>> {
 		return create
-			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply color and terminal formatting (one of 'auto’, 'always’, or 'never’)")
+			<*> m <| Option(key: "color", defaultValue: ColorArgument.Auto, usage: "whether to apply color and terminal formatting (one of 'auto', 'always', or 'never')")
 	}
 }


### PR DESCRIPTION
When executing `carthage help`, it outputs four kinds of quotation.
It would be nice to use only apostrophe (\u0027) for this.

| Before | After |
| :---: | :---: |
| ![screen shot 2016-09-14 at 1 28 06 pm](https://cloud.githubusercontent.com/assets/932290/18500054/1f7ecd12-7a7f-11e6-80ca-2e177026004b.png) | ![screen shot 2016-09-14 at 1 27 05 pm](https://cloud.githubusercontent.com/assets/932290/18500052/1eb89188-7a7f-11e6-8582-0ea910863dd7.png) |
| Full output (carthage help build) | Full output (carthage help build) |
| ![screen shot 2016-09-14 at 12 54 42 pm](https://cloud.githubusercontent.com/assets/932290/18499981/a5e2f41a-7a7e-11e6-9e3c-61b164ab7baf.png) | ![screen shot 2016-09-14 at 12 47 16 pm](https://cloud.githubusercontent.com/assets/932290/18499986/abc51886-7a7e-11e6-9da5-2affc267caff.png) |

