### PR TITLE
Don't use Cartfiles in Resolver

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -130,9 +130,17 @@ public func duplicateProjectsIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile) ->
 /// Represents a parsed Cartfile.resolved, which specifies which exact version was
 /// checked out for each dependency.
 public struct ResolvedCartfile {
-	/// The dependencies listed in the Cartfile.resolved, in the order that they
-	/// should be built.
+	/// The dependencies listed in the Cartfile.resolved.
 	public var dependencies: [Dependency<PinnedVersion>]
+	
+	/// The version of each project
+	public var versions: [ProjectIdentifier: PinnedVersion] {
+		var versions: [ProjectIdentifier: PinnedVersion] = [:]
+		for dependency in dependencies {
+			versions[dependency.project] = dependency.version
+		}
+		return versions
+	}
 
 	public init(dependencies: [Dependency<PinnedVersion>]) {
 		self.dependencies = dependencies
@@ -162,13 +170,6 @@ public struct ResolvedCartfile {
 		}
 
 		return result.map { _ in cartfile }
-	}
-
-	/// Returns the dependency whose project matches the given project or nil.
-	internal func dependency(for project: ProjectIdentifier) -> Dependency<PinnedVersion>? {
-		return dependencies.lazy
-			.filter { $0.project == project }
-			.first
 	}
 }
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -359,7 +359,11 @@ public final class Project {
 		return SignalProducer
 			.zip(loadCombinedCartfile(), resolvedCartfile)
 			.flatMap(.merge) { cartfile, resolvedCartfile in
-				return resolver.resolve(dependencies: cartfile.dependencies, lastResolved: resolvedCartfile, dependenciesToUpdate: dependenciesToUpdate)
+				return resolver.resolve(
+					dependencies: cartfile.dependencies,
+					lastResolved: resolvedCartfile?.versions,
+					dependenciesToUpdate: dependenciesToUpdate
+				)
 			}
 			.collect()
 			.map(ResolvedCartfile.init)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -250,7 +250,7 @@ public final class Project {
 	}
 
 	/// Produces the sub dependencies of the given dependency
-	func dependencyProjectsForDependency(dependency: Dependency<PinnedVersion>) -> SignalProducer<Set<ProjectIdentifier>, CarthageError> {
+	func dependencyProjects(for dependency: Dependency<PinnedVersion>) -> SignalProducer<Set<ProjectIdentifier>, CarthageError> {
 		return self.dependencies(for: dependency)
 			.map { $0.project }
 			.collect()
@@ -591,7 +591,7 @@ public final class Project {
 						.startOnQueue(self.gitOperationQueue)
 				} else {
 					return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, revision: revision)
-						.then(self.dependencyProjectsForDependency(dependency))
+						.then(self.dependencyProjects(for: dependency))
 						.flatMap(.merge) { dependencies in
 							return self.symlinkCheckoutPathsForDependencyProject(dependency.project, subDependencies: dependencies, rootDirectoryURL: self.directoryURL)
 						}
@@ -610,7 +610,7 @@ public final class Project {
 		// dependencies before the projects that depend on them.
 		return SignalProducer<Dependency<PinnedVersion>, CarthageError>(cartfile.dependencies)
 			.flatMap(.merge) { (dependency: Dependency<PinnedVersion>) -> SignalProducer<DependencyGraph, CarthageError> in
-				return self.dependencyProjectsForDependency(dependency)
+				return self.dependencyProjects(for: dependency)
 					.map { dependencies in
 						[dependency.project: dependencies]
 					}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -323,7 +323,7 @@ public final class Project {
 			.flatMapError { _ in .empty }
 			.attemptMap(Cartfile.from(string:))
 			.flatMap(.concat) { cartfile -> SignalProducer<Dependency<VersionSpecifier>, CarthageError> in
-				return SignalProducer(Array(cartfile.dependencies))
+				return SignalProducer(cartfile.dependencies)
 			}
 	}
 

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -169,7 +169,7 @@ public struct Resolver {
 	///
 	/// This is a helper method, and not meant to be called from outside.
 	private func graphs(for nodes: [DependencyNode], dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
-		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.graphsForNodes")
+		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.graphs")
 		
 		return SignalProducer<(DependencyGraph, [DependencyNode]), CarthageError>
 			.attempt {

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -14,31 +14,35 @@ import ReactiveCocoa
 public struct Resolver {
 	private let versionsForDependency: (ProjectIdentifier) -> SignalProducer<PinnedVersion, CarthageError>
 	private let resolvedGitReference: (ProjectIdentifier, String) -> SignalProducer<PinnedVersion, CarthageError>
-	private let cartfileForDependency: (Dependency<PinnedVersion>) -> SignalProducer<Cartfile, CarthageError>
+	private let dependenciesForDependency: (Dependency<PinnedVersion>) -> SignalProducer<Dependency<VersionSpecifier>, CarthageError>
 
 	/// Instantiates a dependency graph resolver with the given behaviors.
 	///
 	/// versionsForDependency - Sends a stream of available versions for a
 	///                         dependency.
-	/// cartfileForDependency - Loads the Cartfile for a specific version of a
-	///                         dependency.
-	/// resolvedGitReference  - Resolves an arbitrary Git reference to the
-	///                         latest object.
-	public init(versionsForDependency: (ProjectIdentifier) -> SignalProducer<PinnedVersion, CarthageError>, cartfileForDependency: (Dependency<PinnedVersion>) -> SignalProducer<Cartfile, CarthageError>, resolvedGitReference: (ProjectIdentifier, String) -> SignalProducer<PinnedVersion, CarthageError>) {
+	/// dependenciesForDependency - Loads the dependencies for a specific
+	///                             version of a dependency.
+	/// resolvedGitReference - Resolves an arbitrary Git reference to the
+	///                        latest object.
+	public init(
+		versionsForDependency: (ProjectIdentifier) -> SignalProducer<PinnedVersion, CarthageError>,
+		dependenciesForDependency: (Dependency<PinnedVersion>) -> SignalProducer<Dependency<VersionSpecifier>, CarthageError>,
+		resolvedGitReference: (ProjectIdentifier, String) -> SignalProducer<PinnedVersion, CarthageError>
+	) {
 		self.versionsForDependency = versionsForDependency
-		self.cartfileForDependency = cartfileForDependency
+		self.dependenciesForDependency = dependenciesForDependency
 		self.resolvedGitReference = resolvedGitReference
 	}
 
-	/// Attempts to determine the latest valid version to use for each dependency
-	/// specified in the given Cartfile, and all nested dependencies thereof.
+	/// Attempts to determine the latest valid version to use for each
+	/// dependency in `dependencies`, and all nested dependencies thereof.
 	///
 	/// Sends each recursive dependency with its resolved version, in the order
 	/// that they should be built.
-	public func resolveDependenciesInCartfile(cartfile: Cartfile, lastResolved: ResolvedCartfile? = nil, dependenciesToUpdate: [String]? = nil) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
-		return graphsForCartfile(cartfile, dependencyOf: nil, basedOnGraph: DependencyGraph())
+	public func resolve(dependencies dependencies: Set<Dependency<VersionSpecifier>>, lastResolved: ResolvedCartfile? = nil, dependenciesToUpdate: [String]? = nil) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
+		return graphs(for: Array(dependencies), dependencyOf: nil, basedOnGraph: DependencyGraph())
 			.take(first: 1)
-			.observe(on: QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.resolveDependencesInCartfile"))
+			.observe(on: QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.resolve"))
 			.flatMap(.merge) { graph -> SignalProducer<Dependency<PinnedVersion>, CarthageError> in
 				let orderedNodes = graph.orderedNodes.map { node -> DependencyNode in
 					node.dependencies = graph.edges[node] ?? []
@@ -81,17 +85,16 @@ public struct Resolver {
 	}
 
 	/// Sends all permutations of valid DependencyNodes, corresponding to the
-	/// dependencies listed in the given Cartfile, in the order that they should
-	/// be tried.
+	/// given dependencies, in the order that they should be tried.
 	///
 	/// In other words, this will always send arrays equal in length to
-	/// `cartfile.dependencies`. Each array represents one possible permutation
-	/// of those dependencies (chosen from among the versions that actually
-	/// exist for each).
-	private func nodePermutationsForCartfile(cartfile: Cartfile) -> SignalProducer<[DependencyNode], CarthageError> {
-		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.nodePermutationsForCartfile")
+	/// `dependencies`. Each array represents one possible permutation of those
+	/// dependencies (chosen from among the versions that actually exist for
+	/// each).
+	private func nodePermutations(for dependencies: [Dependency<VersionSpecifier>]) -> SignalProducer<[DependencyNode], CarthageError> {
+		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.nodePermutations")
 
-		return SignalProducer(cartfile.dependencies)
+		return SignalProducer(dependencies)
 			.map { dependency -> SignalProducer<DependencyNode, CarthageError> in
 				return SignalProducer(value: dependency)
 					.flatMap(.concat) { dependency -> SignalProducer<PinnedVersion, CarthageError> in
@@ -129,26 +132,27 @@ public struct Resolver {
 	private func graphsForDependenciesOfNode(node: DependencyNode, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
 		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.graphsForDependenciesOfNode")
 
-		return cartfileForDependency(node.dependencyVersion)
+		return dependenciesForDependency(node.dependencyVersion)
 			.start(on: scheduler)
-			.concat(SignalProducer(value: Cartfile(dependencies: [])))
+			.collect()
+			.concat(value: [])
 			.take(first: 1)
 			.observe(on: scheduler)
-			.flatMap(.concat) { cartfile in
-				return self.graphsForCartfile(cartfile, dependencyOf: node, basedOnGraph: inputGraph)
+			.flatMap(.concat) { dependencies in
+				return self.graphs(for: dependencies, dependencyOf: node, basedOnGraph: inputGraph)
 			}
 	}
 	
-	/// Recursively permutes the dependencies in `cartfile` and all dependencies
-	/// thereof, attaching each permutation to `inputGraph` as a dependency of
-	/// the specified node (or as a root otherwise).
+	/// Recursively permutes `dependencies` and all dependencies thereof,
+	/// attaching each permutation to `inputGraph` as a dependency of the
+	/// specified node (or as a root otherwise).
 	///
 	/// This is a helper method, and not meant to be called from outside.
-	private func graphsForCartfile(cartfile: Cartfile, dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
-		return nodePermutationsForCartfile(cartfile)
+	private func graphs(for dependencies: [Dependency<VersionSpecifier>], dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
+		return nodePermutations(for: dependencies)
 			.flatMap(.concat) { (nodes: [DependencyNode]) -> SignalProducer<Event<DependencyGraph, CarthageError>, NoError> in
 				return self
-					.graphsForNodes(nodes, dependencyOf: dependencyOf, basedOnGraph: inputGraph)
+					.graphs(for: nodes, dependencyOf: dependencyOf, basedOnGraph: inputGraph)
 					.materialize()
 			}
 			// Pass through resolution errors only if we never got
@@ -161,7 +165,7 @@ public struct Resolver {
 	/// the specified node (or as a root otherwise).
 	///
 	/// This is a helper method, and not meant to be called from outside.
-	private func graphsForNodes(nodes: [DependencyNode], dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
+	private func graphs(for nodes: [DependencyNode], dependencyOf: DependencyNode?, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
 		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.graphsForNodes")
 		
 		return SignalProducer<(DependencyGraph, [DependencyNode]), CarthageError>

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -41,7 +41,7 @@ public struct Resolver {
 	/// that they should be built.
 	public func resolve(
 		dependencies dependencies: Set<Dependency<VersionSpecifier>>,
-		lastResolved: ResolvedCartfile? = nil,
+	    lastResolved: [ProjectIdentifier: PinnedVersion]? = nil,
 		dependenciesToUpdate: [String]? = nil
 	) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
 		return graphs(for: Array(dependencies), dependencyOf: nil, basedOnGraph: DependencyGraph())
@@ -75,10 +75,9 @@ public struct Resolver {
 					}
 
 					// The dependencies which are not related to the targets
-					// should not be affected, so use the version in the last
-					// Cartfile.resolved.
-					if let dependencyForProject = lastResolved.dependency(for: node.project) {
-						return dependencyForProject
+					// should not be affected, so use the last resolved version.
+					if let version = lastResolved[node.project] {
+						return Dependency(project: node.project, version: version)
 					}
 
 					// Skip newly added nodes which are not in the targets.

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -41,7 +41,7 @@ public struct Resolver {
 	/// that they should be built.
 	public func resolve(
 		dependencies dependencies: Set<Dependency<VersionSpecifier>>,
-	    lastResolved: [ProjectIdentifier: PinnedVersion]? = nil,
+		lastResolved: [ProjectIdentifier: PinnedVersion]? = nil,
 		dependenciesToUpdate: [String]? = nil
 	) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
 		return graphs(for: dependencies, dependencyOf: nil, basedOnGraph: DependencyGraph())

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -39,7 +39,11 @@ public struct Resolver {
 	///
 	/// Sends each recursive dependency with its resolved version, in the order
 	/// that they should be built.
-	public func resolve(dependencies dependencies: Set<Dependency<VersionSpecifier>>, lastResolved: ResolvedCartfile? = nil, dependenciesToUpdate: [String]? = nil) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
+	public func resolve(
+		dependencies dependencies: Set<Dependency<VersionSpecifier>>,
+		lastResolved: ResolvedCartfile? = nil,
+		dependenciesToUpdate: [String]? = nil
+	) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
 		return graphs(for: Array(dependencies), dependencyOf: nil, basedOnGraph: DependencyGraph())
 			.take(first: 1)
 			.observe(on: QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.resolve"))

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -97,7 +97,7 @@ public struct Resolver {
 	private func nodePermutations(for dependencies: Set<Dependency<VersionSpecifier>>) -> SignalProducer<[DependencyNode], CarthageError> {
 		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.nodePermutations")
 
-		return SignalProducer(Array(dependencies))
+		return SignalProducer(dependencies)
 			.map { dependency -> SignalProducer<DependencyNode, CarthageError> in
 				return SignalProducer(value: dependency)
 					.flatMap(.concat) { dependency -> SignalProducer<PinnedVersion, CarthageError> in

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -75,7 +75,7 @@ class ResolverSpec: QuickSpec {
 				dependencies: testCartfile.dependencies,
 				lastResolved: ResolvedCartfile(dependencies: [
 						self.dependencyForOwner("danielgindi", name: "ios-charts", version: "2.4.0"),
-					]),
+					]).versions,
 				dependenciesToUpdate: [ "Mantle", "ReactiveCocoa" ]
 			)
 			let dependencies = self.orderedDependencies(producer)

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -43,15 +43,15 @@ class ResolverSpec: QuickSpec {
 
 		beforeEach {
 			resolver = Resolver(
-				versionsForDependency: self.versionsForDependency,
-				cartfileForDependency: self.cartfileForDependency,
+				versionsForDependency: self.versions(for:),
+				dependenciesForDependency: self.dependencies(for:),
 				resolvedGitReference: self.resolvedGitReference
 			)
 		}
 
 		it("should resolve a Cartfile") {
 			let testCartfile: Cartfile = self.loadTestCartfile("TestCartfile")
-			let producer = resolver.resolveDependenciesInCartfile(testCartfile)
+			let producer = resolver.resolve(dependencies: testCartfile.dependencies)
 			let dependencies = self.orderedDependencies(producer)
 			expect(dependencies.count) == 8
 
@@ -71,8 +71,8 @@ class ResolverSpec: QuickSpec {
 		it("should resolve a Cartfile for specific dependencies") {
 			let testCartfile: Cartfile = self.loadTestCartfile("TestCartfile")
 
-			let producer = resolver.resolveDependenciesInCartfile(
-				testCartfile,
+			let producer = resolver.resolve(
+				dependencies: testCartfile.dependencies,
 				lastResolved: ResolvedCartfile(dependencies: [
 						self.dependencyForOwner("danielgindi", name: "ios-charts", version: "2.4.0"),
 					]),
@@ -104,7 +104,7 @@ class ResolverSpec: QuickSpec {
 
 		it("should resolve a Cartfile whose dependency is specified by both a branch name and a SHA which is the HEAD of that branch") {
 			let testCartfile: Cartfile = self.loadTestCartfile("TestCartfileProposedVersion")
-			let producer = resolver.resolveDependenciesInCartfile(testCartfile)
+			let producer = resolver.resolve(dependencies: testCartfile.dependencies)
 			let dependencies = self.orderedDependencies(producer)
 			expect(dependencies.count) == 3
 
@@ -133,18 +133,19 @@ class ResolverSpec: QuickSpec {
 				default:
 					assert(false)
 				}
-			}, cartfileForDependency: { dependency -> SignalProducer<Cartfile, CarthageError> in
+			}, dependenciesForDependency: { dependency -> SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError> in
 				if dependency.project.name == "EmbeddedFrameworks" {
-					return SignalProducer(value: self.loadTestCartfile("EmbeddedFrameworksCartfile"))
+					let cartfile: Cartfile = self.loadTestCartfile("EmbeddedFrameworksCartfile")
+					return SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError>(Array(cartfile.dependencies))
 				} else {
-					return SignalProducer(value: Cartfile())
+					return .empty
 				}
 			}, resolvedGitReference: { _ -> SignalProducer<PinnedVersion, CarthageError> in
 				return SignalProducer(error: .invalidArgument(description: "unexpected test error"))
 			})
 
 			let testCartfile: Cartfile = self.loadTestCartfile("EmbeddedFrameworksContainerCartfile")
-			let producer = resolver.resolveDependenciesInCartfile(testCartfile)
+			let producer = resolver.resolve(dependencies: testCartfile.dependencies)
 			let dependencies = self.orderedDependencies(producer)
 			expect(dependencies.count) == 4
 
@@ -158,7 +159,7 @@ class ResolverSpec: QuickSpec {
 		}
 	}
 
-	private func versionsForDependency(project: ProjectIdentifier) -> SignalProducer<PinnedVersion, CarthageError> {
+	private func versions(for project: ProjectIdentifier) -> SignalProducer<PinnedVersion, CarthageError> {
 		return SignalProducer([
 			PinnedVersion("0.4.1"),
 			PinnedVersion("0.9.0"),
@@ -169,27 +170,47 @@ class ResolverSpec: QuickSpec {
 		])
 	}
 
-	private func cartfileForDependency(dependency: CarthageKit.Dependency<PinnedVersion>) -> SignalProducer<Cartfile, CarthageError> {
-		let cartfile: Result<Cartfile, CarthageError>
-
+	private func dependencies(for dependency: CarthageKit.Dependency<PinnedVersion>) -> SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError> {
 		switch dependency.project {
 		case .gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")):
-			cartfile = Cartfile.from(string: "github \"jspahrsummers/libextobjc\" ~> 0.4\ngithub \"jspahrsummers/objc-build-scripts\" >= 3.0")
+			return SignalProducer([
+				CarthageKit.Dependency(
+					project: .gitHub(Repository(owner: "jspahrsummers", name: "libextobjc")),
+					version: .compatibleWith(SemanticVersion(major: 0, minor: 4, patch: 0))
+				),
+				CarthageKit.Dependency(
+					project: .gitHub(Repository(owner: "jspahrsummers", name: "objc-build-scripts")),
+					version: .atLeast(SemanticVersion(major: 3, minor: 0, patch: 0))
+				),
+			])
 
 		case .gitHub(Repository(owner: "jspahrsummers", name: "objc-build-scripts")):
-			cartfile = Cartfile.from(string: "github \"jspahrsummers/xcconfigs\" ~> 1.0")
+			return SignalProducer([
+				CarthageKit.Dependency(
+					project: .gitHub(Repository(owner: "jspahrsummers", name: "xcconfigs")),
+					version: .compatibleWith(SemanticVersion(major: 1, minor: 0, patch: 0))
+				),
+			])
 
 		case .git(GitURL("/tmp/TestCartfileBranch")):
-			cartfile = Cartfile.from(string: "git \"https://enterprise.local/desktop/git-error-translations2.git\" \"development\"")
+			return SignalProducer([
+				CarthageKit.Dependency(
+					project: .git(GitURL("https://enterprise.local/desktop/git-error-translations2.git")),
+					version: .gitReference("development")
+				),
+			])
 
 		case .git(GitURL("/tmp/TestCartfileSHA")):
-			cartfile = Cartfile.from(string: "git \"https://enterprise.local/desktop/git-error-translations2.git\" \"8ff4393ede2ca86d5a78edaf62b3a14d90bffab9\"")
+			return SignalProducer([
+				CarthageKit.Dependency(
+					project: .git(GitURL("https://enterprise.local/desktop/git-error-translations2.git")),
+					version: .gitReference("8ff4393ede2ca86d5a78edaf62b3a14d90bffab9")
+				),
+			])
 
 		default:
-			cartfile = .success(Cartfile())
+			return .empty
 		}
-
-		return SignalProducer(value: cartfile.value!)
 	}
 
 	private func resolvedGitReference(project: ProjectIdentifier, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -136,7 +136,7 @@ class ResolverSpec: QuickSpec {
 			}, dependenciesForDependency: { dependency -> SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError> in
 				if dependency.project.name == "EmbeddedFrameworks" {
 					let cartfile: Cartfile = self.loadTestCartfile("EmbeddedFrameworksCartfile")
-					return SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError>(Array(cartfile.dependencies))
+					return SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError>(cartfile.dependencies)
 				} else {
 					return .empty
 				}


### PR DESCRIPTION
This simplifies the code a bit and begins to make testing the resolver easier. (You no longer need to construct a `Cartfile` for testing.)

I hope to extend this in the future and making testing even easier.