### PR TITLE
[swift3-prep] Rename `URL` to `url` to avoid conflict with `Foundation.URL`

### DIFF
--- a/Source/CarthageKit/BuildArguments.swift
+++ b/Source/CarthageKit/BuildArguments.swift
@@ -45,11 +45,11 @@ public struct BuildArguments {
 		var args = [ "xcodebuild" ]
 
 		switch project {
-		case let .workspace(URL):
-			args += [ "-workspace", URL.path! ]
+		case let .workspace(url):
+			args += [ "-workspace", url.path! ]
 
-		case let .projectFile(URL):
-			args += [ "-project", URL.path! ]
+		case let .projectFile(url):
+			args += [ "-project", url.path! ]
 		}
 
 		if let scheme = scheme {

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -26,7 +26,7 @@ public struct Cartfile {
 
 	/// Returns the location where Cartfile should exist within the given
 	/// directory.
-	public static func URLInDirectory(directoryURL: NSURL) -> NSURL {
+	public static func urlInDirectory(directoryURL: NSURL) -> NSURL {
 		return directoryURL.appendingPathComponent("Cartfile")
 	}
 
@@ -133,7 +133,7 @@ public struct ResolvedCartfile {
 
 	/// Returns the location where Cartfile.resolved should exist within the given
 	/// directory.
-	public static func URLInDirectory(directoryURL: NSURL) -> NSURL {
+	public static func urlInDirectory(directoryURL: NSURL) -> NSURL {
 		return directoryURL.appendingPathComponent("Cartfile.resolved")
 	}
 
@@ -187,8 +187,8 @@ public enum ProjectIdentifier: Comparable {
 		case let .gitHub(repo):
 			return repo.name
 
-		case let .git(URL):
-			return URL.name ?? URL.URLString
+		case let .git(url):
+			return url.name ?? url.urlString
 		}
 	}
 
@@ -222,8 +222,8 @@ extension ProjectIdentifier: Hashable {
 		case let .gitHub(repo):
 			return repo.hashValue
 
-		case let .git(URL):
-			return URL.hashValue
+		case let .git(url):
+			return url.hashValue
 		}
 	}
 }
@@ -238,8 +238,8 @@ extension ProjectIdentifier: Scannable {
 				return Repository.fromIdentifier(repoIdentifier).map { self.gitHub($0) }
 			}
 		} else if scanner.scanString("git", into: nil) {
-			parser = { URLString in
-				return .success(self.git(GitURL(URLString)))
+			parser = { urlString in
+				return .success(self.git(GitURL(urlString)))
 			}
 		} else {
 			return .failure(CarthageError.parseError(description: "unexpected dependency type in line: \(scanner.currentLine)"))
@@ -276,8 +276,8 @@ extension ProjectIdentifier: CustomStringConvertible {
 			}
 			return "github \"\(repoDescription)\""
 
-		case let .git(URL):
-			return "git \"\(URL)\""
+		case let .git(url):
+			return "git \"\(url)\""
 		}
 	}
 }

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -26,7 +26,7 @@ private func gitHubUserAgent() -> String {
 
 extension Repository {
 	/// The URL that should be used for cloning this repository over HTTPS.
-	public var HTTPSURL: GitURL {
+	public var httpsURL: GitURL {
 		let auth = tokenFromEnvironment(forServer: server).map { "\($0)@" } ?? ""
 		let scheme = server.URL.scheme!
 
@@ -34,7 +34,7 @@ extension Repository {
 	}
 
 	/// The URL that should be used for cloning this repository over SSH.
-	public var SSHURL: GitURL {
+	public var sshURL: GitURL {
 		return GitURL("ssh://git@\(server.URL.host!)/\(owner)/\(name).git")
 	}
 
@@ -60,10 +60,10 @@ extension Repository {
 
 		// GitHub Enterprise
 		if let
-			URL = NSURL(string: identifier),
-			host = URL.host,
+			url = NSURL(string: identifier),
+			host = url.host,
 			// The trailing slash of the host is included in the components.
-			var pathComponents = URL.pathComponents?.filter({ $0 != "/" })
+			var pathComponents = url.pathComponents?.filter({ $0 != "/" })
 			where pathComponents.count >= 2
 		{
 			// Consider that the instance might be in subdirectories.
@@ -75,7 +75,7 @@ extension Repository {
 			if host == "github.com" || host == "www.github.com" {
 				return .success(self.init(owner: owner, name: stripGitSuffix(name)))
 			} else {
-				let baseURL = URL.URLByDeletingLastPathComponent!.URLByDeletingLastPathComponent!
+				let baseURL = url.URLByDeletingLastPathComponent!.URLByDeletingLastPathComponent!
 				return .success(self.init(server: .enterprise(url: baseURL), owner: owner, name: stripGitSuffix(name)))
 			}
 		}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -27,13 +27,13 @@ public enum ProjectLocator: Comparable {
 	/// The file URL this locator refers to.
 	public var fileURL: NSURL {
 		switch self {
-		case let .workspace(URL):
-			assert(URL.fileURL)
-			return URL
+		case let .workspace(url):
+			assert(url.fileURL)
+			return url
 
-		case let .projectFile(URL):
-			assert(URL.fileURL)
-			return URL
+		case let .projectFile(url):
+			assert(url.fileURL)
+			return url
 		}
 	}
 
@@ -96,17 +96,17 @@ public func locateProjectsInDirectory(directoryURL: NSURL) -> SignalProducer<Pro
 		.flatMap(.merge) { directoriesToSkip in
 			return FileManager.`default`
 				.carthage_enumerator(at: directoryURL.URLByResolvingSymlinksInPath!, includingPropertiesForKeys: [ NSURLTypeIdentifierKey ], options: enumerationOptions, catchErrors: true)
-				.map { _, URL in URL }
-				.filter { URL in
-					return !directoriesToSkip.contains { $0.hasSubdirectory(URL) }
+				.map { _, url in url }
+				.filter { url in
+					return !directoriesToSkip.contains { $0.hasSubdirectory(url) }
 				}
 		}
-		.map { URL -> ProjectLocator? in
-			if let UTI = URL.typeIdentifier.value {
-				if (UTTypeConformsTo(UTI, "com.apple.dt.document.workspace")) {
-					return .workspace(URL)
-				} else if (UTTypeConformsTo(UTI, "com.apple.xcode.project")) {
-					return .projectFile(URL)
+		.map { url -> ProjectLocator? in
+			if let uti = url.typeIdentifier.value {
+				if (UTTypeConformsTo(uti as CFString, "com.apple.dt.document.workspace" as CFString)) {
+					return .workspace(url)
+				} else if (UTTypeConformsTo(uti as CFString, "com.apple.xcode.project" as CFString)) {
+					return .projectFile(url)
 				}
 			}
 			return nil
@@ -703,11 +703,11 @@ private func mergeExecutables(executableURLs: [NSURL], _ outputURL: NSURL) -> Si
 	precondition(outputURL.fileURL)
 
 	return SignalProducer<NSURL, CarthageError>(values: executableURLs)
-		.attemptMap { URL -> Result<String, CarthageError> in
-			if let path = URL.path {
+		.attemptMap { url -> Result<String, CarthageError> in
+			if let path = url.path {
 				return .success(path)
 			} else {
-				return .failure(.parseError(description: "expected file URL to built executable, got (URL)"))
+				return .failure(.parseError(description: "expected file URL to built executable, got \(url)"))
 			}
 		}
 		.collect()
@@ -729,12 +729,12 @@ private func mergeModuleIntoModule(sourceModuleDirectoryURL: NSURL, _ destinatio
 	precondition(destinationModuleDirectoryURL.fileURL)
 
 	return FileManager.`default`.carthage_enumerator(at: sourceModuleDirectoryURL, includingPropertiesForKeys: [], options: [ .SkipsSubdirectoryDescendants, .SkipsHiddenFiles ], catchErrors: true)
-		.attemptMap { _, URL -> Result<NSURL, CarthageError> in
-			let lastComponent: String? = URL.lastPathComponent
+		.attemptMap { _, url -> Result<NSURL, CarthageError> in
+			let lastComponent: String? = url.lastPathComponent
 			let destinationURL = destinationModuleDirectoryURL.appendingPathComponent(lastComponent!).URLByResolvingSymlinksInPath!
 
 			do {
-				try FileManager.`default`.copyItem(at: URL, to: destinationURL)
+				try FileManager.`default`.copyItem(at: url, to: destinationURL)
 				return .success(destinationURL)
 			} catch let error as NSError {
 				return .failure(.writeFailed(destinationURL, error))
@@ -1488,8 +1488,8 @@ public func BCSymbolMapsForFramework(frameworkURL: NSURL) -> SignalProducer<NSUR
 }
 
 /// Sends a set of UUIDs for each architecture present in the given URL.
-private func UUIDsFromDwarfdump(URL: NSURL) -> SignalProducer<Set<UUID>, CarthageError> {
-	let dwarfdumpTask = Task("/usr/bin/xcrun", arguments: [ "dwarfdump", "--uuid", URL.path! ])
+private func UUIDsFromDwarfdump(url: NSURL) -> SignalProducer<Set<UUID>, CarthageError> {
+	let dwarfdumpTask = Task("/usr/bin/xcrun", arguments: [ "dwarfdump", "--uuid", url.path! ])
 
 	return dwarfdumpTask.launch()
 		.ignoreTaskData()
@@ -1527,7 +1527,7 @@ private func UUIDsFromDwarfdump(URL: NSURL) -> SignalProducer<Set<UUID>, Carthag
 			if !uuids.isEmpty {
 				return SignalProducer(value: uuids)
 			} else {
-				return SignalProducer(error: .invalidUUIDs(description: "Could not parse UUIDs using dwarfdump from \(URL.path!)"))
+				return SignalProducer(error: .invalidUUIDs(description: "Could not parse UUIDs using dwarfdump from \(url.path!)"))
 			}
 		}
 }

--- a/Source/CarthageKitTests/ArchiveSpec.swift
+++ b/Source/CarthageKitTests/ArchiveSpec.swift
@@ -78,7 +78,7 @@ class ArchiveSpec: QuickSpec {
 				expect(unzipResult?.error).to(beNil())
 
 				let enumerationResult = FileManager.`default`.carthage_enumerator(at: unzipResult?.value ?? temporaryURL, includingPropertiesForKeys: [])
-					.map { enumerator, URL in URL }
+					.map { enumerator, url in url }
 					.map { $0.lastPathComponent! }
 					.collect()
 					.single()

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -376,14 +376,14 @@ internal func beRelativeSymlinkToDirectory(directory: NSURL) -> MatcherFunc<NSUR
 		failureMessage.postfixMessage = "be a relative symlink to \(directory)"
 		let actualURL = try actualExpression.evaluate()
 
-		guard let URL = actualURL else {
+		guard let url = actualURL else {
 			return false
 		}
 		var isSymlink: Bool = false
 		do {
 			var isSymlinkObj: AnyObject?
-			URL.removeCachedResourceValueForKey(NSURLIsSymbolicLinkKey)
-			try URL.getResourceValue(&isSymlinkObj, forKey: NSURLIsSymbolicLinkKey)
+			url.removeCachedResourceValueForKey(NSURLIsSymbolicLinkKey)
+			try url.getResourceValue(&isSymlinkObj, forKey: NSURLIsSymbolicLinkKey)
 			if isSymlinkObj != nil {
 				isSymlink = isSymlinkObj!.boolValue
 			}
@@ -394,14 +394,14 @@ internal func beRelativeSymlinkToDirectory(directory: NSURL) -> MatcherFunc<NSUR
 			return false
 		}
 
-		let destination: NSString = try! FileManager.`default`.destinationOfSymbolicLink(atPath: URL.path!)
+		let destination: NSString = try! FileManager.`default`.destinationOfSymbolicLink(atPath: url.path!)
 
 		guard !destination.absolutePath else {
 			failureMessage.postfixMessage += ", but is not a relative symlink"
 			return false
 		}
 
-		let standardDestination = URL.URLByResolvingSymlinksInPath?.URLByStandardizingPath
+		let standardDestination = url.URLByResolvingSymlinksInPath?.URLByStandardizingPath
 		let desiredDestination = directory.URLByStandardizingPath
 
 		let urlsEqual = standardDestination != nil && desiredDestination != nil && standardDestination == desiredDestination

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -216,7 +216,7 @@ public struct BuildCommand: CommandType {
 			return SignalProducer(value: out)
 		} else {
 			return openTemporaryFile()
-				.map { handle, URL in (handle, .Some(URL)) }
+				.map { handle, url in (handle, Optional(url)) }
 				.mapError { error in
 					let temporaryDirectoryURL = NSURL.fileURLWithPath(NSTemporaryDirectory(), isDirectory: true)
 					return .writeFailed(temporaryDirectoryURL, error)

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -90,7 +90,7 @@ private func copyBCSymbolMapsForFramework(frameworkURL: NSURL, fromDirectory dir
 	return SignalProducer(result: builtProductsFolder())
 		.flatMap(.merge) { builtProductsURL in
 			return BCSymbolMapsForFramework(frameworkURL)
-				.map { URL in directoryURL.appendingPathComponent(URL.lastPathComponent!, isDirectory: false) }
+				.map { url in directoryURL.appendingPathComponent(url.lastPathComponent!, isDirectory: false) }
 				.copyFileURLsIntoDirectory(builtProductsURL)
 		}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -58,7 +58,7 @@ public struct ColorOptions: OptionsType {
 		let isColorful: Bool
 		let bullets: String
 		let bulletin: Wrap
-		let URL: Wrap
+		let url: Wrap
 		let projectName: Wrap
 		let path: Wrap
 		
@@ -70,7 +70,7 @@ public struct ColorOptions: OptionsType {
 			self.isColorful = isColorful
 			bulletin      = wrap(isColorful, wrap: Color.Wrap(foreground: .Blue, style: .Bold))
 			bullets       = bulletin(string: "***") + " "
-			URL           = wrap(isColorful, wrap: Color.Wrap(styles: .Underlined))
+			url           = wrap(isColorful, wrap: Color.Wrap(styles: .Underlined))
 			projectName   = wrap(isColorful, wrap: Color.Wrap(styles: .Bold))
 			path          = wrap(isColorful, wrap: Color.Wrap(foreground: .Yellow))
 		}


### PR DESCRIPTION
This also adopts https://swift.org/documentation/api-design-guidelines/#follow-case-conventions for some occurrences.

#1558 
