### PR TITLE
Detect duplicates early

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		89E80E641C755059000F8DCB /* BuildArgumentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E80E631C755059000F8DCB /* BuildArgumentsSpec.swift */; };
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
+		BE624F491E13424400EAEFC9 /* DuplicateDependenciesCartfile in Resources */ = {isa = PBXBuildFile; fileRef = BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */; };
 		BEA86F9F1C9F914A0049360B /* Curry.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = BEB076641C8A1FD800ABD373 /* Curry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BEA86FA01C9F91500049360B /* Tentacle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = BEB076651C8A1FD800ABD373 /* Tentacle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BEB076661C8A1FD800ABD373 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB076641C8A1FD800ABD373 /* Curry.framework */; };
@@ -190,6 +191,7 @@
 		89E80E631C755059000F8DCB /* BuildArgumentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArgumentsSpec.swift; sourceTree = "<group>"; };
 		98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-bash-completion"; sourceTree = "<group>"; };
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
+		BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DuplicateDependenciesCartfile; sourceTree = "<group>"; };
 		BEB076641C8A1FD800ABD373 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Curry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEB076651C8A1FD800ABD373 /* Tentacle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Tentacle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD07EB101E0EA5B200CFBEE4 /* ProjectLocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectLocator.swift; sourceTree = "<group>"; };
@@ -532,6 +534,7 @@
 				CD7F22431C67649F00B018A9 /* TestCartfileProposedVersion */,
 				D0F551DB1A0D71AB0093311F /* TestCartfile.resolved */,
 				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
+				BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */,
 				D04A39811A2F72FB000C5604 /* EmbeddedFrameworksCartfile */,
 				D04A397F1A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile */,
 			);
