### PR TITLE
Fix a failing integration test

### DIFF
--- a/Source/CarthageIntegration/update.bats
+++ b/Source/CarthageIntegration/update.bats
@@ -2,9 +2,10 @@
 
 setup() {
     cd $BATS_TMPDIR
-    rm -rf Argo
-    git clone -b v2.3.0 https://github.com/thoughtbot/Argo.git
-    cd Argo
+    rm -rf UpdateTest
+    mkdir UpdateTest && cd UpdateTest
+    echo 'github "antitypical/Result" == 2.1.3' > Cartfile
+    echo 'github "Quick/Nimble" == 4.1.0' > Cartfile.private
 }
 
 teardown() {
@@ -14,6 +15,6 @@ teardown() {
 @test "carthage update builds everything" {
     run carthage update --platform mac --no-use-binaries
     [ "$status" -eq 0 ]
-    [ -e Carthage/Build/Mac/Curry.framework ]
-    [ -e Carthage/Build/Mac/Runes.framework ]
+    [ -e Carthage/Build/Mac/Result.framework ]
+    [ -e Carthage/Build/Mac/Nimble.framework ]
 }


### PR DESCRIPTION
The failure is seen here: https://travis-ci.org/Carthage/Carthage/jobs/167228879. That is because Argo v2.3.0 did not specify version constraint for Curry in its `Cartfile.private`. So when running `carthage update` in the checked out repository, the latest Curry v3.0.0 for Swift 3, which can't be built by Xcode 7.3, will be used. ~~Using Argo v3.1.0 should fix the problem.~~