### PR TITLE
Git: added underlying error when generating CarthageError.RepositoryCheckoutFailed

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -512,14 +512,14 @@ public func resolveReferenceInRepository(repositoryFileURL: NSURL, _ reference: 
 	return ensureDirectoryExistsAtURL(repositoryFileURL)
 		.then(launchGitTask([ "rev-parse", "\(reference)^{object}" ], repositoryFileURL: repositoryFileURL))
 		.map { string in string.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) }
-		.mapError { _ in CarthageError.RepositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No object named \"\(reference)\" exists", underlyingError: nil) }
+		.mapError { error in CarthageError.RepositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No object named \"\(reference)\" exists", underlyingError: error as NSError) }
 }
 
 /// Attempts to resolve the given tag into an object SHA.
 internal func resolveTagInRepository(repositoryFileURL: NSURL, _ tag: String) -> SignalProducer<String, CarthageError> {
 	return launchGitTask([ "show-ref", "--tags", "--hash", tag ], repositoryFileURL: repositoryFileURL)
 		.map { string in string.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) }
-		.mapError { _ in CarthageError.RepositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No tag named \"\(tag)\" exists", underlyingError: nil) }
+		.mapError { error in CarthageError.RepositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No tag named \"\(tag)\" exists", underlyingError: error as NSError) }
 }
 
 /// Attempts to determine whether the given directory represents a Git


### PR DESCRIPTION
I'm trying to figure out why `Carthage` is failing to update `xcconfigs` now:
> Failed to check out repository into /Users/nachosoto/Library/Caches/org.carthage.CarthageKit/dependencies/xcconfigs: No object named "master" exists

I cleared `Users/nachosoto/Library/Caches/org.carthage.CarthageKit` but still no luck. Note that I had already correctly fetched this, so I don't know why this is suddenly broken.
Looks like this is similar to #400. I ran `git rev-parse master` from that folder:
> [nachosoto(master)]$ git rev-parse master
> cc451b08e052b6146f5caf66bc1120420c529c7b

But as you can see that's not the problem. This PR should hopefully provide more visibility into the actual underlying issue.

_Note: I'm on version `0.18.1`._

---------------

### Update

I just figured out what was wrong: I had the environment variable `GIT_DIR` defined in my terminal with the value `.git`, and I was running `carthage update` from a folder other than the root of the repo. I'm not sure why this would be a problem for Carthage given that I wasn't using `--use-submodules`, but it doesn't really matter anymore I guess. Hopefully adding this extra piece of information to the error will be helpful for other people that run into something like this :)