### PR TITLE
Add support for pre-release and build metadata, as per SemVer specs

### DIFF
--- a/Source/CarthageKitTests/VersionSpec.swift
+++ b/Source/CarthageKitTests/VersionSpec.swift
@@ -32,11 +32,16 @@ class SemanticVersionSpec: QuickSpec {
 		it("should parse semantic versions") {
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("1.4")).value) == SemanticVersion(major: 1, minor: 4, patch: 0)
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8.9")).value) == SemanticVersion(major: 2, minor: 8, patch: 9)
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("2.8.2-alpha")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha")
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("2.8.2-alpha+build234")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha", buildMetadata: "build234")
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("2.8.2+build234")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, buildMetadata: "build234")
+
 		}
 
 		it("should fail on invalid semantic versions") {
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v1")).value).to(beNil())
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8-alpha")).value).to(beNil())
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8-alpha")).value).to(beNil()) // pre-release should be after patch
+			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8+build345")).value).to(beNil()) // build should be after patch
 			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("null-string-beta-2")).value).to(beNil())
 		}
 	}

--- a/Source/CarthageKitTests/VersionSpec.swift
+++ b/Source/CarthageKitTests/VersionSpec.swift
@@ -27,6 +27,38 @@ class SemanticVersionSpec: QuickSpec {
 			expect(version) < SemanticVersion(major: 10, minor: 0, patch: 0)
 			expect(version) < SemanticVersion(major: 2, minor: 10, patch: 1)
 			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 10)
+			
+			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 2, buildMetadata: "b421")
+			expect(version) == SemanticVersion(major: 2, minor: 1, patch: 1, buildMetadata: "b2334")
+			expect(version) > SemanticVersion(major: 2, minor: 1, patch: 0, buildMetadata: "b421")
+		}
+		
+		it("should order pre-release versions correctly") {
+			let version = SemanticVersion(major: 2, minor: 1, patch: 1, preRelease: "alpha8")
+			
+			expect(version) < SemanticVersion(major: version.major, minor: version.minor, patch: version.patch)
+			expect(version) > SemanticVersion(major: version.major, minor: version.minor, patch: version.patch-1)
+			expect(version) == SemanticVersion(major: version.major, minor: version.minor, patch: version.patch, preRelease: version.preRelease)
+			
+			// As specified in http://semver.org/
+			// "Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0"
+			
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) < SemanticVersion(major: 1, minor: 0, patch: 0)
+			
+			// now test the reverse (to catch error if the < function ALWAYS returns true)
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0)) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
 		}
 
 		it("should parse semantic versions") {
@@ -50,13 +82,19 @@ class SemanticVersionSpec: QuickSpec {
 class VersionSpecifierSpec: QuickSpec {
 	override func spec() {
 		let versionZeroOne = SemanticVersion.fromPinnedVersion(PinnedVersion("0.1.0")).value!
+		let versionZeroOnePre = SemanticVersion.fromPinnedVersion(PinnedVersion("0.1.0-pre23")).value!
 		let versionZeroOneOne = SemanticVersion.fromPinnedVersion(PinnedVersion("0.1.1")).value!
 		let versionZeroTwo = SemanticVersion.fromPinnedVersion(PinnedVersion("0.2.0")).value!
+		let versionZeroTwoPre = SemanticVersion.fromPinnedVersion(PinnedVersion("0.2.0-candidate")).value!
 		let versionOne = SemanticVersion.fromPinnedVersion(PinnedVersion("1.3.2")).value!
 		let versionTwoZero = SemanticVersion.fromPinnedVersion(PinnedVersion("2.0.2")).value!
 		let versionTwoOne = SemanticVersion.fromPinnedVersion(PinnedVersion("2.1.1")).value!
 		let versionTwoTwo = SemanticVersion.fromPinnedVersion(PinnedVersion("2.2.0")).value!
 		let versionThree = SemanticVersion.fromPinnedVersion(PinnedVersion("3.0.0")).value!
+		let versionTwoOneAlpha = SemanticVersion.fromPinnedVersion(PinnedVersion("2.1.1-alpha")).value!
+		let versionTwoOneAlphaOne = SemanticVersion.fromPinnedVersion(PinnedVersion("2.1.1-alpha.1")).value!
+		let nonSemantic = PinnedVersion("branch-2")
+
 
 		func testIntersection(lhs: VersionSpecifier, _ rhs: VersionSpecifier, expected: VersionSpecifier?) {
 			if let expected = expected {
@@ -77,6 +115,16 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.satisfiedBy(versionTwoTwo.pinnedVersion!)) == true
 				expect(specifier.satisfiedBy(versionThree.pinnedVersion!)) == true
 			}
+			
+			it("should not allow a non-semantic version for Any") {
+				let specifier = VersionSpecifier.Any
+				expect(specifier.satisfiedBy(nonSemantic)) == false
+			}
+			
+			it("should not allow a pre-release version for Any") {
+				let specifier = VersionSpecifier.Any
+				expect(specifier.satisfiedBy(versionTwoOneAlpha.pinnedVersion!)) == false
+			}
 
 			it("should allow greater or equal versions for AtLeast") {
 				let specifier = VersionSpecifier.AtLeast(versionTwoOne)
@@ -85,6 +133,34 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.satisfiedBy(versionTwoOne.pinnedVersion!)) == true
 				expect(specifier.satisfiedBy(versionTwoTwo.pinnedVersion!)) == true
 				expect(specifier.satisfiedBy(versionThree.pinnedVersion!)) == true
+			}
+			
+			it("should not allow a non-semantic version for AtLeast") {
+				let specifier = VersionSpecifier.AtLeast(versionTwoOne)
+				expect(specifier.satisfiedBy(nonSemantic)) == false
+			}
+			
+			it("should not allow for a pre-release of the same non-pre-release version for AtLeast")
+			{
+				let specifier = VersionSpecifier.AtLeast(versionTwoOne)
+				expect(specifier.satisfiedBy(versionTwoOneAlpha.pinnedVersion!)) == false
+			}
+			
+			it("should allow for a non-pre-release of the same pre-release version for AtLeast")
+			{
+				let specifier = VersionSpecifier.AtLeast(versionTwoOneAlpha)
+				expect(specifier.satisfiedBy(versionTwoOne.pinnedVersion!)) == true
+			}
+			
+			it("should allow for a greater pre-release of the same pre-release version for AtLeast")
+			{
+				let specifier = VersionSpecifier.AtLeast(versionTwoOneAlpha)
+				expect(specifier.satisfiedBy(versionTwoOneAlphaOne.pinnedVersion!)) == true
+			}
+			
+			it("shold not allow for a greater pre-release version for AtLease") {
+				let specifier = VersionSpecifier.AtLeast(versionTwoZero)
+				expect(specifier.satisfiedBy(versionTwoOneAlpha.pinnedVersion!)) == false
 			}
 
 			it("should allow greater or equal minor and patch versions for CompatibleWith") {
@@ -95,6 +171,16 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.satisfiedBy(versionTwoTwo.pinnedVersion!)) == true
 				expect(specifier.satisfiedBy(versionThree.pinnedVersion!)) == false
 			}
+			
+			it("should not allow a non-semantic version for AtLeast") {
+				let specifier = VersionSpecifier.CompatibleWith(versionTwoOne)
+				expect(specifier.satisfiedBy(nonSemantic)) == false
+			}
+			
+			it("should not allow equal minor and patch pre-release version for CompatibleWith") {
+				let specifier = VersionSpecifier.CompatibleWith(versionTwoOne)
+				expect(specifier.satisfiedBy(versionTwoOneAlpha.pinnedVersion!)) == false
+			}
 
 			it("should only allow exact versions for Exactly") {
 				let specifier = VersionSpecifier.Exactly(versionTwoTwo)
@@ -104,11 +190,27 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.satisfiedBy(versionTwoTwo.pinnedVersion!)) == true
 				expect(specifier.satisfiedBy(versionThree.pinnedVersion!)) == false
 			}
+			
+			it("should allow exact pre-release versions for Exactly") {
+				let specifier = VersionSpecifier.Exactly(versionTwoOneAlpha)
+				expect(specifier.satisfiedBy(versionTwoOneAlpha.pinnedVersion!)) == true
+			}
 
+			it("should not allow for a non-semantic version for Exactly") {
+				let specifier = VersionSpecifier.Exactly(versionTwoOne)
+				expect(specifier.satisfiedBy(nonSemantic)) == false
+			}
+			
 			it("should allow only greater patch versions to satisfy 0.x") {
 				let specifier = VersionSpecifier.CompatibleWith(versionZeroOne)
 				expect(specifier.satisfiedBy(versionZeroOneOne.pinnedVersion!)) == true
 				expect(specifier.satisfiedBy(versionZeroTwo.pinnedVersion!)) == false
+			}
+			
+			it("should allow only greater patch versions to satisfy 0.x") {
+				let specifier = VersionSpecifier.CompatibleWith(versionZeroOne)
+				expect(specifier.satisfiedBy(versionZeroOnePre.pinnedVersion!)) == false
+				expect(specifier.satisfiedBy(versionZeroTwoPre.pinnedVersion!)) == false
 			}
 		}
 