@@ -672,6 +675,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D04A39801A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile in Resources */,
+				BE624F491E13424400EAEFC9 /* DuplicateDependenciesCartfile in Resources */,
 				D0AAAB5519FB1062007B24B3 /* TestCartfile in Resources */,
 				D0F551DC1A0D71AB0093311F /* TestCartfile.resolved in Resources */,
 				D04A39821A2F72FB000C5604 /* EmbeddedFrameworksCartfile in Resources */,

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -90,18 +90,18 @@ public struct Cartfile {
 			return Cartfile
 				.from(string: cartfileContents)
 				.mapError { error in
-					if case let .duplicateDependencies(dupes) = error {
-						let dupes = dupes
-							.map { dependency in
-								return DuplicateDependency(
-									project: dependency.project,
-									locations: [ cartfileURL.carthage_path ]
-								)
-							}
-						return .duplicateDependencies(dupes)
-					} else {
+					guard case let .duplicateDependencies(dupes) = error else {
 						return error
 					}
+					
+					let dependencies = dupes
+						.map { dependency in
+							return DuplicateDependency(
+								project: dependency.project,
+								locations: [ cartfileURL.carthage_path ]
+							)
+						}
+					return .duplicateDependencies(dependencies)
 				}
 		} catch let error as NSError {
 			return .failure(CarthageError.readFailed(cartfileURL, error))

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -69,14 +69,40 @@ public struct Cartfile {
 			}
 		}
 
-		return result.map { _ in cartfile }
+		return result.flatMap { _ in
+			let dupes = cartfile
+				.dependencyCountedSet
+				.filter { $0.1 > 1 }
+				.map { $0.0 }
+				.map { DuplicateDependency(project: $0, locations: []) }
+			
+			if !dupes.isEmpty {
+				return .failure(.duplicateDependencies(dupes))
+			}
+			return .success(cartfile)
+		}
 	}
 
 	/// Attempts to parse a Cartfile from a file at a given URL.
 	public static func from(file cartfileURL: URL) -> Result<Cartfile, CarthageError> {
 		do {
 			let cartfileContents = try String(contentsOf: cartfileURL, encoding: .utf8)
-			return Cartfile.from(string: cartfileContents)
+			return Cartfile
+				.from(string: cartfileContents)
+				.mapError { error in
+					if case let .duplicateDependencies(dupes) = error {
+						let dupes = dupes
+							.map { dependency in
+								return DuplicateDependency(
+									project: dependency.project,
+									locations: [ cartfileURL.carthage_path ]
+								)
+							}
+						return .duplicateDependencies(dupes)
+					} else {
+						return error
+					}
+				}
 		} catch let error as NSError {
 			return .failure(CarthageError.readFailed(cartfileURL, error))
 		}
@@ -96,13 +122,6 @@ extension Cartfile: CustomStringConvertible {
 
 // Duplicate dependencies
 extension Cartfile {
-	/// Returns an array containing projects that are listed as duplicate
-	/// dependencies.
-	public func duplicateProjects() -> [ProjectIdentifier] {
-		return self.dependencyCountedSet.filter { $0.1 > 1 }
-			.map { $0.0 }
-	}
-
 	/// Returns the dependencies in a cartfile as a counted set containing the
 	/// corresponding projects, represented as a dictionary.
 	private var dependencyCountedSet: [ProjectIdentifier: Int] {

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -237,10 +237,10 @@ extension CarthageError: CustomStringConvertible {
 			return "xcodebuild timed out while trying to read \(project) 😭"
 			
 		case let .duplicateDependencies(duplicateDeps):
-			let deps = duplicateDeps.sorted() // important to match expected order in test cases
-				.reduce("") { (acc, dep) in
-					"\(acc)\n\t\(dep)"
-				}
+			let deps = duplicateDeps
+				.sorted() // important to match expected order in test cases
+				.map { "\n\t" + $0.description }
+				.joined(separator: "")
 
 			return "The following dependencies are duplicates:\(deps)"
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -216,9 +216,7 @@ public final class Project {
 			.attemptMap { cartfile, privateCartfile -> Result<Cartfile, CarthageError> in
 				var cartfile = cartfile
 
-				let duplicateDeps = cartfile.duplicateProjects().map { DuplicateDependency(project: $0, locations: ["\(CarthageProjectCartfilePath)"]) }
-					+ privateCartfile.duplicateProjects().map { DuplicateDependency(project: $0, locations: ["\(CarthageProjectPrivateCartfilePath)"]) }
-					+ duplicateProjectsIn(cartfile, privateCartfile).map { DuplicateDependency(project: $0, locations: ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]) }
+				let duplicateDeps = duplicateProjectsIn(cartfile, privateCartfile).map { DuplicateDependency(project: $0, locations: ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]) }
 
 				if duplicateDeps.isEmpty {
 					cartfile.append(privateCartfile)

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -92,7 +92,7 @@ class CartfileSpec: QuickSpec {
 				let self3Dupe = dupes[1]
 				expect(self3Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self3", name: "self3"))
 			} else {
-				fatalError("should error")
+				fail("Cartfile should error with duplicate dependencies")
 			}
 		}
 

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -80,20 +80,21 @@ class CartfileSpec: QuickSpec {
 			let result = Cartfile.from(string: testCartfile)
 			expect(result.error).notTo(beNil())
 
-			if case let .duplicateDependencies(dupes)? = result.error {
-				let dupes = dupes
-					.map { $0.project }
-					.sort { $0.description < $1.description }
-				expect(dupes.count) == 2
-				
-				let self2Dupe = dupes[0]
-				expect(self2Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self2", name: "self2"))
-				
-				let self3Dupe = dupes[1]
-				expect(self3Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self3", name: "self3"))
-			} else {
+			guard case let .duplicateDependencies(dupes)? = result.error else {
 				fail("Cartfile should error with duplicate dependencies")
+				return
 			}
+			
+			let projects = dupes
+				.map { $0.project }
+				.sort { $0.description < $1.description }
+			expect(dupes.count) == 2
+			
+			let self2Dupe = projects[0]
+			expect(self2Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self2", name: "self2"))
+			
+			let self3Dupe = projects[1]
+			expect(self3Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self3", name: "self3"))
 		}
 
 		it("should detect duplicate dependencies across two Cartfiles") {

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -74,23 +74,26 @@ class CartfileSpec: QuickSpec {
 		}
 
 		it("should detect duplicate dependencies in a single Cartfile") {
-			let testCartfileURL = Bundle(for: type(of: self)).url(forResource: "DuplicateDependencies/Cartfile", withExtension: "")!
+			let testCartfileURL = Bundle(for: type(of: self)).url(forResource: "DuplicateDependenciesCartfile", withExtension: "")!
 			let testCartfile = try! String(contentsOf: testCartfileURL, encoding: .utf8)
 
 			let result = Cartfile.from(string: testCartfile)
-			expect(result.error).to(beNil())
+			expect(result.error).notTo(beNil())
 
-			let cartfile = result.value!
-			expect(cartfile.dependencies.count) == 11
-
-			let dupes = cartfile.duplicateProjects().sort { $0.description < $1.description }
-			expect(dupes.count) == 2
-
-			let self2Dupe = dupes[0]
-			expect(self2Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self2", name: "self2"))
-
-			let self3Dupe = dupes[1]
-			expect(self3Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self3", name: "self3"))
+			if case let .duplicateDependencies(dupes)? = result.error {
+				let dupes = dupes
+					.map { $0.project }
+					.sort { $0.description < $1.description }
+				expect(dupes.count) == 2
+				
+				let self2Dupe = dupes[0]
+				expect(self2Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self2", name: "self2"))
+				
+				let self3Dupe = dupes[1]
+				expect(self3Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self3", name: "self3"))
+			} else {
+				fatalError("should error")
+			}
 		}
 
 		it("should detect duplicate dependencies across two Cartfiles") {
@@ -107,7 +110,7 @@ class CartfileSpec: QuickSpec {
 			expect(result2.error).to(beNil())
 
 			let cartfile = result.value!
-			expect(cartfile.dependencies.count) == 11
+			expect(cartfile.dependencies.count) == 5
 
 			let cartfile2 = result2.value!
 			expect(cartfile2.dependencies.count) == 3

--- a/Source/CarthageKitTests/DuplicateDependencies/Cartfile
+++ b/Source/CarthageKitTests/DuplicateDependencies/Cartfile
@@ -1,10 +1,3 @@
-github "self3/self3"
-github "self2/Self2"
-github "self3/self3"
-github "self1/self1"
-github "Self3/Self3"
-github "Self2/self2"
-
 github "1/1"
 github "2/2"
 github "3/3"

--- a/Source/CarthageKitTests/DuplicateDependenciesCartfile
+++ b/Source/CarthageKitTests/DuplicateDependenciesCartfile
@@ -1,0 +1,6 @@
+github "self3/self3"
+github "self2/Self2"
+github "self3/self3"
+github "self1/self1"
+github "Self3/Self3"
+github "Self2/self2"

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -55,8 +55,6 @@ class ProjectSpec: QuickSpec {
 				let bothLocations = ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]
 
 				let expectedError = CarthageError.duplicateDependencies([
-					makeDependency("self2", "self2", mainLocation),
-					makeDependency("self3", "self3", mainLocation),
 					makeDependency("1", "1", bothLocations),
 					makeDependency("3", "3", bothLocations),
 					makeDependency("5", "5", bothLocations),

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -51,13 +51,12 @@ class ProjectSpec: QuickSpec {
 					return DuplicateDependency(project: project, locations: locations)
 				}
 
-				let mainLocation = ["\(CarthageProjectCartfilePath)"]
-				let bothLocations = ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]
+				let locations = ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]
 
 				let expectedError = CarthageError.duplicateDependencies([
-					makeDependency("1", "1", bothLocations),
-					makeDependency("3", "3", bothLocations),
-					makeDependency("5", "5", bothLocations),
+					makeDependency("1", "1", locations),
+					makeDependency("3", "3", locations),
+					makeDependency("5", "5", locations),
 				])
 
 				expect(resultError) == expectedError


### PR DESCRIPTION
This is the first step in some cleanup I want to do—changing Cartfiles to have `Set`s of dependencies instead of `Array`s, changing `Resolver` to not know about `Cartfile`s, etc.