### PR TITLE
Before symlinking, filter submodules in `CarthageProjectCheckoutsPath` which would conflict with dependencies.

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -263,7 +263,9 @@ public func contentsOfFileInRepository(repositoryFileURL: NSURL, _ path: String,
 /// Checks out the working tree of the given (ideally bare) repository, at the
 /// specified revision, to the given folder. If the folder does not exist, it
 /// will be created.
-public func checkoutRepositoryToDirectory(repositoryFileURL: NSURL, _ workingDirectoryURL: NSURL, revision: String = "HEAD", shouldCloneSubmodule: Submodule -> Bool = { _ in true }) -> SignalProducer<(), CarthageError> {
+///
+/// Submodules of the working tree must be handled seperately.
+public func checkoutRepositoryToDirectory(repositoryFileURL: NSURL, _ workingDirectoryURL: NSURL, revision: String = "HEAD") -> SignalProducer<(), CarthageError> {
 	return SignalProducer.attempt { () -> Result<[String: String], CarthageError> in
 			do {
 				try NSFileManager.defaultManager().createDirectoryAtURL(workingDirectoryURL, withIntermediateDirectories: true, attributes: nil)
@@ -276,21 +278,7 @@ public func checkoutRepositoryToDirectory(repositoryFileURL: NSURL, _ workingDir
 			return .Success(environment)
 		}
 		.flatMap(.Concat) { environment in launchGitTask([ "checkout", "--quiet", "--force", revision ], repositoryFileURL: repositoryFileURL, environment: environment) }
-		.then(cloneSubmodulesForRepository(repositoryFileURL, workingDirectoryURL, revision: revision, shouldCloneSubmodule: shouldCloneSubmodule))
-}
-
-/// Clones matching submodules for the given repository at the specified
-/// revision, into the given working directory.
-public func cloneSubmodulesForRepository(repositoryFileURL: NSURL, _ workingDirectoryURL: NSURL, revision: String = "HEAD", shouldCloneSubmodule: Submodule -> Bool = { _ in true }) -> SignalProducer<(), CarthageError> {
-	return submodulesInRepository(repositoryFileURL, revision: revision)
-		.flatMap(.Concat) { submodule -> SignalProducer<(), CarthageError> in
-			if shouldCloneSubmodule(submodule) {
-				return cloneSubmoduleInWorkingDirectory(submodule, workingDirectoryURL)
-			} else {
-				return .empty
-			}
-		}
-		.filter { _ in false }
+		.then(.empty)
 }
 
 /// Clones the given submodule into the working directory of its parent

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -703,8 +703,8 @@ public final class Project {
 		let symlinksProducer = self.dependenciesForDependency(dependency)
 			.zipWith( // file system objects from git in `CarthageProjectCheckoutsPath` which might conflict with symlinks.
 				launchGitTask(
-					[ "ls-files", "--full-name", "-z", dependency.version.commitish, CarthageProjectCheckoutsPath ],
-					repositoryFileURL: self.directoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
+					[ "ls-tree", "--full-name", "-z", dependency.version.commitish, CarthageProjectCheckoutsPath ],
+					repositoryFileURL:self.directoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
 				)
 					.map { (output: String) -> [String] in
 						output.characters

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -703,8 +703,8 @@ public final class Project {
 		let symlinksProducer = self.dependenciesForDependency(dependency)
 			.zipWith( // file system objects from git in `CarthageProjectCheckoutsPath` which might conflict with symlinks.
 				launchGitTask(
-					[ "ls-tree", "--full-name", "-z", dependency.version.commitish, CarthageProjectCheckoutsPath ],
-					repositoryFileURL:self.directoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
+					[ "ls-files", "--full-name", "-z", dependency.version.commitish, CarthageProjectCheckoutsPath ],
+					repositoryFileURL: self.directoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
 				)
 					.map { (output: String) -> [String] in
 						output.characters

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -690,19 +690,12 @@ public final class Project {
 		let symlinksProducer = SignalProducer(values: subDependencyNames)
 			.filter { name in
 				let checkoutURL = rootCheckoutsURL.appendingPathComponent(name)
-				let isDirectory: Bool
-				do {
-					var value: AnyObject?
-					try checkoutURL.getResourceValue(&value, forKey: NSURLIsDirectoryKey)
-					if let value = value {
-						isDirectory = value.boolValue
-					} else {
-						return false
-					}
-				} catch {
+				var value: AnyObject?
+				if let _ = try? checkoutURL.getResourceValue(&value, forKey: NSURLIsDirectoryKey), let value = value {
+					return value.boolValue
+				} else {
 					return false
 				}
-				return isDirectory
 			}
 			.attemptMap { name -> Result<(), CarthageError> in
 				let dependencyCheckoutURL = dependencyCheckoutsURL.appendingPathComponent(name)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -571,26 +571,54 @@ public final class Project {
 		return cloneOrFetchDependency(project, commitish: revision)
 			.flatMap(.Merge) { repositoryURL -> SignalProducer<(), CarthageError> in
 				let workingDirectoryURL = self.directoryURL.appendingPathComponent(project.relativePath, isDirectory: true)
-				var submodule: Submodule?
 				
-				if var foundSubmodule = submodulesByPath[project.relativePath] {
-					foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
-					foundSubmodule.SHA = revision
-					submodule = foundSubmodule
-				} else if self.useSubmodules {
-					submodule = Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
+				/// Filter out submodules in `CarthageProjectCheckoutsPath` which would conflict with dependencies.
+				func filter(dependencies: Set<ProjectIdentifier>, by submodules: [Submodule]) -> [ProjectIdentifier] {
+					return dependencies.filter { identifier in
+						!(submodules.filter { (submodule: Submodule) -> Bool in
+							submodule.path.characters.prefix(9).last == .Some("/") && String(
+								submodule.path.characters.prefix(CarthageProjectCheckoutsPath.characters.count)
+							).caseInsensitiveCompare(CarthageProjectCheckoutsPath) == .OrderedSame
+						}.map { $0.name } as [String]).contains(identifier.name)
+					}
 				}
 				
-				if let submodule = submodule {
-					return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
+				/// The submodule for an already existing submodule at dependency project’s path
+				/// or the submodule to be added at this path given the `--use-submodules` flag.
+				func submodule() -> Submodule? {
+					if var foundSubmodule = submodulesByPath[project.relativePath] {
+						foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
+						foundSubmodule.SHA = revision
+						return foundSubmodule
+					} else if self.useSubmodules {
+						return Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
+					} else {
+						return nil
+					}
+				}
+				
+				let signal: SignalProducer<Submodule, CarthageError>
+				
+				if let submodule = submodule() {
+					// Submodules for subdependencies of `project` are recursed through and initialized by git.
+					signal = addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
 						.startOnQueue(self.gitOperationQueue)
+						.then(submodulesInRepository(self.directoryURL, revision: revision))
 				} else {
-					return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
-						.then(self.dependenciesForDependency(dependency))
-						.flatMap(.Merge) { dependencies in
-							return self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: dependencies, rootDirectoryURL: self.directoryURL)
+					signal = checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
+						.then(submodulesInRepository(self.directoryURL, revision: revision))
+						.attempt /* just for side effects */ {
+							// For checkouts of “ideally bare” depositories, we clone submodules for subdependencies ourselves.
+							cloneSubmoduleInWorkingDirectory($0, workingDirectoryURL).single()!
 						}
 				}
+				
+				return signal.collect().flatMap(.Merge) { submodules in
+					// Symlink dependencies which do not match submodules.
+					self.dependenciesForDependency(dependency).flatMap(.Merge) { dependencies in
+						self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: filter(dependencies, by: submodules), rootDirectoryURL: self.directoryURL)
+					}
+				}.then(.empty)
 			}
 			.on(started: {
 				self._projectEventsObserver.sendNext(.CheckingOut(project, revision))
@@ -679,7 +707,7 @@ public final class Project {
 	}
 
 	/// Creates symlink between the dependency checkouts and the root checkouts
-	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: Set<ProjectIdentifier>, rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
+	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: [ProjectIdentifier], rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
 		let rootCheckoutsURL = rootDirectoryURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).URLByResolvingSymlinksInPath!
 		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 		let dependencyURL = rawDependencyURL.URLByResolvingSymlinksInPath!

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -571,6 +571,8 @@ public final class Project {
 		return cloneOrFetchDependency(project, commitish: revision)
 			.flatMap(.Merge) { repositoryURL -> SignalProducer<(), CarthageError> in
 				let workingDirectoryURL = self.directoryURL.appendingPathComponent(project.relativePath, isDirectory: true)
+				/// The submodule for an already existing submodule at dependency project’s path
+				/// or the submodule to be added at this path given the `--use-submodules` flag.
 				var submodule: Submodule?
 				
 				if var foundSubmodule = submodulesByPath[project.relativePath] {
@@ -581,16 +583,41 @@ public final class Project {
 					submodule = Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
 				}
 				
-				if let submodule = submodule {
-					return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
-						.startOnQueue(self.gitOperationQueue)
-				} else {
-					return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
-						.then(self.dependenciesForDependency(dependency))
-						.flatMap(.Merge) { dependencies in
-							return self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: dependencies, rootDirectoryURL: self.directoryURL)
-						}
+				/// Filter out submodules in `CarthageProjectCheckoutsPath` which would conflict with dependencies.
+				func filter(dependencies: Set<ProjectIdentifier>, by submodules: [Submodule]) -> [ProjectIdentifier] {
+					return dependencies.filter { identifier in
+						!(submodules.filter { (submodule: Submodule) -> Bool in
+							submodule.path.characters.prefix(9).last == .Some("/") && String(
+								submodule.path.characters.prefix(CarthageProjectCheckoutsPath.characters.count)
+							).caseInsensitiveCompare(CarthageProjectCheckoutsPath) == .OrderedSame
+						}.map { $0.name } as [String]).contains(identifier.name)
+					}
 				}
+				
+				let (checkoutOrClone, potentiallyCloneSubmoduleInWorkingDirectory): (
+					SignalProducer<(), CarthageError>,
+					(Submodule) -> SignalProducer<(), CarthageError>
+				) = submodule.map {
+					(
+						addSubmoduleToRepository(self.directoryURL, $0, GitURL(repositoryURL.path!)).startOnQueue(self.gitOperationQueue),
+						{ _ in return .empty } // No-op — submodules are recursed through and initialized by git, in above call
+					)
+				} ?? /* Otherwise, for checkouts of “ideally bare” depositories, we clone submodules ourselves. */ (
+					checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision),
+					{ return cloneSubmoduleInWorkingDirectory($0, workingDirectoryURL) }
+				)
+				
+				return checkoutOrClone.then(
+					submodulesInRepository(self.directoryURL, revision: revision)
+						.attempt /* just for side effects */ {
+							potentiallyCloneSubmoduleInWorkingDirectory($0).single()!
+						}.collect().flatMap(.Merge) { submodules in
+							// Symlink dependencies which do not match submodules.
+							self.dependenciesForDependency(dependency).flatMap(.Merge) { dependencies in
+								self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: filter(dependencies, by: submodules), rootDirectoryURL: self.directoryURL)
+							}
+						}
+				).then(.empty)
 			}
 			.on(started: {
 				self._projectEventsObserver.sendNext(.CheckingOut(project, revision))
@@ -679,7 +706,7 @@ public final class Project {
 	}
 
 	/// Creates symlink between the dependency checkouts and the root checkouts
-	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: Set<ProjectIdentifier>, rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
+	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: [ProjectIdentifier], rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
 		let rootCheckoutsURL = rootDirectoryURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).URLByResolvingSymlinksInPath!
 		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 		let dependencyURL = rawDependencyURL.URLByResolvingSymlinksInPath!

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -690,12 +690,19 @@ public final class Project {
 		let symlinksProducer = SignalProducer(values: subDependencyNames)
 			.filter { name in
 				let checkoutURL = rootCheckoutsURL.appendingPathComponent(name)
-				var value: AnyObject?
-				if let _ = try? checkoutURL.getResourceValue(&value, forKey: NSURLIsDirectoryKey), let value = value {
-					return value.boolValue
-				} else {
+				let isDirectory: Bool
+				do {
+					var value: AnyObject?
+					try checkoutURL.getResourceValue(&value, forKey: NSURLIsDirectoryKey)
+					if let value = value {
+						isDirectory = value.boolValue
+					} else {
+						return false
+					}
+				} catch {
 					return false
 				}
+				return isDirectory
 			}
 			.attemptMap { name -> Result<(), CarthageError> in
 				let dependencyCheckoutURL = dependencyCheckoutsURL.appendingPathComponent(name)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -571,26 +571,40 @@ public final class Project {
 		return cloneOrFetchDependency(project, commitish: revision)
 			.flatMap(.Merge) { repositoryURL -> SignalProducer<(), CarthageError> in
 				let workingDirectoryURL = self.directoryURL.appendingPathComponent(project.relativePath, isDirectory: true)
-				var submodule: Submodule?
 				
-				if var foundSubmodule = submodulesByPath[project.relativePath] {
-					foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
-					foundSubmodule.SHA = revision
-					submodule = foundSubmodule
-				} else if self.useSubmodules {
-					submodule = Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
+				/// The submodule for an already existing submodule at dependency project’s path
+				/// or the submodule to be added at this path given the `--use-submodules` flag.
+				func submodule() -> Submodule? {
+					if var foundSubmodule = submodulesByPath[project.relativePath] {
+						foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
+						foundSubmodule.SHA = revision
+						return foundSubmodule
+					} else if self.useSubmodules {
+						return Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
+					} else {
+						return nil
+					}
 				}
 				
-				if let submodule = submodule {
-					return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
+				let checkoutOrCloneDependency: SignalProducer<(), CarthageError>
+				
+				if let submodule = submodule() {
+					// Submodules for subdependencies of `project` are recursed through and initialized by git.
+					checkoutOrCloneDependency = addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
 						.startOnQueue(self.gitOperationQueue)
 				} else {
-					return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
-						.then(self.dependenciesForDependency(dependency))
-						.flatMap(.Merge) { dependencies in
-							return self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: dependencies, rootDirectoryURL: self.directoryURL)
-						}
+					checkoutOrCloneDependency = checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
+						.then(
+							submodulesInRepository(self.directoryURL, revision: revision)
+								.flatMap(.Merge) {
+									// For checkouts of “ideally bare” depositories, we clone submodules for subdependencies ourselves.
+									cloneSubmoduleInWorkingDirectory($0, workingDirectoryURL)
+								}
+						)
 				}
+				
+				return checkoutOrCloneDependency
+					.then(self.symlinkCheckoutPathsForDependencyProject(dependency, rootDirectoryURL: self.directoryURL))
 			}
 			.on(started: {
 				self._projectEventsObserver.sendNext(.CheckingOut(project, revision))
@@ -679,15 +693,51 @@ public final class Project {
 	}
 
 	/// Creates symlink between the dependency checkouts and the root checkouts
-	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: Set<ProjectIdentifier>, rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
+	private func symlinkCheckoutPathsForDependencyProject(dependency: Dependency<PinnedVersion>, rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
 		let rootCheckoutsURL = rootDirectoryURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).URLByResolvingSymlinksInPath!
-		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
+		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
 		let dependencyURL = rawDependencyURL.URLByResolvingSymlinksInPath!
 		let dependencyCheckoutsURL = dependencyURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).URLByResolvingSymlinksInPath!
-		let subDependencyNames = subDependencies.map { $0.name }
 		let fileManager = NSFileManager.defaultManager()
 
-		let symlinksProducer = SignalProducer(values: subDependencyNames)
+		let symlinksProducer = self.dependenciesForDependency(dependency)
+			.zipWith( // file system objects from git in `CarthageProjectCheckoutsPath` which might conflict with symlinks.
+				launchGitTask(
+					[ "ls-tree", "--full-name", "-z", dependency.version.commitish, CarthageProjectCheckoutsPath ],
+					repositoryFileURL:self.directoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
+				)
+					.map { (output: String) -> [String] in
+						output.characters
+							.split(allowEmptySlices: false) { $0 == "\0" }
+							.map { String($0) }
+							.flatMap { (path: String) -> String? in
+								let componentsRelativeToDirectoryURL = {
+									return NSURL(string: $0, relativeToURL: self.directoryURL)?.URLByStandardizingPath?.pathComponents
+								}
+								if
+									let components = componentsRelativeToDirectoryURL(path),
+									let comparator = componentsRelativeToDirectoryURL(CarthageProjectCheckoutsPath)
+									where (components.count == comparator.count + 1) && Array(components.prefix(comparator.count)) == comparator
+								{
+									return components.last!
+								} else {
+									return nil
+								}
+							}
+					}
+			)
+			.flatMap(.Merge) { (dependencies: Set<ProjectIdentifier>, components: [String]) -> SignalProducer<ProjectIdentifier, CarthageError> in
+					.init(values: dependencies.filter { dependency in
+						// Filter out dependencies with names matching (case-insensitively) file system objects from git in `CarthageProjectCheckoutsPath`.
+						// Edge case warning on file system case-sensitivity. If a differently-cased file system object exists in git
+						// and is stored on a case-sensitive file system (like the Sierra preview of APFS), we currently preempt
+						// the non-conflicting symlink. Probably, nobody actually desires or needs the opposite behavior.
+						components.filter {
+							dependency.name.caseInsensitiveCompare($0) == .OrderedSame
+						}.isEmpty
+					})
+			}
+			.map { $0.name }
 			.filter { name in
 				let checkoutURL = rootCheckoutsURL.appendingPathComponent(name)
 				var value: AnyObject?
@@ -700,7 +750,7 @@ public final class Project {
 			.attemptMap { name -> Result<(), CarthageError> in
 				let dependencyCheckoutURL = dependencyCheckoutsURL.appendingPathComponent(name)
 				let subdirectoryPath = (CarthageProjectCheckoutsPath as NSString).stringByAppendingPathComponent(name)
-				let linkDestinationPath = relativeLinkDestinationForDependencyProject(dependency, subdirectory: subdirectoryPath)
+				let linkDestinationPath = relativeLinkDestinationForDependencyProject(dependency.project, subdirectory: subdirectoryPath)
 				do {
 					try fileManager.createSymbolicLinkAtPath(dependencyCheckoutURL.path!, withDestinationPath: linkDestinationPath)
 				} catch let error as NSError {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -571,40 +571,26 @@ public final class Project {
 		return cloneOrFetchDependency(project, commitish: revision)
 			.flatMap(.Merge) { repositoryURL -> SignalProducer<(), CarthageError> in
 				let workingDirectoryURL = self.directoryURL.appendingPathComponent(project.relativePath, isDirectory: true)
+				var submodule: Submodule?
 				
-				/// The submodule for an already existing submodule at dependency project’s path
-				/// or the submodule to be added at this path given the `--use-submodules` flag.
-				func submodule() -> Submodule? {
-					if var foundSubmodule = submodulesByPath[project.relativePath] {
-						foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
-						foundSubmodule.SHA = revision
-						return foundSubmodule
-					} else if self.useSubmodules {
-						return Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
-					} else {
-						return nil
-					}
+				if var foundSubmodule = submodulesByPath[project.relativePath] {
+					foundSubmodule.URL = repositoryURLForProject(project, preferHTTPS: self.preferHTTPS)
+					foundSubmodule.SHA = revision
+					submodule = foundSubmodule
+				} else if self.useSubmodules {
+					submodule = Submodule(name: project.relativePath, path: project.relativePath, URL: repositoryURLForProject(project, preferHTTPS: self.preferHTTPS), SHA: revision)
 				}
 				
-				let checkoutOrCloneDependency: SignalProducer<(), CarthageError>
-				
-				if let submodule = submodule() {
-					// Submodules for subdependencies of `project` are recursed through and initialized by git.
-					checkoutOrCloneDependency = addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
+				if let submodule = submodule {
+					return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path!))
 						.startOnQueue(self.gitOperationQueue)
 				} else {
-					checkoutOrCloneDependency = checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
-						.then(
-							submodulesInRepository(self.directoryURL, revision: revision)
-								.flatMap(.Merge) {
-									// For checkouts of “ideally bare” depositories, we clone submodules for subdependencies ourselves.
-									cloneSubmoduleInWorkingDirectory($0, workingDirectoryURL)
-								}
-						)
+					return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
+						.then(self.dependenciesForDependency(dependency))
+						.flatMap(.Merge) { dependencies in
+							return self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: dependencies, rootDirectoryURL: self.directoryURL)
+						}
 				}
-				
-				return checkoutOrCloneDependency
-					.then(self.symlinkCheckoutPathsForDependencyProject(dependency, rootDirectoryURL: self.directoryURL))
 			}
 			.on(started: {
 				self._projectEventsObserver.sendNext(.CheckingOut(project, revision))
@@ -693,51 +679,15 @@ public final class Project {
 	}
 
 	/// Creates symlink between the dependency checkouts and the root checkouts
-	private func symlinkCheckoutPathsForDependencyProject(dependency: Dependency<PinnedVersion>, rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
+	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: Set<ProjectIdentifier>, rootDirectoryURL: NSURL) -> SignalProducer<(), CarthageError> {
 		let rootCheckoutsURL = rootDirectoryURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).URLByResolvingSymlinksInPath!
-		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
+		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 		let dependencyURL = rawDependencyURL.URLByResolvingSymlinksInPath!
 		let dependencyCheckoutsURL = dependencyURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).URLByResolvingSymlinksInPath!
+		let subDependencyNames = subDependencies.map { $0.name }
 		let fileManager = NSFileManager.defaultManager()
 
-		let symlinksProducer = self.dependenciesForDependency(dependency)
-			.zipWith( // file system objects from git in `CarthageProjectCheckoutsPath` which might conflict with symlinks.
-				launchGitTask(
-					[ "ls-tree", "--full-name", "-z", dependency.version.commitish, CarthageProjectCheckoutsPath ],
-					repositoryFileURL:self.directoryURL.appendingPathComponent(dependency.project.relativePath, isDirectory: true)
-				)
-					.map { (output: String) -> [String] in
-						output.characters
-							.split(allowEmptySlices: false) { $0 == "\0" }
-							.map { String($0) }
-							.flatMap { (path: String) -> String? in
-								let componentsRelativeToDirectoryURL = {
-									return NSURL(string: $0, relativeToURL: self.directoryURL)?.URLByStandardizingPath?.pathComponents
-								}
-								if
-									let components = componentsRelativeToDirectoryURL(path),
-									let comparator = componentsRelativeToDirectoryURL(CarthageProjectCheckoutsPath)
-									where (components.count == comparator.count + 1) && Array(components.prefix(comparator.count)) == comparator
-								{
-									return components.last!
-								} else {
-									return nil
-								}
-							}
-					}
-			)
-			.flatMap(.Merge) { (dependencies: Set<ProjectIdentifier>, components: [String]) -> SignalProducer<ProjectIdentifier, CarthageError> in
-					.init(values: dependencies.filter { dependency in
-						// Filter out dependencies with names matching (case-insensitively) file system objects from git in `CarthageProjectCheckoutsPath`.
-						// Edge case warning on file system case-sensitivity. If a differently-cased file system object exists in git
-						// and is stored on a case-sensitive file system (like the Sierra preview of APFS), we currently preempt
-						// the non-conflicting symlink. Probably, nobody actually desires or needs the opposite behavior.
-						components.filter {
-							dependency.name.caseInsensitiveCompare($0) == .OrderedSame
-						}.isEmpty
-					})
-			}
-			.map { $0.name }
+		let symlinksProducer = SignalProducer(values: subDependencyNames)
 			.filter { name in
 				let checkoutURL = rootCheckoutsURL.appendingPathComponent(name)
 				var value: AnyObject?
@@ -750,7 +700,7 @@ public final class Project {
 			.attemptMap { name -> Result<(), CarthageError> in
 				let dependencyCheckoutURL = dependencyCheckoutsURL.appendingPathComponent(name)
 				let subdirectoryPath = (CarthageProjectCheckoutsPath as NSString).stringByAppendingPathComponent(name)
-				let linkDestinationPath = relativeLinkDestinationForDependencyProject(dependency.project, subdirectory: subdirectoryPath)
+				let linkDestinationPath = relativeLinkDestinationForDependencyProject(dependency, subdirectory: subdirectoryPath)
 				do {
 					try fileManager.createSymbolicLinkAtPath(dependencyCheckoutURL.path!, withDestinationPath: linkDestinationPath)
 				} catch let error as NSError {


### PR DESCRIPTION
Previously, no symlinks would be created in projects handled as submodules through the `--use-submodules` flag. See #1484, thoughtbot/Argo#412.

`checkoutRepositoryToDirectory` no longer handles submodules of inputted repository's working tree. Remove currently never-overridden `shouldCloneSubmodule: Submodule -> Bool = { _ in true }` in `checkoutRepositoryToDirectory`.
`cloneSubmodulesForRepository` removed, `cloneOrFetchDependency` subsumes behavior for all pre-existing code paths.

<strike>In `symlinkCheckoutPathsForDependencyProject`, input array of `ProjectIdentifier`, rather than set solely because `CollectionType.filter` returns an array.</strike>

In `symlinkCheckoutPathsForDependencyProject`, input dependency of `Dependency<PinnedVersion>` and no longer input  subDependencies of `Set<ProjectIdentifier>`.

---

This passes `XCTest`s locally for me and fixes (at least, in simple local tests) the issue with projects (like Argo) handled as submodules through the `--use-submodules` flag. Adding an integration test to verify this and prevent regressions is probably a good idea.

<details>
<summary>

Argo Fix · Repro/Shell Output</summary>



``` shell
~ $   cd /tmp; mkdir-and-cd "thoughtbot-argo — $(nice-date)"

/tmp/thoughtbot-argo — 09-21-16 — 10·00AM
$ echo 'github "thoughtbot/Argo" "4b57653"' >! Cartfile

/tmp/thoughtbot-argo — 09-21-16 — 10·00AM
$ git init
Initialized empty Git repository in /private/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/.git/

/tmp/thoughtbot-argo — 09-21-16 — 10·00AM - [master●]
$ git add .

/tmp/thoughtbot-argo — 09-21-16 — 10·00AM - [master●]
$ git commit -m 'Initialize repository.'
[master (root-commit) 4e2068c] Initialize repository.
 1 file changed, 1 insertion(+)
 create mode 100644 Cartfile

/tmp/thoughtbot-argo — 09-21-16 — 10·00AM - [master]
$ "/Users/jdhealy/Code/Carthage/DerivedData/Carthage/Build/Products/Debug/carthage" bootstrap --use-submodules --platform Mac --verbose
*** No Cartfile.resolved found, updating dependencies
*** Fetching Runes
*** Checking out Runes at "e00cf681ec03a2dbf2b4cd6dd1e24d522f55474b"
*** Checking out Argo at "4b57653f7760bd3eedfd1c1fbc821bde191e603d"
*** Building scheme "Runes-Mac" in Runes.xcodeproj
/usr/bin/xcrun xcodebuild -project "/private/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Runes.xcodeproj" -scheme Runes-Mac -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean buildBuild settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY =
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO

=== CLEAN TARGET Runes-Mac OF PROJECT Runes WITH CONFIGURATION Release ===

Check dependencies

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Headers
/bin/ln -sfh Versions/Current/Runes /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Runes

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework.dSYM
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework.dSYM

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build

** CLEAN SUCCEEDED **

=== BUILD TARGET Runes-Mac OF PROJECT Runes WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/all-product-headers.yaml
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Mac-OutputFileMap.json
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/swift-overrides.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.LinkFileList
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/module.modulemap
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/Runes_vers.c
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module-overlay.yaml

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Headers
/bin/ln -sfh Versions/Current/Runes /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Runes

ProcessInfoPlistFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Resources/Info.plist Resources/Info.plist
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    builtin-infoPlistUtility /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Resources/Info.plist -expandbuildsettings -platform macosx -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Resources/Info.plist

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -incremental -module-name Runes -O -whole-module-optimization -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.9 -g -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -application-extension -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -c -num-threads 4 /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Sources/Runes.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Sources/Optional.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Sources/Array.swift -output-file-map /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Mac-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module-overlay.yaml -Xcc -working-directory/tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes

CompileSwift normal x86_64
    cd /tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Sources/Runes.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Sources/Optional.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Sources/Array.swift" -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -application-extension -g -import-underlying-module -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module-overlay.yaml -Xcc "-working-directory/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes" -emit-module-doc-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftdoc -O -module-name Runes -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h -serialize-diagnostics-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.dia -emit-dependencies-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.d -num-threads 4 -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Optional.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Array.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Headers/Runes-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Headers/Runes-Swift.h

CompileC /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/Runes_vers.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fmodules -gmodules -fmodules-cache-path=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Xclang -fmodule-implementation-of -Xclang Runes -fapplication-extension -Wno-trigraphs -fpascal-strings -Os -fno-common -Wno-missing-field-initializers -Wno-missing-prototypes -Werror=return-type -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -g -Wno-sign-conversion -Wno-infinite-recursion -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap -ivfsoverlay /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/all-product-headers.yaml -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/include -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/x86_64 -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -MMD -MT dependencies -MF /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.d --serialize-diagnostics /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.dia -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/Runes_vers.c -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftdoc
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftdoc

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftmodule

Ld /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Runes normal x86_64
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    export MACOSX_DEPLOYMENT_TARGET=10.9
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -L/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release -filelist /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.LinkFileList -install_name @rpath/Runes.framework/Versions/A/Runes -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.9 -Xlinker -object_path_lto -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_lto.o -fapplication-extension -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_dependency_info.dat -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Runes

GenerateDSYMFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework.dSYM /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Runes
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Runes -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework.dSYM

CpHeader Resources/Runes.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Headers/Runes.h
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Resources/Runes.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Headers

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules/module.modulemap
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Intermediates/Runes.build/Release/Runes-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework/Versions/A/Modules

Touch /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/touch -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Runes-apbqihjvbsharefigssgaahskynw/Build/Products/Release/Runes.framework

** BUILD SUCCEEDED **

*** Building scheme "Argo-Mac" in Argo.xcworkspace
/usr/bin/xcrun xcodebuild -workspace "/private/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo.xcworkspace" -scheme Argo-Mac -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean buildBuild settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY =
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO

=== CLEAN TARGET Runes-Mac OF PROJECT Runes WITH CONFIGURATION Release ===

Check dependencies

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Headers
/bin/ln -sfh Versions/Current/Runes /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Runes

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework.dSYM
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework.dSYM

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework

=== CLEAN TARGET Argo-Mac OF PROJECT Argo WITH CONFIGURATION Release ===

Check dependencies

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Headers
/bin/ln -sfh Versions/Current/Argo /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Argo

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework.dSYM
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework.dSYM

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build

** CLEAN SUCCEEDED **

=== BUILD TARGET Runes-Mac OF PROJECT Runes WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/all-product-headers.yaml
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Mac-OutputFileMap.json
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/swift-overrides.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/module.modulemap
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/Runes_vers.c
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module-overlay.yaml
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.LinkFileList
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes.hmap

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Headers
/bin/ln -sfh Versions/Current/Runes /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Runes

ProcessInfoPlistFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Resources/Info.plist Resources/Info.plist
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    builtin-infoPlistUtility /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Resources/Info.plist -expandbuildsettings -platform macosx -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Resources/Info.plist

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -incremental -module-name Runes -O -whole-module-optimization -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.9 -g -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -application-extension -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -c -num-threads 4 /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Sources/Runes.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Sources/Optional.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Sources/Array.swift -output-file-map /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Mac-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module-overlay.yaml -Xcc -working-directory/tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes

CompileSwift normal x86_64
    cd /tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Sources/Runes.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Sources/Optional.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes/Sources/Array.swift" -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -application-extension -g -import-underlying-module -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/unextended-module-overlay.yaml -Xcc "-working-directory/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes" -emit-module-doc-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftdoc -O -module-name Runes -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h -serialize-diagnostics-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.dia -emit-dependencies-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.d -num-threads 4 -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Optional.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Array.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Headers/Runes-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Headers/Runes-Swift.h

CompileC /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/Runes_vers.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fmodules -gmodules -fmodules-cache-path=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Xclang -fmodule-implementation-of -Xclang Runes -fapplication-extension -Wno-trigraphs -fpascal-strings -Os -fno-common -Wno-missing-field-initializers -Wno-missing-prototypes -Werror=return-type -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -g -Wno-sign-conversion -Wno-infinite-recursion -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-generated-files.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-own-target-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-all-non-framework-target-headers.hmap -ivfsoverlay /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/all-product-headers.yaml -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Runes-project-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/include -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/x86_64 -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -MMD -MT dependencies -MF /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.d --serialize-diagnostics /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.dia -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/DerivedSources/Runes_vers.c -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_vers.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftdoc
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftdoc

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules/Runes.swiftmodule/x86_64.swiftmodule

Ld /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Runes normal x86_64
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    export MACOSX_DEPLOYMENT_TARGET=10.9
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -L/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -filelist /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.LinkFileList -install_name @rpath/Runes.framework/Versions/A/Runes -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.9 -Xlinker -object_path_lto -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_lto.o -fapplication-extension -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes.swiftmodule -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/Objects-normal/x86_64/Runes_dependency_info.dat -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Runes

GenerateDSYMFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework.dSYM /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Runes
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Runes -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework.dSYM

CpHeader Resources/Runes.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Headers/Runes.h
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Runes/Resources/Runes.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Headers

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules/module.modulemap
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Runes.build/Release/Runes-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework/Versions/A/Modules

Touch /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Runes"
    /usr/bin/touch -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Runes.framework

=== BUILD TARGET Argo-Mac OF PROJECT Argo WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources/Argo_vers.c
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-project-headers.hmap
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo-Mac-OutputFileMap.json
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.LinkFileList
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-own-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-all-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/unextended-module-overlay.yaml
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-generated-files.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/all-product-headers.yaml
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-all-non-framework-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/unextended-module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/swift-overrides.hmap

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Headers
/bin/ln -sfh Versions/Current/Argo /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Argo

ProcessInfoPlistFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Resources/Info.plist Argo/Resources/Info.plist
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    builtin-infoPlistUtility /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Resources/Info.plist -expandbuildsettings -platform macosx -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Resources/Info.plist

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -incremental -module-name Argo -O -whole-module-optimization -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.9 -g -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -application-extension -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -c -num-threads 4 /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Decoded.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Applicative.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decodable.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Alternative.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/decode.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/JSON.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Extensions/NSNumber.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/flatReduce.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/FailureCoalescing.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/sequence.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/DecodeError.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Extensions/Dictionary.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/catDecoded.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Operators/Decode.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Extensions/RawRepresentable.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Monad.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Functor.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Types/StandardTypes.swift /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Operators/Argo.swift -output-file-map /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo-Mac-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftmodule -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/unextended-module-overlay.yaml -Xcc -working-directory/tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo

CompileSwift normal x86_64
    cd /tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Decoded.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Applicative.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decodable.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Alternative.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/decode.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/JSON.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Extensions/NSNumber.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/flatReduce.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/FailureCoalescing.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/sequence.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/DecodeError.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Extensions/Dictionary.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Functions/catDecoded.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Operators/Decode.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Extensions/RawRepresentable.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Monad.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/Decoded/Functor.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Types/StandardTypes.swift" "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo/Argo/Operators/Argo.swift" -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -application-extension -g -import-underlying-module -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/unextended-module-overlay.yaml -Xcc "-working-directory/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo" -emit-module-doc-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftdoc -O -module-name Argo -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftmodule -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo-Swift.h -serialize-diagnostics-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Decoded.dia -emit-dependencies-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Decoded.d -num-threads 4 -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Decoded.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Applicative.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Decodable.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Alternative.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/decode-6A3F63928A20CA7.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/JSON.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/NSNumber.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/flatReduce.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/FailureCoalescing.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/sequence.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/DecodeError.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Dictionary.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/catDecoded.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Decode-5F09601C9204BC80.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/RawRepresentable.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Monad.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Functor.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/StandardTypes.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Headers/Argo-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo-Swift.h
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Headers/Argo-Swift.h

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules/Argo.swiftmodule/x86_64.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftmodule
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules/Argo.swiftmodule/x86_64.swiftmodule

CompileC /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo_vers.o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources/Argo_vers.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fmodules -gmodules -fmodules-cache-path=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Xclang -fmodule-implementation-of -Xclang Argo -fapplication-extension -Wno-trigraphs -fpascal-strings -Os -fno-common -Wmissing-field-initializers -Wno-missing-prototypes -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wmissing-braces -Wparentheses -Wswitch -Wunused-function -Wunused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wconditional-uninitialized -Wno-unknown-pragmas -Wshadow -Wno-four-char-constants -Wconversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wsign-compare -Wshorten-64-to-32 -Wpointer-sign -Wnewline-eof -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -g -Wsign-conversion -Wno-infinite-recursion -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-generated-files.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-own-target-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-all-non-framework-target-headers.hmap -ivfsoverlay /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/all-product-headers.yaml -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Argo-project-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/include -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources/x86_64 -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -MMD -MT dependencies -MF /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo_vers.d --serialize-diagnostics /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo_vers.dia -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/DerivedSources/Argo_vers.c -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo_vers.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules/Argo.swiftmodule/x86_64.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftdoc
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules/Argo.swiftmodule/x86_64.swiftdoc

Ld /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Argo normal x86_64
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    export MACOSX_DEPLOYMENT_TARGET=10.9
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -L/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release -filelist /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.LinkFileList -install_name @rpath/Argo.framework/Versions/A/Argo -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.9 -Xlinker -object_path_lto -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo_lto.o -fapplication-extension -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo.swiftmodule -framework Runes -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/Objects-normal/x86_64/Argo_dependency_info.dat -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Argo

GenerateDSYMFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework.dSYM /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Argo
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Argo -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework.dSYM

CpHeader Argo/Resources/Argo.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Headers/Argo.h
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /tmp/thoughtbot-argo\ —\ 09-21-16\ —\ 10·00AM/Carthage/Checkouts/Argo/Argo/Resources/Argo.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Headers

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules/module.modulemap
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Intermediates/Argo.build/Release/Argo-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework/Versions/A/Modules

Touch /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework
    cd "/tmp/thoughtbot-argo — 09-21-16 — 10·00AM/Carthage/Checkouts/Argo"
    /usr/bin/touch -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Argo-erczchpbkeamuffrdzqyrdormopz/Build/Products/Release/Argo.framework

** BUILD SUCCEEDED **


/tmp/thoughtbot-argo — 09-21-16 — 10·00AM - [master●●]
$ k Carthage/Checkouts/Argo/Carthage/Checkouts/
total 8
drwxr-xr-x 3 jdhealy wheel 102 21 Sep   10:01   .
drwxr-xr-x 4 jdhealy wheel 136 21 Sep   10:01   ..
lrwxr-xr-x 1 jdhealy wheel  39 21 Sep   10:01 | Runes -> ../../../../../Carthage/Checkouts/Runes

/tmp/thoughtbot-argo — 09-21-16 — 10·00AM - [master●●]
$
```

</details>

<details>
<summary>

Commandant Also Succeeds · Repro/Shell Output</summary>



``` shell
~ $   cd /tmp; mkdir-and-cd "commandant — $(nice-date)"

/tmp/commandant — 09-21-16 — 02·47PM
$ echo 'github "Carthage/Commandant" == 0.10.1' >! Cartfile

/tmp/commandant — 09-21-16 — 02·47PM
$ git init
Initialized empty Git repository in /private/tmp/commandant — 09-21-16 — 02·47PM/.git/

/tmp/commandant — 09-21-16 — 02·47PM - [master●]
$ git add .

/tmp/commandant — 09-21-16 — 02·47PM - [master●]
$ git commit -m 'Initialize repository.'
[master (root-commit) 91f6329] Initialize repository.
 1 file changed, 1 insertion(+)
 create mode 100644 Cartfile

/tmp/commandant — 09-21-16 — 02·47PM - [master]
$ "/Users/jdhealy/Code/Carthage/DerivedData/Carthage/Build/Products/Debug/carthage" bootstrap --use-submodules --platform Mac --verbose
*** No Cartfile.resolved found, updating dependencies
*** Cloning Commandant
*** Cloning Result
*** Checking out Result at "2.1.3"
*** Checking out Commandant at "0.10.1"
*** Building scheme "Result-Mac" in Result.xcodeproj
/usr/bin/xcrun xcodebuild -project "/private/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result/Result.xcodeproj" -scheme Result-Mac -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean buildBuild settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY =
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO

=== CLEAN TARGET Result-Mac OF PROJECT Result WITH CONFIGURATION Release ===

Check dependencies

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Headers
/bin/ln -sfh Versions/Current/Result /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Result

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework.dSYM
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework.dSYM

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build

** CLEAN SUCCEEDED **

=== BUILD TARGET Result-Mac OF PROJECT Result WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Mac-OutputFileMap.json
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/Result_vers.c
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.LinkFileList
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/swift-overrides.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/all-product-headers.yaml
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module-overlay.yaml
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result.hmap

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Headers
/bin/ln -sfh Versions/Current/Result /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Result

ProcessInfoPlistFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Resources/Info.plist Result/Info.plist
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    builtin-infoPlistUtility /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Result/Result/Info.plist -expandbuildsettings -platform macosx -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Resources/Info.plist

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.Swift_2_3
    /Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/bin/swiftc -incremental -module-name Result -O -whole-module-optimization -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.9 -g -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -application-extension -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -c -num-threads 4 /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Result/Result/ResultType.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Result/Result/Result.swift -output-file-map /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Mac-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module-overlay.yaml -Xcc -working-directory/tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Result

CompileSwift normal x86_64
    cd /tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result
    /Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/bin/swift -frontend -c "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result/Result/ResultType.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result/Result/Result.swift" -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -application-extension -g -import-underlying-module -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module-overlay.yaml -Xcc "-working-directory/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result" -emit-module-doc-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftdoc -O -module-name Result -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h -serialize-diagnostics-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/ResultType.dia -emit-dependencies-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/ResultType.d -num-threads 4 -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/ResultType.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Headers/Result-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Headers/Result-Swift.h

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftdoc
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftdoc

CompileC /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/Result_vers.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fmodules -gmodules -fmodules-cache-path=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Xclang -fmodule-implementation-of -Xclang Result -fapplication-extension -Wno-trigraphs -fpascal-strings -Os -Wno-missing-field-initializers -Wno-missing-prototypes -Werror=return-type -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -g -Wno-sign-conversion -Wno-infinite-recursion -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap -ivfsoverlay /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/all-product-headers.yaml -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/include -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/x86_64 -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -MMD -MT dependencies -MF /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.d --serialize-diagnostics /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.dia -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/Result_vers.c -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftmodule

Ld /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Result normal x86_64
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    export MACOSX_DEPLOYMENT_TARGET=10.9
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -L/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release -filelist /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.LinkFileList -install_name @rpath/Result.framework/Versions/A/Result -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.9 -Xlinker -object_path_lto -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_lto.o -fapplication-extension -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_dependency_info.dat -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Result

GenerateDSYMFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework.dSYM /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Result
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Result -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework.dSYM

CpHeader Result/Result.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Headers/Result.h
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Result/Result/Result.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Headers

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules/module.modulemap
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Intermediates/Result.build/Release/Result-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework/Versions/A/Modules

Touch /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Result"
    /usr/bin/touch -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Result-dwjoimrimngkxwhgpwgjbrbjjurl/Build/Products/Release/Result.framework

** BUILD SUCCEEDED **

*** Building scheme "Commandant" in Commandant.xcworkspace
/usr/bin/xcrun xcodebuild -workspace "/private/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Commandant.xcworkspace" -scheme Commandant -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean buildBuild settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY =
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO

=== CLEAN TARGET Result-Mac OF PROJECT Result WITH CONFIGURATION Release ===

Check dependencies

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Headers
/bin/ln -sfh Versions/Current/Result /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Result

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework.dSYM
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework.dSYM

=== CLEAN TARGET Commandant OF PROJECT Commandant WITH CONFIGURATION Release ===

Check dependencies

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Headers
/bin/ln -sfh Versions/Current/Commandant /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Commandant

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build

Clean.Remove clean /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework.dSYM
    builtin-rm -rf /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework.dSYM

** CLEAN SUCCEEDED **

=== BUILD TARGET Result-Mac OF PROJECT Result WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/swift-overrides.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Mac-OutputFileMap.json
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module-overlay.yaml
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/all-product-headers.yaml
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/Result_vers.c
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.LinkFileList
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Headers
/bin/ln -sfh Versions/Current/Result /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Result

ProcessInfoPlistFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Resources/Info.plist Result/Info.plist
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    builtin-infoPlistUtility /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/Info.plist -expandbuildsettings -platform macosx -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Resources/Info.plist

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.Swift_2_3
    /Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/bin/swiftc -incremental -module-name Result -O -whole-module-optimization -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.9 -g -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -application-extension -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -c -num-threads 4 /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/ResultType.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/Result.swift -output-file-map /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Mac-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module-overlay.yaml -Xcc -working-directory/tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result

CompileSwift normal x86_64
    cd /tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result
    /Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/bin/swift -frontend -c "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/ResultType.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/Result.swift" -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -application-extension -g -import-underlying-module -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/unextended-module-overlay.yaml -Xcc "-working-directory/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result" -emit-module-doc-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftdoc -O -module-name Result -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h -serialize-diagnostics-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/ResultType.dia -emit-dependencies-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/ResultType.d -num-threads 4 -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/ResultType.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Headers/Result-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Headers/Result-Swift.h

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftdoc
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftdoc

CompileC /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/Result_vers.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fmodules -gmodules -fmodules-cache-path=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Xclang -fmodule-implementation-of -Xclang Result -fapplication-extension -Wno-trigraphs -fpascal-strings -Os -Wno-missing-field-initializers -Wno-missing-prototypes -Werror=return-type -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -g -Wno-sign-conversion -Wno-infinite-recursion -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-generated-files.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-own-target-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-all-non-framework-target-headers.hmap -ivfsoverlay /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/all-product-headers.yaml -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Result-project-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/include -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/x86_64 -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -MMD -MT dependencies -MF /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.d --serialize-diagnostics /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.dia -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/DerivedSources/Result_vers.c -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_vers.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules/Result.swiftmodule/x86_64.swiftmodule

Ld /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Result normal x86_64
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    export MACOSX_DEPLOYMENT_TARGET=10.9
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -L/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -filelist /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.LinkFileList -install_name @rpath/Result.framework/Versions/A/Result -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.9 -Xlinker -object_path_lto -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_lto.o -fapplication-extension -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result.swiftmodule -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/Objects-normal/x86_64/Result_dependency_info.dat -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Result

GenerateDSYMFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework.dSYM /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Result
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Result -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework.dSYM

CpHeader Result/Result.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Headers/Result.h
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result/Result/Result.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Headers

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules/module.modulemap
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Result.build/Release/Result-Mac.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework/Versions/A/Modules

Touch /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Carthage/Checkouts/Result"
    /usr/bin/touch -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Result.framework

=== BUILD TARGET Commandant OF PROJECT Commandant WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/all-product-headers.yaml
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.LinkFileList
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-own-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-all-non-framework-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-project-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/module.modulemap
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources/Commandant_vers.c
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/swift-overrides.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant-OutputFileMap.json
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-all-target-headers.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/unextended-module.modulemap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-generated-files.hmap
write-file /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/unextended-module-overlay.yaml

Create product structure
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules
/bin/ln -sfh Versions/Current/Modules /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Modules
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Headers
/bin/mkdir -p /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Resources
/bin/ln -sfh A /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/Current
/bin/ln -sfh Versions/Current/Resources /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Resources
/bin/ln -sfh Versions/Current/Headers /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Headers
/bin/ln -sfh Versions/Current/Commandant /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Commandant

ProcessInfoPlistFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Resources/Info.plist Sources/Commandant/Info.plist
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    builtin-infoPlistUtility /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Info.plist -expandbuildsettings -platform macosx -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Resources/Info.plist

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.Swift_2_3
    /Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/bin/swiftc -incremental -module-name Commandant -O -whole-module-optimization -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.9 -g -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -application-extension -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -c -num-threads 4 /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Argument.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/HelpCommand.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Swift3to22.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/ArgumentType.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Option.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Errors.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Switch.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Command.swift /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/ArgumentParser.swift -output-file-map /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftmodule -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources -Xcc -DNDEBUG=1 -emit-objc-header -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/unextended-module-overlay.yaml -Xcc -working-directory/tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant

CompileSwift normal x86_64
    cd /tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant
    /Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/bin/swift -frontend -c "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Argument.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/HelpCommand.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Swift3to22.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/ArgumentType.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Option.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Errors.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Switch.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Command.swift" "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/ArgumentParser.swift" -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -F /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -application-extension -g -import-underlying-module -module-cache-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -serialize-debugging-options -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-generated-files.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-own-target-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-project-headers.hmap -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/include -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources/x86_64 -Xcc -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources -Xcc -DNDEBUG=1 -Xcc -ivfsoverlay -Xcc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/unextended-module-overlay.yaml -Xcc "-working-directory/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant" -emit-module-doc-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftdoc -O -module-name Commandant -emit-module-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftmodule -emit-objc-header-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant-Swift.h -serialize-diagnostics-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Argument.dia -emit-dependencies-path /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Argument.d -num-threads 4 -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Argument.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/HelpCommand.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Swift3to22.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/ArgumentType.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Option.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Errors.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Switch.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Command.o -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/ArgumentParser.o

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Headers/Commandant-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant-Swift.h
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant-Swift.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Headers/Commandant-Swift.h

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules/Commandant.swiftmodule/x86_64.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftmodule
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftmodule /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules/Commandant.swiftmodule/x86_64.swiftmodule

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules/Commandant.swiftmodule/x86_64.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftdoc
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    /usr/bin/ditto -rsrc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftdoc /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules/Commandant.swiftmodule/x86_64.swiftdoc

CompileC /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant_vers.o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources/Commandant_vers.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fmodules -gmodules -fmodules-cache-path=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/Users/jdhealy/Library/Developer/Xcode/DerivedData/ModuleCache/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -Xclang -fmodule-implementation-of -Xclang Commandant -fapplication-extension -Wno-trigraphs -fpascal-strings -Os -fno-common -Werror -Wmissing-field-initializers -Wno-missing-prototypes -Werror=return-type -Wunreachable-code -Werror=deprecated-objc-isa-usage -Werror=objc-root-class -Wmissing-braces -Wparentheses -Wswitch -Wunused-function -Wunused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wno-unknown-pragmas -Wno-shadow -Wfour-char-constants -Wconversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wsign-compare -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -DNDEBUG=1 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -g -Wno-sign-conversion -Wno-infinite-recursion -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-generated-files.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-own-target-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-all-non-framework-target-headers.hmap -ivfsoverlay /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/all-product-headers.yaml -iquote /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Commandant-project-headers.hmap -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/include -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources/x86_64 -I/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources -Wno-error=unknown-warning-option -Wno-gcc-compat -Wno-unused-const-variable -Wno-nullability-completeness -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -MMD -MT dependencies -MF /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant_vers.d --serialize-diagnostics /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant_vers.dia -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/DerivedSources/Commandant_vers.c -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant_vers.o

Ld /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Commandant normal x86_64
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    export MACOSX_DEPLOYMENT_TARGET=10.9
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -L/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -F/Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release -filelist /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.LinkFileList -install_name @rpath/Commandant.framework/Commandant -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/../Frameworks -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.9 -Xlinker -object_path_lto -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant_lto.o -fapplication-extension -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/Swift_2.3.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant.swiftmodule -framework Result -single_module -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/Objects-normal/x86_64/Commandant_dependency_info.dat -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Commandant

GenerateDSYMFile /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework.dSYM /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Commandant
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Commandant -o /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework.dSYM

CpHeader Sources/Commandant/Commandant.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Headers/Commandant.h
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /tmp/commandant\ —\ 09-21-16\ —\ 02·47PM/Carthage/Checkouts/Commandant/Sources/Commandant/Commandant.h /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Headers

Ditto /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules/module.modulemap
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -strip-debug-symbols -strip-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip -resolve-src-symlinks /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Intermediates/Commandant.build/Release/Commandant.build/module.modulemap /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework/Versions/A/Modules

Touch /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework
    cd "/tmp/commandant — 09-21-16 — 02·47PM/Carthage/Checkouts/Commandant"
    /usr/bin/touch -c /Users/jdhealy/Library/Developer/Xcode/DerivedData/Commandant-dipyyglhyymcvdcvdqtahpzganfk/Build/Products/Release/Commandant.framework

** BUILD SUCCEEDED **


/tmp/commandant — 09-21-16 — 02·47PM - [master●●]
$ k Carthage/Checkouts/Commandant/Carthage/Checkouts/
total 0
drwxr-xr-x  6 jdhealy wheel 204 21 Sep   14:48   .
drwxr-xr-x  4 jdhealy wheel 136 21 Sep   14:48   ..
drwxr-xr-x 20 jdhealy wheel 680 21 Sep   14:48 | Nimble
drwxr-xr-x 24 jdhealy wheel 816 21 Sep   14:48 | Quick
drwxr-xr-x 14 jdhealy wheel 476 21 Sep   14:48 | Result
drwxr-xr-x 10 jdhealy wheel 340 21 Sep   14:48 | xcconfigs

/tmp/commandant — 09-21-16 — 02·47PM - [master●●]
$ cd Carthage/Checkouts/Commandant; git submodule status
 188caeb094bc342614d8a5c706cd8bb9a6c355eb Carthage/Checkouts/Nimble (v4.1.0-8-g188caeb)
 e2cfb86c8379417c9272bb853e9f0c407167d486 Carthage/Checkouts/Quick (remotes/origin/xcode-run-selected-specs-178-ge2cfb86)
 9b5e373891dfe0de11ba2a8e9a5cafd570b858c4 Carthage/Checkouts/Result (2.1.3)
 d78854b22b9567e7f30d748bdd4966c86bcc93a5 Carthage/Checkouts/xcconfigs (0.7-29-gd78854b)
```

</details>
