### PR TITLE
Increasing Xcode timeout from 30 to 60 seconds

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -490,7 +490,7 @@ public struct BuildSettings {
 			// can sometimes hang indefinitely on projects that don't
 			// share any schemes, so automatically bail out if it looks
 			// like that's happening.
-			.timeoutWithError(.XcodebuildTimeout(arguments.project), afterInterval: 30, onScheduler: QueueScheduler(qos: QOS_CLASS_DEFAULT))
+			.timeoutWithError(.XcodebuildTimeout(arguments.project), afterInterval: 60, onScheduler: QueueScheduler(qos: QOS_CLASS_DEFAULT))
 			.retry(5)
 			.map { (data: NSData) -> String in
 				return NSString(data: data, encoding: NSStringEncoding(NSUTF8StringEncoding))! as String


### PR DESCRIPTION
Credits: https://github.com/samsonjs/Carthage/commit/946e202019c9ede36a4ea6cfb57df067dd8cb3ee

Fixes https://github.com/Carthage/Carthage/issues/1310. Please see that issue for details.

Here is a set of examples with failures:

* iOS: https://travis-ci.org/mattt/FormatterKit/jobs/159922844#L774-L777
* macOS: https://travis-ci.org/mattt/FormatterKit/jobs/159922845#L774-L777
* watchOS: https://travis-ci.org/mattt/FormatterKit/jobs/159922846#L774-L777
* tvOS: https://travis-ci.org/mattt/FormatterKit/jobs/159922847#L774-L777

And here I used my fork of Carthage:

* iOS: https://travis-ci.org/mattt/FormatterKit/jobs/165110137
* macOS: https://travis-ci.org/mattt/FormatterKit/jobs/165110138
* watchOS: https://travis-ci.org/mattt/FormatterKit/jobs/165110139
* tvOS: https://travis-ci.org/mattt/FormatterKit/jobs/165110140