### PR TITLE
Don't pass Xcode errors through

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -687,6 +687,13 @@ public func buildInDirectory(directoryURL: URL, withOptions options: BuildOption
 				}
 
 				let buildProgress = buildScheme(scheme, withConfiguration: options.configuration, inProject: project, workingDirectoryURL: directoryURL, derivedDataPath: options.derivedDataPath, toolchain: options.toolchain, sdkFilter: wrappedSDKFilter)
+					.flatMapError { error -> SignalProducer<TaskEvent<URL>, CarthageError> in
+						if case let .taskError(taskError) = error {
+							return .init(error: .buildFailed(taskError, log: nil))
+						} else {
+							return .init(error: error)
+						}
+					}
 					// Discard any existing Success values, since we want to
 					// use our initial value instead of waiting for
 					// completion.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -687,11 +687,11 @@ public func buildInDirectory(directoryURL: URL, withOptions options: BuildOption
 				}
 
 				let buildProgress = buildScheme(scheme, withConfiguration: options.configuration, inProject: project, workingDirectoryURL: directoryURL, derivedDataPath: options.derivedDataPath, toolchain: options.toolchain, sdkFilter: wrappedSDKFilter)
-					.flatMapError { error -> SignalProducer<TaskEvent<URL>, CarthageError> in
+					.mapError { (error) -> CarthageError in
 						if case let .taskError(taskError) = error {
-							return .init(error: .buildFailed(taskError, log: nil))
+							return .buildFailed(taskError, log: nil)
 						} else {
-							return .init(error: error)
+							return error
 						}
 					}
 					// Discard any existing Success values, since we want to

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -97,11 +97,11 @@ public struct BuildCommand: CommandType {
 				}
 
 				return buildProgress
-					.flatMapError { error in
+					.mapError { error in
 						if case let .buildFailed(taskError, _) = error {
-							return SignalProducer(error: .buildFailed(taskError, log: temporaryURL))
+							return .buildFailed(taskError, log: temporaryURL)
 						} else {
-							return SignalProducer(error: error)
+							return error
 						}
 					}
 					.on(

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -90,7 +90,7 @@ public struct BuildCommand: CommandType {
 						switch event {
 						case .Launch, .Success:
 							return true
-						case .StandardError, .StandardOutput:
+						case .StandardOutput, .StandardError:
 							return false
 						}
 					}


### PR DESCRIPTION
Direct users to the xcodebuild log to help them self-diagnose errors.

Fixes #1626.

## Before
```
$ carthage update --no-use-binaries
*** Fetching Result
*** Checking out Result at "1.0.2"
*** xcodebuild output can be found in /var/folders/xj/sydx1wkd0p147x0k_7v667940000gn/T/carthage-xcodebuild.yIaqhL.log
*** Building scheme "Result-Mac" in Result.xcodeproj
** CLEAN FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
** BUILD FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
A shell task (/usr/bin/xcrun xcodebuild -project /Users/mdiep/Downloads/tmp/Carthage/Checkouts/Result/Result.xcodeproj -scheme Result-Mac -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build) failed with exit code 65:
** CLEAN FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
** BUILD FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
```

## After
```
$ carthage-dev update --no-use-binaries
*** Fetching Result
*** Checking out Result at "1.0.2"
*** xcodebuild output can be found in /var/folders/xj/sydx1wkd0p147x0k_7v667940000gn/T/carthage-xcodebuild.NCkGIT.log
*** Building scheme "Result-Mac" in Result.xcodeproj
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -project /Users/mdiep/Downloads/tmp/Carthage/Checkouts/Result/Result.xcodeproj -scheme Result-Mac -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build

This usually indicates that project itself failed to compile.Please check the xcodebuild log for more details: /var/folders/xj/sydx1wkd0p147x0k_7v667940000gn/T/carthage-xcodebuild.NCkGIT.log
```