### PR TITLE
add support for schemes with spaces

### DIFF
--- a/Source/CarthageKit/BuildArguments.swift
+++ b/Source/CarthageKit/BuildArguments.swift
@@ -53,7 +53,7 @@ public struct BuildArguments {
 		}
 
 		if let scheme = scheme {
-			args += [ "-scheme", scheme ]
+			args += [ "-scheme", "\"\(scheme)\"" ]
 		}
 
 		if let configuration = configuration {


### PR DESCRIPTION
Some projects, e.g. SwiftyJSON, use scheme names like "SwiftyJSON tvOS", which need to be put in quotation marks because of the space