### PR TITLE
Allow the user to cache build artefacts for a particular revision of a dependency 

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -16,11 +16,14 @@ public struct BuildOptions {
 	public let toolchain: String?
 	/// The path to the custom derived data folder.
 	public let derivedDataPath: String?
+	/// The path to the cached binaries folder.
+	public let useBuildProductsCache: Bool
 
-	public init(configuration: String, platforms: Set<Platform> = [], toolchain: String? = nil, derivedDataPath: String? = nil) {
+	public init(configuration: String, platforms: Set<Platform> = [], toolchain: String? = nil, derivedDataPath: String? = nil, useBuildProductsCache: Bool = false) {
 		self.configuration = configuration
 		self.platforms = platforms
 		self.toolchain = toolchain
 		self.derivedDataPath = derivedDataPath
+		self.useBuildProductsCache = useBuildProductsCache
 	}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Result
 import ReactiveCocoa
+import ReactiveTask
 import Tentacle
 
 /// Carthage's bundle identifier.
@@ -73,6 +74,11 @@ public let CarthageDependencyAssetsURL: NSURL = CarthageUserCachesURL.appendingP
 /// ~/Library/Caches/org.carthage.CarthageKit/dependencies/
 public let CarthageDependencyRepositoriesURL: NSURL = CarthageUserCachesURL.appendingPathComponent("dependencies", isDirectory: true)
 
+/// The file URL to the directory in which built binaries will be cached.
+///
+/// ~/Library/Caches/org.carthage.CarthageKit/build/
+public let CarthageDependencyBuildCacheURL: NSURL = CarthageUserCachesURL.appendingPathComponent("build", isDirectory: true)
+
 /// The relative path to a project's Cartfile.
 public let CarthageProjectCartfilePath = "Cartfile"
 
@@ -116,6 +122,9 @@ public enum ProjectEvent {
 	/// Building the project is being skipped, since the project is not sharing
 	/// any framework schemes.
 	case skippedBuilding(ProjectIdentifier, String)
+
+	/// Building the project is being skipped, since the project has cached binaries.
+	case usedCachedBinaries(ProjectIdentifier)
 }
 
 /// Represents a project that is using Carthage.
@@ -747,8 +756,22 @@ public final class Project {
 				if !FileManager.`default`.fileExists(atPath: dependencyPath) {
 					return .empty
 				}
+				
+				let cachedBinariesPath: NSURL? = {
+					if options.useBuildProductsCache {
+						return CarthageDependencyBuildCacheURL.appendingPathComponent(dependency.project.name, isDirectory: true).appendingPathComponent(dependency.version.commitish, isDirectory: true)
+					}
+					
+					return nil
+				}()
+				
+				var isDirectory: ObjCBool = false
+				if let cachedBinariesPath = cachedBinariesPath where FileManager.`default`.fileExists(atPath: cachedBinariesPath.path!, isDirectory: &isDirectory) && isDirectory {
+					self._projectEventsObserver.send(value: .usedCachedBinaries(dependency.project))
+					return copyCachedBinaries(cachedBinariesPath, to: self.directoryURL)
+				}
 
-				return buildDependencyProject(dependency.project, self.directoryURL, withOptions: options, sdkFilter: sdkFilter)
+				return buildDependencyProject(dependency.project, self.directoryURL, withOptions: options, cachedBinariesPath: cachedBinariesPath, sdkFilter: sdkFilter)
 					.flatMapError { error in
 						switch error {
 						case .noSharedFrameworkSchemes:
@@ -764,6 +787,13 @@ public final class Project {
 					}
 			}
 	}
+}
+
+private func copyCachedBinaries(from: NSURL, to: NSURL) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	let task = Task("/usr/bin/env", arguments: [ "cp", "-r", from.path! + "/", to.path! ])
+	return task.launch()
+		.mapError(CarthageError.taskError)
+		.then(.empty)
 }
 
 /// Constructs a file URL to where the binary corresponding to the given

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -91,7 +91,7 @@ class XcodeSpec: QuickSpec {
 			]
 
 			for project in dependencies {
-				let result = buildDependencyProject(project, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+				let result = buildDependencyProject(project, directoryURL, withOptions: BuildOptions(configuration: "Debug"), cachedBinariesPath: nil)
 					.flatten(.concat)
 					.ignoreTaskData()
 					.on(next: { (project, scheme) in
@@ -102,7 +102,7 @@ class XcodeSpec: QuickSpec {
 				expect(result.error).to(beNil())
 			}
 
-			let result = buildInDirectory(directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(directoryURL, withOptions: BuildOptions(configuration: "Debug"), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in
@@ -187,7 +187,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.`default`.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in
@@ -217,7 +217,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.`default`.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in
@@ -241,7 +241,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.`default`.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in
@@ -263,7 +263,7 @@ class XcodeSpec: QuickSpec {
 
 		it("should build for one platform") {
 			let project = ProjectIdentifier.gitHub(Repository(owner: "github", name: "Archimedes"))
-			let result = buildDependencyProject(project, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
+			let result = buildDependencyProject(project, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in
@@ -284,7 +284,7 @@ class XcodeSpec: QuickSpec {
 
 		it("should build for multiple platforms") {
 			let project = ProjectIdentifier.gitHub(Repository(owner: "github", name: "Archimedes"))
-			let result = buildDependencyProject(project, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
+			let result = buildDependencyProject(project, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in
@@ -331,7 +331,7 @@ class XcodeSpec: QuickSpec {
 			let buildURL = directoryURL.appendingPathComponent(CarthageBinariesFolderPath)
 			let dependencyBuildURL = dependencyURL.appendingPathComponent(CarthageBinariesFolderPath)
 
-			let result = buildDependencyProject(dependency, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildDependencyProject(dependency, directoryURL, withOptions: BuildOptions(configuration: "Debug"), cachedBinariesPath: nil)
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(next: { (project, scheme) in

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -106,6 +106,9 @@ internal struct ProjectEventSink {
 
 		case let .skippedBuilding(project, message):
 			carthage.println(formatting.bullets + "Skipped building " + formatting.projectName(string: project.name) + " due to the error:\n" + message)
+			
+		case let .usedCachedBinaries(project):
+			carthage.println(formatting.bullets + "Using cached binaries for " + formatting.projectName(string: project.name))
 		}
 	}
 }


### PR DESCRIPTION
This patch caches the build products or a given dependency at a given commitish. Subsequent builds for that specific dependency+commitish will then use the cached artefacts instead of building again. The cache is only used when `--use-build-products-cache` is specified on the command line.

I had not taken a look at the pending PRs when I started this and it turns out that the goal is is similar to #1489 however it works across projects. It is more or less a work in progress and I would love some feedback on this. 