### PR TITLE
Rewrite ResolverSpec to contain all its data

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -43,7 +43,6 @@
 		CD2482671E1A05F50001EFE2 /* MachOType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2482661E1A05F50001EFE2 /* MachOType.swift */; };
 		CD28C99D1E11846200322AF7 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD28C99C1E11846200322AF7 /* ProductType.swift */; };
 		CD3E530B1DE33095002C135C /* Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3E530A1DE33095002C135C /* Availability.swift */; };
-		CD7F22441C67649F00B018A9 /* TestCartfileProposedVersion in Resources */ = {isa = PBXBuildFile; fileRef = CD7F22431C67649F00B018A9 /* TestCartfileProposedVersion */; };
 		CDA0B6CA1C468E67006C499C /* GitSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA0B6C91C468E67006C499C /* GitSpec.swift */; };
 		CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */ = {isa = PBXBuildFile; fileRef = CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */; };
 		CDE559291E12263A00ED7F5F /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE559281E12263A00ED7F5F /* BuildSettings.swift */; };
@@ -63,8 +62,6 @@
 		D026578C1B143BA000E833B5 /* swift-is-crashy.c in Sources */ = {isa = PBXBuildFile; fileRef = D026578B1B143BA000E833B5 /* swift-is-crashy.c */; };
 		D02DB8E01A4BC9B600097CDE /* Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02DB8DF1A4BC9B600097CDE /* Fetch.swift */; };
 		D03B32BF19EA49D8007788BE /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B32BE19EA49D8007788BE /* Build.swift */; };
-		D04A39801A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile in Resources */ = {isa = PBXBuildFile; fileRef = D04A397F1A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile */; };
-		D04A39821A2F72FB000C5604 /* EmbeddedFrameworksCartfile in Resources */ = {isa = PBXBuildFile; fileRef = D04A39811A2F72FB000C5604 /* EmbeddedFrameworksCartfile */; };
 		D05BD1991A26864F00A36A0E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05BD1981A26864F00A36A0E /* Extensions.swift */; };
 		D069CA241A4E3B2700314A85 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = D069CA231A4E3B2700314A85 /* Archive.swift */; };
 		D074EDC51A049283001DE082 /* FrameworkExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D074EDC41A049283001DE082 /* FrameworkExtensions.swift */; };
@@ -205,7 +202,6 @@
 		CD2482661E1A05F50001EFE2 /* MachOType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MachOType.swift; sourceTree = "<group>"; };
 		CD28C99C1E11846200322AF7 /* ProductType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		CD3E530A1DE33095002C135C /* Availability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Availability.swift; sourceTree = "<group>"; };
-		CD7F22431C67649F00B018A9 /* TestCartfileProposedVersion */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestCartfileProposedVersion; sourceTree = "<group>"; };
 		CDA0B6C91C468E67006C499C /* GitSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitSpec.swift; sourceTree = "<group>"; };
 		CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestResolvedCartfile.resolved; sourceTree = "<group>"; };
 		CDE559281E12263A00ED7F5F /* BuildSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
@@ -223,8 +219,6 @@
 		D026578B1B143BA000E833B5 /* swift-is-crashy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "swift-is-crashy.c"; sourceTree = "<group>"; };
 		D02DB8DF1A4BC9B600097CDE /* Fetch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fetch.swift; sourceTree = "<group>"; };
 		D03B32BE19EA49D8007788BE /* Build.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Build.swift; sourceTree = "<group>"; };
-		D04A397F1A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EmbeddedFrameworksContainerCartfile; sourceTree = "<group>"; };
-		D04A39811A2F72FB000C5604 /* EmbeddedFrameworksCartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EmbeddedFrameworksCartfile; sourceTree = "<group>"; };
 		D05BD1981A26864F00A36A0E /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D069CA231A4E3B2700314A85 /* Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
 		D074EDC41A049283001DE082 /* FrameworkExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameworkExtensions.swift; sourceTree = "<group>"; };
@@ -537,12 +531,9 @@
 				D01F8A4719EA28F600643E7C /* Quick.framework */,
 				D0D1217D19E87B05005E4BAA /* Info.plist */,
 				D0AAAB5419FB1062007B24B3 /* TestCartfile */,
