### PR TITLE
Adds the -skipUnavailableActions flag when retrieving build settings

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -481,7 +481,7 @@ public struct BuildSettings {
 		// rdar://27052195
 		// Including the action "clean" works around this issue, which is further
 		// discussed here: https://forums.developer.apple.com/thread/50372
-		let task = xcodebuildTask(["clean", "-showBuildSettings"], arguments)
+		let task = xcodebuildTask(["clean", "-showBuildSettings", "-skipUnavailableActions"], arguments)
 
 		return launchTask(task)
 			.ignoreTaskData()


### PR DESCRIPTION
`xcodebuild clean -showBuildSettings` can fail if the scheme doesn't support the clean action, same as issue https://github.com/Carthage/Carthage/issues/1541. This adds a flag to skip unavailable actions instead of failing.

An example with PINRemoteImage:

```shell
$ carthage update
*** Checking out PINRemoteImage at "3.0.0-beta.6"
*** xcodebuild output can be found in /var/folders/4x/k22fcvxj09q33bnxlpc1ngv00000gn/T/carthage-xcodebuild.D68Rup.log
A shell task (/usr/bin/xcrun xcodebuild -workspace /Users/zach/code/tmp/CarthageTest/Carthage/Checkouts/PINRemoteImage/Example-Mac/PINRemoteImage.xcworkspace -scheme PINRemoteImage -configuration Release CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean -showBuildSettings) failed with exit code 66:
xcodebuild: error: Scheme PINRemoteImage is not currently configured for the clean action.
```

Running directly:
```shell
$ xcodebuild -workspace PINRemoteImage.xcworkspace -scheme PINRemoteImage -configuration Release CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean -showBuildSettings
Build settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY = 
    CODE_SIGNING_REQUIRED = NO

xcodebuild: error: Scheme PINRemoteImage is not currently configured for the clean action.
```

xcodebuild has a `-skipUnavailableActions` option:
> -skipUnavailableActions
           Skip actions that cannot be performed instead of failing. This option is only honored if -scheme is passed.


With that option, we get the settings and no error:

```shell
$ xcodebuild -workspace PINRemoteImage.xcworkspace -scheme PINRemoteImage -configuration Release CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean -showBuildSettings -skipUnavailableActions
Build settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY = 
    CODE_SIGNING_REQUIRED = NO
```

I don't know if there are any side-effects from that flag, but seems pretty safe since we're just retrieving the build settings here. I'm not very familiar with the codebase, so let me know if this the right place to put that.