### PR TITLE
[swift3-prep] Add `Observer.send(value:)` and `Observer.send(error:)` shims

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -16,7 +16,7 @@ extension String {
 	internal var linesProducer: SignalProducer<String, NoError> {
 		return SignalProducer { observer, disposable in
 			(self as NSString).enumerateLinesUsingBlock { (line, stop) in
-				observer.sendNext(line)
+				observer.send(value: line)
 
 				if disposable.disposed {
 					stop.memory = true
@@ -60,13 +60,13 @@ extension SignalType {
 
 					signalValues.append(value)
 					for otherValue in otherValues {
-						observer.sendNext((value, otherValue))
+						observer.send(value: (value, otherValue))
 					}
 
 					lock.unlock()
 
 				case let .Failed(error):
-					observer.sendFailed(error)
+					observer.send(error: error)
 
 				case .Completed:
 					lock.lock()
@@ -90,13 +90,13 @@ extension SignalType {
 
 					otherValues.append(value)
 					for signalValue in signalValues {
-						observer.sendNext((signalValue, value))
+						observer.send(value: (signalValue, value))
 					}
 
 					lock.unlock()
 
 				case let .Failed(error):
-					observer.sendFailed(error)
+					observer.send(error: error)
 
 				case .Completed:
 					lock.lock()
@@ -191,7 +191,7 @@ extension SignalType where Value: EventType, Value.Error == Error {
 					switch innerEvent.event {
 					case let .Next(value):
 						receivedValue = true
-						observer.sendNext(value)
+						observer.send(value: value)
 
 					case let .Failed(error):
 						receivedError = error
@@ -204,11 +204,11 @@ extension SignalType where Value: EventType, Value.Error == Error {
 					}
 
 				case let .Failed(error):
-					observer.sendFailed(error)
+					observer.send(error: error)
 
 				case .Completed:
 					if let receivedError = receivedError where !receivedValue {
-						observer.sendFailed(receivedError)
+						observer.send(error: receivedError)
 					}
 
 					observer.sendCompleted()
@@ -304,7 +304,7 @@ extension NSFileManager {
 				if catchErrors {
 					return true
 				} else {
-					observer.sendFailed(CarthageError.readFailed(URL, error))
+					observer.send(error: CarthageError.readFailed(URL, error))
 					return false
 				}
 			}!
@@ -312,7 +312,7 @@ extension NSFileManager {
 			while !disposable.disposed {
 				if let URL = enumerator.nextObject() as? NSURL {
 					let value = (enumerator, URL)
-					observer.sendNext(value)
+					observer.send(value: value)
 				} else {
 					break
 				}

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -244,7 +244,7 @@ public func listTags(repositoryFileURL: NSURL) -> SignalProducer<String, Carthag
 					}
 
 					if let line = line {
-						observer.sendNext(line)
+						observer.send(value: line)
 					}
 				}
 
@@ -383,7 +383,7 @@ private func parseConfigEntries(contents: String, keyPrefix: String = "", keySuf
 			}
 
 			if let key = key as? String {
-				observer.sendNext((key, value))
+				observer.send(value: (key, value))
 			}
 		}
 
@@ -502,7 +502,7 @@ private func ensureDirectoryExistsAtURL(fileURL: NSURL) -> SignalProducer<(), Ca
 		if NSFileManager.defaultManager().fileExistsAtPath(fileURL.path!, isDirectory: &isDirectory) && isDirectory {
 			observer.sendCompleted()
 		} else {
-			observer.sendFailed(.readFailed(fileURL, nil))
+			observer.send(error: .readFailed(fileURL, nil))
 		}
 	}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -272,7 +272,7 @@ public final class Project {
 		return cloneOrFetchProject(project, preferHTTPS: self.preferHTTPS, commitish: commitish)
 			.on(next: { event, _ in
 				if let event = event {
-					self._projectEventsObserver.sendNext(event)
+					self._projectEventsObserver.send(value: event)
 				}
 			})
 			.map { _, URL in URL }
@@ -491,7 +491,7 @@ public final class Project {
 				case let .APIError(_, _, error):
 					// Log the GitHub API request failure, not to error out,
 					// because that should not be fatal error.
-					self._projectEventsObserver.sendNext(.skippedDownloadingBinaries(project, error.message))
+					self._projectEventsObserver.send(value: .skippedDownloadingBinaries(project, error.message))
 					return .empty
 
 				default:
@@ -499,7 +499,7 @@ public final class Project {
 				}
 			}
 			.on(next: { release in
-				self._projectEventsObserver.sendNext(.downloadingBinaries(project, release.nameWithFallback))
+				self._projectEventsObserver.send(value: .downloadingBinaries(project, release.nameWithFallback))
 			})
 			.flatMap(.Concat) { release -> SignalProducer<NSURL, CarthageError> in
 				return SignalProducer<Release.Asset, CarthageError>(values: release.assets)
@@ -593,7 +593,7 @@ public final class Project {
 				}
 			}
 			.on(started: {
-				self._projectEventsObserver.sendNext(.checkingOut(project, revision))
+				self._projectEventsObserver.send(value: .checkingOut(project, revision))
 			})
 	}
 	
@@ -755,7 +755,7 @@ public final class Project {
 							// Log that building the dependency is being skipped,
 							// not to error out with `.noSharedFrameworkSchemes`
 							// to continue building other dependencies.
-							self._projectEventsObserver.sendNext(.skippedBuilding(dependency.project, error.description))
+							self._projectEventsObserver.send(value: .skippedBuilding(dependency.project, error.description))
 							return .empty
 
 						default:

--- a/Source/CarthageKit/Swift3Shims.swift
+++ b/Source/CarthageKit/Swift3Shims.swift
@@ -17,6 +17,18 @@ import ReactiveTask
 		}
 	}
 
+	// MARK: - ReactiveSwift
+
+	internal extension Observer {
+		func send(value value: Value) {
+			sendNext(value)
+		}
+
+		func send(error error: Error) {
+			sendFailed(error)
+		}
+	}
+
 	// MARK: - ReactiveTask
 
 	internal extension TaskEvent {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -503,7 +503,7 @@ public struct BuildSettings {
 					let flushTarget = { () -> () in
 						if let currentTarget = currentTarget {
 							let buildSettings = self.init(target: currentTarget, settings: currentSettings)
-							observer.sendNext(buildSettings)
+							observer.send(value: buildSettings)
 						}
 
 						currentTarget = nil
@@ -793,14 +793,14 @@ private func settingsByTarget<Error>(producer: SignalProducer<TaskEvent<BuildSet
 					if let transformed = transformedEvent.value {
 						settings = combineDictionaries(settings, rhs: transformed)
 					} else {
-						observer.sendNext(transformedEvent)
+						observer.send(value: transformedEvent)
 					}
 
 				case let .Failed(error):
-					observer.sendFailed(error)
+					observer.send(error: error)
 
 				case .Completed:
-					observer.sendNext(.success(settings))
+					observer.send(value: .success(settings))
 					observer.sendCompleted()
 
 				case .Interrupted:
@@ -1034,7 +1034,7 @@ public func buildScheme(scheme: String, withConfiguration configuration: String,
 											let simulatorSettings = simulatorSettingsByTarget[target]
 											assert(simulatorSettings != nil, "No \(simulatorSDK) build settings found for target \"\(target)\"")
 
-											observer.sendNext((deviceSettings, simulatorSettings!))
+											observer.send(value: (deviceSettings, simulatorSettings!))
 										}
 
 										observer.sendCompleted()

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -101,7 +101,7 @@ public struct BuildCommand: CommandType {
 						.on(next: { taskEvent in
 							switch taskEvent {
 							case let .StandardOutput(data):
-								stdoutObserver.sendNext(data)
+								stdoutObserver.send(value: data)
 
 							default:
 								break


### PR DESCRIPTION
#1558 

Based on [the file](https://github.com/ReactiveCocoa/ReactiveSwift/blob/bac956ee3e93dcad0b5528009362502ec91257c8/Sources/Deprecations%2BRemovals.swift).