### PR DESCRIPTION
# Issue addressed

Our `Cartfile` reads:

```
github "wireapp/wire-ios-data-model" ~> 25.0
```

The `wire-ios-data-model` repository currently has the following tags:

```
...
23.0.0
23.0.0-callkit
23.1.0
23.2.0
23.2.0-callkit
23.3.0
23.3.1
24.0.0
25.0.0
25.0.1
...
```

When I run `carthage update --platform iOS`, I would expect to fetch `wire-ios-data-model` at version `25.0.1`. Instead, Carthage will pick `23.2.0-callkit`. After running, my `Cartfile.resolved` is now:

```
...
github "wireapp/wire-ios-data-model" "23.2.0-callkit"
...
```
# Investigation

The pre-release part of the version `23.2.0-callkit` (which follows the [semver specs](http://semver.org/#spec-item-9)) cause the version to fail to parse, because CarthageKit does not yet support pre-release and build metadata (see [here](https://github.com/Carthage/Carthage/blob/279f4b88a75c409f6b586cd8630740d87ab7713c/Source/CarthageKit/Version.swift#L66)).

Additionaly, CarthageKit assumes that a version that can not be parsed will satisfy any requirements (see [here](https://github.com/Carthage/Carthage/blob/279f4b88a75c409f6b586cd8630740d87ab7713c/Source/CarthageKit/Version.swift#L178)). This leads to the first non-parsable version to be picked as a match even if it is a pre-release of an previous incompatible version.
# Changes

Modified `Version.swift` so that now CarthageKit correctly parses pre-release and build metadata informations as per [semver specs](http://semver.org).
# Testing

Versions with pre-release and build metadata have been added to the unit tests of the `SemanticVersion` implementation.
Additionally I manually tested the locally-compiled Carthage version using the example listed earlier and it now behaves correctly, picking `25.0.1` instead of `23.2.0-callkit`.
