### PR TITLE
README: removed Box.framework example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ If you’ve modified your [Cartfile][], or you want to update to the newest vers
 If you only want to update one , or specific, dependencies, pass them as a space-separated list to the `update` command. e.g.
 
 ```
-carthage update Box
+carthage update Result
 ```
 
 or 
 
 ```
-carthage update Box Result
+carthage update Argo Result
 ```
 
 ### Nested dependencies

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
   and add the paths to the frameworks you want to use under “Input Files”, e.g.:
 
   ```
-  $(SRCROOT)/Carthage/Build/iOS/Box.framework
   $(SRCROOT)/Carthage/Build/iOS/Result.framework
   $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
   ```


### PR DESCRIPTION
Good ol' `Box.framework` served us well :)