### PR TITLE
[SemanticVersion] Rename `fromPinnedVersion(_:)` to `from(_:)`

### DIFF
--- a/Source/CarthageKit/Availability.swift
+++ b/Source/CarthageKit/Availability.swift
@@ -68,6 +68,11 @@ extension SDK {
 
 // MARK: - Version.swift
 
+extension SemanticVersion {
+	@available(*, unavailable, renamed="from(_:)")
+	public static func fromPinnedVersion(pinnedVersion: PinnedVersion) -> Result<SemanticVersion, CarthageError> { fatalError() }
+}
+
 extension VersionSpecifier {
 	@available(*, unavailable, renamed="isSatisfied(by:)")
 	public func satisfiedBy(version: PinnedVersion) -> Bool { fatalError() }

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -486,8 +486,8 @@ private class DependencyNode: Comparable {
 }
 
 private func <(lhs: DependencyNode, rhs: DependencyNode) -> Bool {
-	let leftSemantic = SemanticVersion.fromPinnedVersion(lhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
-	let rightSemantic = SemanticVersion.fromPinnedVersion(rhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+	let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+	let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
 
 	// Try higher versions first.
 	return leftSemantic > rightSemantic

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -47,7 +47,7 @@ public struct SemanticVersion: VersionType, Comparable {
 	private static let versionCharacterSet = CharacterSet(charactersIn: "0123456789.")
 
 	/// Attempts to parse a semantic version from a PinnedVersion.
-	public static func fromPinnedVersion(pinnedVersion: PinnedVersion) -> Result<SemanticVersion, CarthageError> {
+	public static func from(_ pinnedVersion: PinnedVersion) -> Result<SemanticVersion, CarthageError> {
 		let scanner = Scanner(string: pinnedVersion.commitish)
 
 		// Skip leading characters, like "v" or "version-" or anything like
@@ -176,7 +176,7 @@ public enum VersionSpecifier: VersionType {
 	/// Determines whether the given version satisfies this version specifier.
 	public func isSatisfied(by version: PinnedVersion) -> Bool {
 		func withSemanticVersion(predicate: (SemanticVersion) -> Bool) -> Bool {
-			if let semanticVersion = SemanticVersion.fromPinnedVersion(version).value {
+			if let semanticVersion = SemanticVersion.from(version).value {
 				return predicate(semanticVersion)
 			} else {
 				// Consider non-semantic versions (e.g., branches) to meet every

--- a/Source/CarthageKitTests/VersionSpec.swift
+++ b/Source/CarthageKitTests/VersionSpec.swift
@@ -30,14 +30,14 @@ class SemanticVersionSpec: QuickSpec {
 		}
 
 		it("should parse semantic versions") {
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("1.4")).value) == SemanticVersion(major: 1, minor: 4, patch: 0)
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8.9")).value) == SemanticVersion(major: 2, minor: 8, patch: 9)
+			expect(SemanticVersion.from(PinnedVersion("1.4")).value) == SemanticVersion(major: 1, minor: 4, patch: 0)
+			expect(SemanticVersion.from(PinnedVersion("v2.8.9")).value) == SemanticVersion(major: 2, minor: 8, patch: 9)
 		}
 
 		it("should fail on invalid semantic versions") {
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v1")).value).to(beNil())
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("v2.8-alpha")).value).to(beNil())
-			expect(SemanticVersion.fromPinnedVersion(PinnedVersion("null-string-beta-2")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("v1")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("v2.8-alpha")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
 		}
 	}
 }
@@ -74,7 +74,7 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 
 			it("should allow greater or equal versions for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.fromPinnedVersion(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == true
@@ -83,7 +83,7 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 
 			it("should allow greater or equal minor and patch versions for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.fromPinnedVersion(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == true
@@ -92,7 +92,7 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 
 			it("should only allow exact versions for .exactly") {
-				let specifier = VersionSpecifier.exactly(SemanticVersion.fromPinnedVersion(v2_2_0).value!)
+				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_2_0).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == false
@@ -101,7 +101,7 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 
 			it("should allow only greater patch versions to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.fromPinnedVersion(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_1_0)) == true
 				expect(specifier.isSatisfied(by: v0_1_1)) == true
 				expect(specifier.isSatisfied(by: v0_2_0)) == false


### PR DESCRIPTION
Adopts API Design Guidelines.

#1558 