-				CD7F22431C67649F00B018A9 /* TestCartfileProposedVersion */,
 				D0F551DB1A0D71AB0093311F /* TestCartfile.resolved */,
 				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
 				BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */,
-				D04A39811A2F72FB000C5604 /* EmbeddedFrameworksCartfile */,
-				D04A397F1A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -680,12 +671,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D04A39801A2F72E6000C5604 /* EmbeddedFrameworksContainerCartfile in Resources */,
 				BE624F491E13424400EAEFC9 /* DuplicateDependenciesCartfile in Resources */,
 				D0AAAB5519FB1062007B24B3 /* TestCartfile in Resources */,
 				D0F551DC1A0D71AB0093311F /* TestCartfile.resolved in Resources */,
-				D04A39821A2F72FB000C5604 /* EmbeddedFrameworksCartfile in Resources */,
-				CD7F22441C67649F00B018A9 /* TestCartfileProposedVersion in Resources */,
 				D0C6E5761A57042100A5E3E7 /* CartfilePrivateOnly.zip in Resources */,
 				CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */,
 			);

--- a/Source/CarthageKitTests/EmbeddedFrameworksCartfile
+++ b/Source/CarthageKitTests/EmbeddedFrameworksCartfile
@@ -1,8 +1,0 @@
-# Require Alamofire
-github "ishkawa/Alamofire" ~> 1.1.1
-
-# Require SwiftyJSON
-github "Present-Inc/SwiftyJSON" ~> 2.1.2
-
-# Require Swell (from the Present fork)
-github "Present-Inc/Swell" >= 1.0

