### PR TITLE
allow frameworks to specify which schemes Carthage should build

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -164,14 +164,26 @@ public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, 
 		.map { (line: String) -> String in line.stringByTrimmingCharactersInSet(.whitespaces) }
 }
 
+
+/// Returns schemes specified by the `.carthage_schemes` file at the directory specified.
+/// Returns `nil` if it doesn't exist.
+private func carthageSchemesFileSchemes(directoryURL: NSURL) -> [String]? {
+	let carthageSchemesFileURL = directoryURL.appendingPathComponent(".carthage_schemes")
+	let contents = try? String(contentsOfURL: carthageSchemesFileURL, encoding: NSUTF8StringEncoding)
+	return contents?.componentsSeparatedByCharactersInSet(.newlines).filter { !$0.isEmpty }
+}
+
 /// Finds schemes of projects or workspaces, which Carthage should build, found
 /// within the given directory.
 public func buildableSchemesInDirectory(directoryURL: NSURL, withConfiguration configuration: String, forPlatforms platforms: Set<Platform> = []) -> SignalProducer<(ProjectLocator, [String]), CarthageError> {
 	precondition(directoryURL.fileURL)
 
+	let filteredSchemes = carthageSchemesFileSchemes(directoryURL)
+
 	return locateProjectsInDirectory(directoryURL)
 		.flatMap(.concat) { project -> SignalProducer<(ProjectLocator, [String]), CarthageError> in
 			return schemesInProject(project)
+				.filter { scheme in return filteredSchemes?.contains(scheme) ?? true }
 				.flatMap(.merge) { scheme -> SignalProducer<String, CarthageError> in
 					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
 


### PR DESCRIPTION
By specifying an optional `.carthage_schemes` file at the root of a framework repo, Carthage can skip much of the work involved in evaluating which schemes to build in a directory.

If present, the `.carthage_schemes` file should be a newline-separated list of scheme names that Carthage should build.

The work involved in evaluating which schemes to build can be substantial due to requiring `xcodebuild` invocations. In the case of the Realm frameworks, for example, using this approach shaves minutes off the total update time.

Since frameworks are sometimes useful for purposes internal to a repo and not meant to be consumed externally, specifying a subset of schemes to build in `.carthage_schemes` can also great speed up build times.

This can also be useful to work around certain Xcode bugs, such as when Xcode considers unit test bundle products to actually be framework products [rdar://29407087](http://www.openradar.me/29407087).