### PR TITLE
Modify help message for platform options

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -27,7 +27,7 @@ extension BuildOptions: OptionsType {
 	public static func evaluate(m: CommandMode, addendum: String) -> Result<BuildOptions, CommandantError<CarthageError>> {
 		return create
 			<*> m <| Option(key: "configuration", defaultValue: "Release", usage: "the Xcode configuration to build" + addendum)
-			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of 'all', 'Mac', 'iOS', 'watchOS', 'tvOS', or comma-separated values of the formers except for 'all')" + addendum)
+			<*> m <| Option(key: "platform", defaultValue: .All, usage: "the platforms to build for (one of 'all', 'macOS', 'iOS', 'watchOS', 'tvOS', or comma-separated values of the formers except for 'all')" + addendum)
 			<*> m <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 			<*> m <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 	}


### PR DESCRIPTION
Modify help message about `--platform` option.

I think it should be `macOS`.
Platform `Mac` is still working, but primary value should be `macOS`.
Because shell completions suggest `macOS`.

https://github.com/Carthage/Carthage/pull/1390/files#diff-cedb56bc6f242f0c6891894f472948c9R70

Please review it. 🙏 