--- a/Source/CarthageKitTests/EmbeddedFrameworksContainerCartfile
+++ b/Source/CarthageKitTests/EmbeddedFrameworksContainerCartfile
@@ -1,2 +1,0 @@
-# Require the EmbeddedFrameworks Example
-github "justinmakaila/EmbeddedFrameworks" == 1.0

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -20,22 +20,22 @@ private let github1 = ProjectIdentifier.gitHub(Repository(owner: "gob", name: "1
 private let github2 = ProjectIdentifier.gitHub(Repository(owner: "gob", name: "2"))
 private let github3 = ProjectIdentifier.gitHub(Repository(owner: "gob", name: "3"))
 
-extension PinnedVersion {
-	private static let v0_1_0 = PinnedVersion("v0.1.0")
-	private static let v1_0_0 = PinnedVersion("v1.0.0")
-	private static let v1_1_0 = PinnedVersion("v1.1.0")
-	private static let v1_2_0 = PinnedVersion("v1.2.0")
-	private static let v2_0_0 = PinnedVersion("v2.0.0")
-	private static let v2_0_1 = PinnedVersion("v2.0.1")
+private extension PinnedVersion {
+	static let v0_1_0 = PinnedVersion("v0.1.0")
+	static let v1_0_0 = PinnedVersion("v1.0.0")
+	static let v1_1_0 = PinnedVersion("v1.1.0")
+	static let v1_2_0 = PinnedVersion("v1.2.0")
+	static let v2_0_0 = PinnedVersion("v2.0.0")
+	static let v2_0_1 = PinnedVersion("v2.0.1")
 }
 
-extension SemanticVersion {
-	private static let v0_1_0 = SemanticVersion(major: 0, minor: 1, patch: 0)
-	private static let v1_0_0 = SemanticVersion(major: 1, minor: 0, patch: 0)
-	private static let v1_1_0 = SemanticVersion(major: 1, minor: 1, patch: 0)
-	private static let v1_2_0 = SemanticVersion(major: 1, minor: 2, patch: 0)
-	private static let v2_0_0 = SemanticVersion(major: 2, minor: 0, patch: 0)
-	private static let v2_0_1 = SemanticVersion(major: 2, minor: 0, patch: 1)
+private extension SemanticVersion {
+	static let v0_1_0 = SemanticVersion(major: 0, minor: 1, patch: 0)
+	static let v1_0_0 = SemanticVersion(major: 1, minor: 0, patch: 0)
+	static let v1_1_0 = SemanticVersion(major: 1, minor: 1, patch: 0)
+	static let v1_2_0 = SemanticVersion(major: 1, minor: 2, patch: 0)
+	static let v2_0_0 = SemanticVersion(major: 2, minor: 0, patch: 0)
+	static let v2_0_1 = SemanticVersion(major: 2, minor: 0, patch: 1)
 }
 
 private struct DB {

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -193,11 +193,19 @@ class ResolverSpec: QuickSpec {
 					.v1_0_0: [:],
 					.v1_1_0: [:],
 					.v1_2_0: [:],
+				],
+				git1: [
+					.v1_0_0: [:],
 				]
 			]
 			
 			let resolved = db.resolve(
-				[ github1: .any ],
+				[
+					github1: .any,
+					// Newly added dependencies which are not inclued in the
+					// list should not be resolved.
+					git1: .any,
+				],
 				resolved: [ github1: .v1_0_0, github2: .v1_0_0, github3: .v1_0_0 ],
 				updating: [ github2 ]
 			)

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -22,10 +22,6 @@ class ResolverSpec: QuickSpec {
 		return T.from(string: testCartfile).value!
 	}
 
-	private func dependencyForOwner(owner: String, name: String, version: String) -> CarthageKit.Dependency<PinnedVersion> {
-		return CarthageKit.Dependency(project: .gitHub(Repository(owner: owner, name: name)), version: PinnedVersion(version))
-	}
-
 	private func orderedDependencies(producer: SignalProducer<CarthageKit.Dependency<PinnedVersion>, CarthageError>) -> [Dependency] {
 		let result = producer
 			.map { Dependency($0.project.name, $0.version.commitish) }
@@ -73,9 +69,9 @@ class ResolverSpec: QuickSpec {
 
 			let producer = resolver.resolve(
 				dependencies: testCartfile.dependencies,
-				lastResolved: ResolvedCartfile(dependencies: [
-						self.dependencyForOwner("danielgindi", name: "ios-charts", version: "2.4.0"),
-					]).versions,
+				lastResolved: [
+					.gitHub(Repository(owner: "danielgindi", name: "ios-charts")): PinnedVersion("2.4.0")
+				],
 				dependenciesToUpdate: [ "Mantle", "ReactiveCocoa" ]
 			)
 			let dependencies = self.orderedDependencies(producer)

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -60,7 +60,7 @@ private struct DB {
 	
 	func resolvedGitReference(project: ProjectIdentifier, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {
 		if let version = references[project]?[reference] {
-			return .init([ version ])
+			return .init(value: version)
 		} else {
 			return .empty
 		}

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -82,7 +82,7 @@ class ResolverSpec: QuickSpec {
 			// Dependencies should be listed in build order.
 			expect(generator.next()) == Dependency("Mantle", "1.3.0")
 
-			// Existing dependencies which are not inclued in the list should
+			// Existing dependencies which are not included in the list should
 			// not be updated.
 			expect(generator.next()) == Dependency("ios-charts", "2.4.0")
 

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -15,11 +15,11 @@ import Result
 import Tentacle
 
 class ResolverSpec: QuickSpec {
-	private func loadTestCartfile<T: CartfileType>(name: String, withExtension: String = "") -> T {
+	private func loadTestCartfile(name: String, withExtension: String = "") -> Cartfile {
 		let testCartfileURL = Bundle(for: type(of: self)).url(forResource: name, withExtension: withExtension)!
 		let testCartfile = try! String(contentsOf: testCartfileURL, encoding: .utf8)
 
-		return T.from(string: testCartfile).value!
+		return Cartfile.from(string: testCartfile).value!
 	}
 
 	private func orderedDependencies(producer: SignalProducer<CarthageKit.Dependency<PinnedVersion>, CarthageError>) -> [Dependency] {
@@ -46,7 +46,7 @@ class ResolverSpec: QuickSpec {
 		}
 
 		it("should resolve a Cartfile") {
-			let testCartfile: Cartfile = self.loadTestCartfile("TestCartfile")
+			let testCartfile = self.loadTestCartfile("TestCartfile")
 			let producer = resolver.resolve(dependencies: testCartfile.dependencies)
 			let dependencies = self.orderedDependencies(producer)
 			expect(dependencies.count) == 8
@@ -65,7 +65,7 @@ class ResolverSpec: QuickSpec {
 		}
 
 		it("should resolve a Cartfile for specific dependencies") {
-			let testCartfile: Cartfile = self.loadTestCartfile("TestCartfile")
+			let testCartfile = self.loadTestCartfile("TestCartfile")
 
 			let producer = resolver.resolve(
 				dependencies: testCartfile.dependencies,
@@ -99,7 +99,7 @@ class ResolverSpec: QuickSpec {
 		}
 
 		it("should resolve a Cartfile whose dependency is specified by both a branch name and a SHA which is the HEAD of that branch") {
-			let testCartfile: Cartfile = self.loadTestCartfile("TestCartfileProposedVersion")
+			let testCartfile = self.loadTestCartfile("TestCartfileProposedVersion")
 			let producer = resolver.resolve(dependencies: testCartfile.dependencies)
 			let dependencies = self.orderedDependencies(producer)
 			expect(dependencies.count) == 3
@@ -131,7 +131,7 @@ class ResolverSpec: QuickSpec {
 				}
 			}, dependenciesForDependency: { dependency -> SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError> in
 				if dependency.project.name == "EmbeddedFrameworks" {
-					let cartfile: Cartfile = self.loadTestCartfile("EmbeddedFrameworksCartfile")
+					let cartfile = self.loadTestCartfile("EmbeddedFrameworksCartfile")
 					return SignalProducer<CarthageKit.Dependency<VersionSpecifier>, CarthageError>(cartfile.dependencies)
 				} else {
 					return .empty
@@ -140,7 +140,7 @@ class ResolverSpec: QuickSpec {
 				return SignalProducer(error: .invalidArgument(description: "unexpected test error"))
 			})
 
-			let testCartfile: Cartfile = self.loadTestCartfile("EmbeddedFrameworksContainerCartfile")
+			let testCartfile = self.loadTestCartfile("EmbeddedFrameworksContainerCartfile")
 			let producer = resolver.resolve(dependencies: testCartfile.dependencies)
 			let dependencies = self.orderedDependencies(producer)
 			expect(dependencies.count) == 4
@@ -229,10 +229,3 @@ private struct Dependency: Equatable {
 private func == (lhs: Dependency, rhs: Dependency) -> Bool {
 	return lhs.name == rhs.name && lhs.version == rhs.version
 }
-
-private protocol CartfileType {
-	static func from(string string: String) -> Result<Self, CarthageError>
-}
-
-extension Cartfile: CartfileType {}
-extension ResolvedCartfile: CartfileType {}

--- a/Source/CarthageKitTests/TestCartfileProposedVersion
+++ b/Source/CarthageKitTests/TestCartfileProposedVersion
@@ -1,3 +1,0 @@
-git "/tmp/TestCartfileBranch" ~> 0.4.0
-git "/tmp/TestCartfileSHA" ~> 0.9
-git "https://enterprise.local/desktop/git-error-translations2.git" "8ff4393"


### PR DESCRIPTION
This makes it _much_ easier IMO to understand what it’s testing and to add new tests. It removes the use of all files (test cartfiles, git repos) in favor of a `DB` struct.