### PR TITLE
[swift3-prep] Make first parameters unnamed explicitly

### DIFF
--- a/Source/CarthageKit/Algorithms.swift
+++ b/Source/CarthageKit/Algorithms.swift
@@ -34,7 +34,7 @@
 ///
 /// Nodes that are equal from a topological perspective are sorted by the
 /// strict total order as defined by `Comparable`.
-public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>) -> [Node]? {
+public func topologicalSort<Node: Comparable>(_ graph: Dictionary<Node, Set<Node>>) -> [Node]? {
 	// Maintain a list of nodes with no incoming edges (sources).
 	var sources = graph
 		.filter { _, incomingEdges in incomingEdges.isEmpty }
@@ -77,7 +77,7 @@ public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>
 /// given graph.
 ///
 /// Returns nil if the provided graph has a cycle or is malformed.
-public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>, nodes: Set<Node>) -> [Node]? {
+public func topologicalSort<Node: Comparable>(_ graph: Dictionary<Node, Set<Node>>, nodes: Set<Node>) -> [Node]? {
 	guard !nodes.isEmpty else { return topologicalSort(graph) }
 
 	precondition(nodes.isSubset(of: Set(graph.keys)))
@@ -93,7 +93,7 @@ public func topologicalSort<Node: Comparable>(graph: Dictionary<Node, Set<Node>>
 
 /// Returns the set of nodes that the given node in the provided graph has as
 /// its incoming nodes, both directly and transitively.
-private func transitiveIncomingNodes<Node: Equatable>(graph: Dictionary<Node, Set<Node>>, node: Node) -> Set<Node> {
+private func transitiveIncomingNodes<Node: Equatable>(_ graph: Dictionary<Node, Set<Node>>, node: Node) -> Set<Node> {
 	guard let nodes = graph[node] else { return Set() }
 
 	let incomingNodes = Set(nodes.flatMap { transitiveIncomingNodes(graph, node: $0) })

--- a/Source/CarthageKit/Availability.swift
+++ b/Source/CarthageKit/Availability.swift
@@ -9,83 +9,83 @@ import Result
 // MARK: - Archive.swift
 
 @available(*, unavailable, renamed="zip(paths:into:workingDirectory:)")
-public func zipIntoArchive(destinationArchiveURL: URL, workingDirectory: String, inputPaths: [String]) -> SignalProducer<(), CarthageError> { fatalError() }
+public func zipIntoArchive(_ destinationArchiveURL: URL, workingDirectory: String, inputPaths: [String]) -> SignalProducer<(), CarthageError> { fatalError() }
 
 @available(*, unavailable, renamed="unzip(archive:to:)")
-public func unzipArchiveToDirectory(fileURL: URL, _ destinationDirectoryURL: URL) -> SignalProducer<(), CarthageError> { fatalError() }
+public func unzipArchiveToDirectory(_ fileURL: URL, _ destinationDirectoryURL: URL) -> SignalProducer<(), CarthageError> { fatalError() }
 
 @available(*, unavailable, renamed="unzip(archive:)")
-public func unzipArchiveToTemporaryDirectory(fileURL: URL) -> SignalProducer<URL, CarthageError> { fatalError() }
+public func unzipArchiveToTemporaryDirectory(_ fileURL: URL) -> SignalProducer<URL, CarthageError> { fatalError() }
 
 // MARK: - Cartfile.swift
 
 extension Cartfile {
 	@available(*, unavailable, renamed="url(in:)")
-	public static func urlInDirectory(directoryURL: URL) -> URL { fatalError() }
+	public static func urlInDirectory(_ directoryURL: URL) -> URL { fatalError() }
 
 	@available(*, unavailable, renamed="from(string:)")
-	public static func fromString(string: String) -> Result<Cartfile, CarthageError> { fatalError() }
+	public static func fromString(_ string: String) -> Result<Cartfile, CarthageError> { fatalError() }
 
 	@available(*, unavailable, renamed="from(file:)")
-	public static func fromFile(cartfileURL: URL) -> Result<Cartfile, CarthageError> { fatalError() }
+	public static func fromFile(_ cartfileURL: URL) -> Result<Cartfile, CarthageError> { fatalError() }
 }
 
 extension ResolvedCartfile {
 	@available(*, unavailable, renamed="url(in:)")
-	public static func urlInDirectory(directoryURL: URL) -> URL { fatalError() }
+	public static func urlInDirectory(_ directoryURL: URL) -> URL { fatalError() }
 
 	@available(*, unavailable, renamed="from(string:)")
-	public static func fromString(string: String) -> Result<ResolvedCartfile, CarthageError> { fatalError() }
+	public static func fromString(_ string: String) -> Result<ResolvedCartfile, CarthageError> { fatalError() }
 
 	@available(*, unavailable, renamed="append(_:)")
-	public mutating func appendCartfile(cartfile: Cartfile) { fatalError() }
+	public mutating func appendCartfile(_ cartfile: Cartfile) { fatalError() }
 }
 
 @available(*, unavailable, renamed="duplicateProjectsIn(_:_:)")
-public func duplicateProjectsInCartfiles(cartfile1: Cartfile, _ cartfile2: Cartfile) -> [ProjectIdentifier] { fatalError() }
+public func duplicateProjectsInCartfiles(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [ProjectIdentifier] { fatalError() }
 
 // MARK: - Git.swift
 
 @available(*, unavailable, renamed="cloneRepository(_:_:isBare:)")
-public func cloneRepository(cloneURL: GitURL, _ destinationURL: URL, bare: Bool = true) -> SignalProducer<String, CarthageError> { fatalError() }
+public func cloneRepository(_ cloneURL: GitURL, _ destinationURL: URL, bare: Bool = true) -> SignalProducer<String, CarthageError> { fatalError() }
 
 // MARK: - MachOType.swift
 
 extension MachOType {
 	@available(*, unavailable, renamed="from(string:)")
-	public static func fromString(string: String) -> Result<MachOType, CarthageError> { fatalError() }
+	public static func fromString(_ string: String) -> Result<MachOType, CarthageError> { fatalError() }
 }
 
 // MARK: - ProductType.swift
 
 extension ProductType {
 	@available(*, unavailable, renamed="from(string:)")
-	public static func fromString(string: String) -> Result<ProductType, CarthageError> { fatalError() }
+	public static func fromString(_ string: String) -> Result<ProductType, CarthageError> { fatalError() }
 }
 
 // MARK: - SDK.swift
 
 extension SDK {
 	@available(*, unavailable, renamed="from(string:)")
-	public static func fromString(string: String) -> Result<SDK, CarthageError> { fatalError() }
+	public static func fromString(_ string: String) -> Result<SDK, CarthageError> { fatalError() }
 }
 
 // MARK: - Version.swift
 
 extension SemanticVersion {
 	@available(*, unavailable, renamed="from(_:)")
-	public static func fromPinnedVersion(pinnedVersion: PinnedVersion) -> Result<SemanticVersion, CarthageError> { fatalError() }
+	public static func fromPinnedVersion(_ pinnedVersion: PinnedVersion) -> Result<SemanticVersion, CarthageError> { fatalError() }
 }
 
 extension VersionSpecifier {
 	@available(*, unavailable, renamed="isSatisfied(by:)")
-	public func satisfiedBy(version: PinnedVersion) -> Bool { fatalError() }
+	public func satisfiedBy(_ version: PinnedVersion) -> Bool { fatalError() }
 }
 
 // MARK: - Xcode.swift
 
 @available(*, unavailable, renamed="ProjectLocator.locate(in:)")
-public func locateProjectsInDirectory(directoryURL: URL) -> SignalProducer<ProjectLocator, CarthageError> { fatalError() }
+public func locateProjectsInDirectory(_ directoryURL: URL) -> SignalProducer<ProjectLocator, CarthageError> { fatalError() }
 
 @available(*, unavailable, renamed="ProjectLocator.schemes(self:)")
-public func schemesInProject(project: ProjectLocator) -> SignalProducer<String, CarthageError> { fatalError() }
+public func schemesInProject(_ project: ProjectLocator) -> SignalProducer<String, CarthageError> { fatalError() }

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -30,7 +30,7 @@ public struct BuildSettings {
 	///
 	/// Upon .success, sends one BuildSettings value for each target included in
 	/// the referenced scheme.
-	public static func loadWithArguments(arguments: BuildArguments) -> SignalProducer<BuildSettings, CarthageError> {
+	public static func loadWithArguments(_ arguments: BuildArguments) -> SignalProducer<BuildSettings, CarthageError> {
 		// xcodebuild (in Xcode 8) has a bug where xcodebuild -showBuildSettings
 		// can hang indefinitely on projects that contain core data models.
 		// rdar://27052195
@@ -99,7 +99,7 @@ public struct BuildSettings {
 	///
 	/// If an SDK is unrecognized or could not be determined, an error will be
 	/// sent on the returned signal.
-	public static func SDKsForScheme(scheme: String, inProject project: ProjectLocator) -> SignalProducer<SDK, CarthageError> {
+	public static func SDKsForScheme(_ scheme: String, inProject project: ProjectLocator) -> SignalProducer<SDK, CarthageError> {
 		return loadWithArguments(BuildArguments(project: project, scheme: scheme))
 			.take(first: 1)
 			.flatMap(.merge) { $0.buildSDKs }

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -212,7 +212,7 @@ public enum ProjectIdentifier: Comparable {
 	}
 }
 
-public func ==(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
+public func ==(_ lhs: ProjectIdentifier, _ rhs: ProjectIdentifier) -> Bool {
 	switch (lhs, rhs) {
 	case let (.gitHub(left), .gitHub(right)):
 		return left == right
@@ -225,7 +225,7 @@ public func ==(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
 	}
 }
 
-public func <(lhs: ProjectIdentifier, rhs: ProjectIdentifier) -> Bool {
+public func <(_ lhs: ProjectIdentifier, _ rhs: ProjectIdentifier) -> Bool {
 	return lhs.name.caseInsensitiveCompare(rhs.name) == .orderedAscending
 }
 
@@ -313,7 +313,7 @@ public struct Dependency<V: VersionType>: Hashable {
 	}
 }
 
-public func ==<V>(lhs: Dependency<V>, rhs: Dependency<V>) -> Bool {
+public func ==<V>(_ lhs: Dependency<V>, _ rhs: Dependency<V>) -> Bool {
 	return lhs.project == rhs.project && lhs.version == rhs.version
 }
 

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -91,11 +91,11 @@ public enum CarthageError: ErrorType, Equatable {
 	case taskError(TaskError)
 }
 
-private func == (lhs: CarthageError.VersionRequirement, rhs: CarthageError.VersionRequirement) -> Bool {
+private func == (_ lhs: CarthageError.VersionRequirement, _ rhs: CarthageError.VersionRequirement) -> Bool {
 	return lhs.specifier == rhs.specifier && lhs.fromProject == rhs.fromProject
 }
 
-public func == (lhs: CarthageError, rhs: CarthageError) -> Bool {
+public func == (_ lhs: CarthageError, _ rhs: CarthageError) -> Bool {
 	switch (lhs, rhs) {
 	case let (.invalidArgument(left), .invalidArgument(right)):
 		return left == right
@@ -332,11 +332,11 @@ extension DuplicateDependency: CustomStringConvertible {
 	}
 }
 
-public func == (lhs: DuplicateDependency, rhs: DuplicateDependency) -> Bool {
+public func == (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {
 	return lhs.project == rhs.project && lhs.locations == rhs.locations
 }
 
-public func < (lhs: DuplicateDependency, rhs: DuplicateDependency) -> Bool {
+public func < (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {
 	if lhs.description < rhs.description {
 		return true
 	}

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -33,7 +33,7 @@ extension String {
 }
 
 /// Merges `rhs` into `lhs` and returns the result.
-internal func combineDictionaries<K, V>(lhs: [K: V], rhs: [K: V]) -> [K: V] {
+internal func combineDictionaries<K, V>(_ lhs: [K: V], rhs: [K: V]) -> [K: V] {
 	var result = lhs
 	for (key, value) in rhs {
 		result.updateValue(value, forKey: key)
@@ -264,7 +264,7 @@ extension URL {
 		return .failure(.readFailed(self, error))
 	}
 
-	public func hasSubdirectory(possibleSubdirectory: URL) -> Bool {
+	public func hasSubdirectory(_ possibleSubdirectory: URL) -> Bool {
 		let standardizedSelf = self.standardizedFileURL
 		let standardizedOther = possibleSubdirectory.standardizedFileURL
 
@@ -319,7 +319,7 @@ extension FileManager {
 /// Creates a counted set from a sequence. The counted set is represented as a
 /// dictionary where the keys are elements from the sequence and values count
 /// how many times elements are present in the sequence.
-internal func buildCountedSet<S: SequenceType>(sequence: S) -> [S.Generator.Element: Int] {
+internal func buildCountedSet<S: SequenceType>(_ sequence: S) -> [S.Generator.Element: Int] {
 	return sequence.reduce([:]) { set, elem in
 		var set = set
 		if let count = set[elem] {

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -77,7 +77,7 @@ public struct GitURL: Equatable {
 }
 
 /// Strips any trailing .git in the given name, if one exists.
-public func stripGitSuffix(string: String) -> String {
+public func stripGitSuffix(_ string: String) -> String {
 	if string.hasSuffix(".git") {
 		return string[string.startIndex..<string.endIndex.advancedBy(-4)]
 	} else {
@@ -85,7 +85,7 @@ public func stripGitSuffix(string: String) -> String {
 	}
 }
 
-public func ==(lhs: GitURL, rhs: GitURL) -> Bool {
+public func ==(_ lhs: GitURL, _ rhs: GitURL) -> Bool {
 	return lhs.normalizedURLString == rhs.normalizedURLString
 }
 
@@ -124,7 +124,7 @@ public struct Submodule: Equatable {
 	}
 }
 
-public func ==(lhs: Submodule, rhs: Submodule) -> Bool {
+public func ==(_ lhs: Submodule, _ rhs: Submodule) -> Bool {
 	return lhs.name == rhs.name && lhs.path == rhs.path && lhs.url == rhs.url && lhs.sha == rhs.sha
 }
 
@@ -170,7 +170,7 @@ public struct FetchCache {
 
 /// Shells out to `git` with the given arguments, optionally in the directory
 /// of an existing repository.
-public func launchGitTask(arguments: [String], repositoryFileURL: URL? = nil, standardInput: SignalProducer<Data, NoError>? = nil, environment: [String: String]? = nil) -> SignalProducer<String, CarthageError> {
+public func launchGitTask(_ arguments: [String], repositoryFileURL: URL? = nil, standardInput: SignalProducer<Data, NoError>? = nil, environment: [String: String]? = nil) -> SignalProducer<String, CarthageError> {
 	// See https://github.com/Carthage/Carthage/issues/219.
 	var updatedEnvironment = environment ?? ProcessInfo.processInfo.environment 
 	updatedEnvironment["GIT_TERMINAL_PROMPT"] = "0"
@@ -186,7 +186,7 @@ public func launchGitTask(arguments: [String], repositoryFileURL: URL? = nil, st
 }
 
 /// Checks if the git version satisfies the given required version.
-public func ensureGitVersion(requiredVersion: String = CarthageRequiredGitVersion) -> SignalProducer<Bool, CarthageError> {
+public func ensureGitVersion(_ requiredVersion: String = CarthageRequiredGitVersion) -> SignalProducer<Bool, CarthageError> {
 	return launchGitTask([ "--version" ])
 		.map { input -> Bool in
 			let scanner = Scanner(string: input)
@@ -204,7 +204,7 @@ public func ensureGitVersion(requiredVersion: String = CarthageRequiredGitVersio
 }
 
 /// Returns a signal that completes when cloning completes successfully.
-public func cloneRepository(cloneURL: GitURL, _ destinationURL: URL, isBare: Bool = true) -> SignalProducer<String, CarthageError> {
+public func cloneRepository(_ cloneURL: GitURL, _ destinationURL: URL, isBare: Bool = true) -> SignalProducer<String, CarthageError> {
 	precondition(destinationURL.isFileURL)
 
 	var arguments = [ "clone" ]
@@ -217,7 +217,7 @@ public func cloneRepository(cloneURL: GitURL, _ destinationURL: URL, isBare: Boo
 }
 
 /// Returns a signal that completes when the fetch completes successfully.
-public func fetchRepository(repositoryFileURL: URL, remoteURL: GitURL? = nil, refspec: String? = nil) -> SignalProducer<String, CarthageError> {
+public func fetchRepository(_ repositoryFileURL: URL, remoteURL: GitURL? = nil, refspec: String? = nil) -> SignalProducer<String, CarthageError> {
 	precondition(repositoryFileURL.isFileURL)
 
 	var arguments = [ "fetch", "--prune", "--quiet" ]
@@ -238,7 +238,7 @@ public func fetchRepository(repositoryFileURL: URL, remoteURL: GitURL? = nil, re
 }
 
 /// Sends each tag found in the given Git repository.
-public func listTags(repositoryFileURL: URL) -> SignalProducer<String, CarthageError> {
+public func listTags(_ repositoryFileURL: URL) -> SignalProducer<String, CarthageError> {
 	return launchGitTask([ "tag", "--column=never" ], repositoryFileURL: repositoryFileURL)
 		.flatMap(.concat) { (allTags: String) -> SignalProducer<String, CarthageError> in
 			return SignalProducer { observer, disposable in
@@ -259,7 +259,7 @@ public func listTags(repositoryFileURL: URL) -> SignalProducer<String, CarthageE
 
 /// Returns the text contents of the path at the given revision, or an error if
 /// the path could not be loaded.
-public func contentsOfFileInRepository(repositoryFileURL: URL, _ path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
+public func contentsOfFileInRepository(_ repositoryFileURL: URL, _ path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
 	let showObject = "\(revision):\(path)"
 	return launchGitTask([ "show", showObject ], repositoryFileURL: repositoryFileURL)
 }
@@ -267,7 +267,7 @@ public func contentsOfFileInRepository(repositoryFileURL: URL, _ path: String, r
 /// Checks out the working tree of the given (ideally bare) repository, at the
 /// specified revision, to the given folder. If the folder does not exist, it
 /// will be created.
-public func checkoutRepositoryToDirectory(repositoryFileURL: URL, _ workingDirectoryURL: URL, revision: String = "HEAD", shouldCloneSubmodule: (Submodule) -> Bool = { _ in true }) -> SignalProducer<(), CarthageError> {
+public func checkoutRepositoryToDirectory(_ repositoryFileURL: URL, _ workingDirectoryURL: URL, revision: String = "HEAD", shouldCloneSubmodule: (Submodule) -> Bool = { _ in true }) -> SignalProducer<(), CarthageError> {
 	return SignalProducer.attempt { () -> Result<[String: String], CarthageError> in
 			do {
 				try FileManager.`default`.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true)
@@ -285,7 +285,7 @@ public func checkoutRepositoryToDirectory(repositoryFileURL: URL, _ workingDirec
 
 /// Clones matching submodules for the given repository at the specified
 /// revision, into the given working directory.
-public func cloneSubmodulesForRepository(repositoryFileURL: URL, _ workingDirectoryURL: URL, revision: String = "HEAD", shouldCloneSubmodule: (Submodule) -> Bool = { _ in true }) -> SignalProducer<(), CarthageError> {
+public func cloneSubmodulesForRepository(_ repositoryFileURL: URL, _ workingDirectoryURL: URL, revision: String = "HEAD", shouldCloneSubmodule: (Submodule) -> Bool = { _ in true }) -> SignalProducer<(), CarthageError> {
 	return submodulesInRepository(repositoryFileURL, revision: revision)
 		.flatMap(.concat) { submodule -> SignalProducer<(), CarthageError> in
 			if shouldCloneSubmodule(submodule) {
@@ -299,7 +299,7 @@ public func cloneSubmodulesForRepository(repositoryFileURL: URL, _ workingDirect
 
 /// Clones the given submodule into the working directory of its parent
 /// repository, but without any Git metadata.
-public func cloneSubmoduleInWorkingDirectory(submodule: Submodule, _ workingDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+public func cloneSubmoduleInWorkingDirectory(_ submodule: Submodule, _ workingDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 	let submoduleDirectoryURL = workingDirectoryURL.appendingPathComponent(submodule.path, isDirectory: true)
 	let purgeGitDirectories = FileManager.`default`.carthage_enumerator(at: submoduleDirectoryURL, includingPropertiesForKeys: [ .isDirectoryKey, .nameKey ], catchErrors: true)
 		.flatMap(.merge) { enumerator, url -> SignalProducer<(), CarthageError> in
@@ -352,7 +352,7 @@ public func cloneSubmoduleInWorkingDirectory(submodule: Submodule, _ workingDire
 
 /// Recursively checks out the given submodule's revision, in its working
 /// directory.
-private func checkoutSubmodule(submodule: Submodule, _ submoduleWorkingDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+private func checkoutSubmodule(_ submodule: Submodule, _ submoduleWorkingDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 	return launchGitTask([ "checkout", "--quiet", submodule.sha ], repositoryFileURL: submoduleWorkingDirectoryURL)
 		.then(launchGitTask([ "submodule", "--quiet", "update", "--init", "--recursive" ], repositoryFileURL: submoduleWorkingDirectoryURL))
 		.then(.empty)
@@ -360,7 +360,7 @@ private func checkoutSubmodule(submodule: Submodule, _ submoduleWorkingDirectory
 
 /// Parses each key/value entry from the given config file contents, optionally
 /// stripping a known prefix/suffix off of each key.
-private func parseConfigEntries(contents: String, keyPrefix: String = "", keySuffix: String = "") -> SignalProducer<(String, String), NoError> {
+private func parseConfigEntries(_ contents: String, keyPrefix: String = "", keySuffix: String = "") -> SignalProducer<(String, String), NoError> {
 	let entries = contents.characters.split(omittingEmptySubsequences: true) { $0 == "\0" }
 
 	return SignalProducer { observer, disposable in
@@ -397,7 +397,7 @@ private func parseConfigEntries(contents: String, keyPrefix: String = "", keySuf
 
 /// Determines the SHA that the submodule at the given path is pinned to, in the
 /// revision of the parent repository specified.
-public func submoduleSHAForPath(repositoryFileURL: URL, _ path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
+public func submoduleSHAForPath(_ repositoryFileURL: URL, _ path: String, revision: String = "HEAD") -> SignalProducer<String, CarthageError> {
 	let task = [ "ls-tree", "-z", revision, path ]
 	return launchGitTask(task, repositoryFileURL: repositoryFileURL)
 		.attemptMap { string in
@@ -414,7 +414,7 @@ public func submoduleSHAForPath(repositoryFileURL: URL, _ path: String, revision
 
 /// Returns each entry of `.gitmodules` found in the given repository revision,
 /// or an empty signal if none exist.
-internal func gitmodulesEntriesInRepository(repositoryFileURL: URL, revision: String?) -> SignalProducer<(name: String, path: String, url: GitURL), CarthageError> {
+internal func gitmodulesEntriesInRepository(_ repositoryFileURL: URL, revision: String?) -> SignalProducer<(name: String, path: String, url: GitURL), CarthageError> {
 	var baseArguments = [ "config", "-z" ]
 	let modulesFile = ".gitmodules"
 
@@ -440,7 +440,7 @@ internal func gitmodulesEntriesInRepository(repositoryFileURL: URL, revision: St
 ///
 /// If in bare repository, return the passed repo path as the root
 /// else, return the path given by "git rev-parse --show-toplevel"
-public func gitRootDirectoryForRepository(repositoryFileURL: URL) -> SignalProducer<URL, CarthageError> {
+public func gitRootDirectoryForRepository(_ repositoryFileURL: URL) -> SignalProducer<URL, CarthageError> {
 	return launchGitTask([ "rev-parse", "--is-bare-repository" ], repositoryFileURL: repositoryFileURL)
 		.map { $0.trimmingCharacters(in: .newlines) }
 		.flatMap(.concat) { isBareRepository -> SignalProducer<URL, CarthageError> in
@@ -456,7 +456,7 @@ public func gitRootDirectoryForRepository(repositoryFileURL: URL) -> SignalProdu
 
 /// Returns each submodule found in the given repository revision, or an empty
 /// signal if none exist.
-public func submodulesInRepository(repositoryFileURL: URL, revision: String = "HEAD") -> SignalProducer<Submodule, CarthageError> {
+public func submodulesInRepository(_ repositoryFileURL: URL, revision: String = "HEAD") -> SignalProducer<Submodule, CarthageError> {
 	return gitmodulesEntriesInRepository(repositoryFileURL, revision: revision)
 		.flatMap(.concat) { name, path, url in
 			return gitRootDirectoryForRepository(repositoryFileURL)
@@ -472,7 +472,7 @@ public func submodulesInRepository(repositoryFileURL: URL, revision: String = "H
 ///
 /// If the specified file URL does not represent a valid Git repository, `false`
 /// will be sent.
-internal func branchExistsInRepository(repositoryFileURL: URL, pattern: String) -> SignalProducer<Bool, NoError> {
+internal func branchExistsInRepository(_ repositoryFileURL: URL, pattern: String) -> SignalProducer<Bool, NoError> {
 	return ensureDirectoryExistsAtURL(repositoryFileURL)
 		.succeeded()
 		.flatMap(.concat) { exists -> SignalProducer<Bool, NoError> in
@@ -491,7 +491,7 @@ internal func branchExistsInRepository(repositoryFileURL: URL, pattern: String) 
 ///
 /// If the specified file URL does not represent a valid Git repository, `false`
 /// will be sent.
-public func commitExistsInRepository(repositoryFileURL: URL, revision: String = "HEAD") -> SignalProducer<Bool, NoError> {
+public func commitExistsInRepository(_ repositoryFileURL: URL, revision: String = "HEAD") -> SignalProducer<Bool, NoError> {
 	return ensureDirectoryExistsAtURL(repositoryFileURL)
 		.then(launchGitTask([ "rev-parse", "\(revision)^{commit}" ], repositoryFileURL: repositoryFileURL))
 		.then(.init(value: true))
@@ -500,7 +500,7 @@ public func commitExistsInRepository(repositoryFileURL: URL, revision: String = 
 
 /// NSTask throws a hissy fit (a.k.a. exception) if the working directory
 /// doesn't exist, so pre-emptively check for that.
-private func ensureDirectoryExistsAtURL(fileURL: URL) -> SignalProducer<(), CarthageError> {
+private func ensureDirectoryExistsAtURL(_ fileURL: URL) -> SignalProducer<(), CarthageError> {
 	return SignalProducer { observer, disposable in
 		var isDirectory: ObjCBool = false
 		if FileManager.`default`.fileExists(atPath: fileURL.carthage_path, isDirectory: &isDirectory) && isDirectory {
@@ -512,7 +512,7 @@ private func ensureDirectoryExistsAtURL(fileURL: URL) -> SignalProducer<(), Cart
 }
 
 /// Attempts to resolve the given reference into an object SHA.
-public func resolveReferenceInRepository(repositoryFileURL: URL, _ reference: String) -> SignalProducer<String, CarthageError> {
+public func resolveReferenceInRepository(_ repositoryFileURL: URL, _ reference: String) -> SignalProducer<String, CarthageError> {
 	return ensureDirectoryExistsAtURL(repositoryFileURL)
 		.then(launchGitTask([ "rev-parse", "\(reference)^{object}" ], repositoryFileURL: repositoryFileURL))
 		.map { string in string.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -520,7 +520,7 @@ public func resolveReferenceInRepository(repositoryFileURL: URL, _ reference: St
 }
 
 /// Attempts to resolve the given tag into an object SHA.
-internal func resolveTagInRepository(repositoryFileURL: URL, _ tag: String) -> SignalProducer<String, CarthageError> {
+internal func resolveTagInRepository(_ repositoryFileURL: URL, _ tag: String) -> SignalProducer<String, CarthageError> {
 	return launchGitTask([ "show-ref", "--tags", "--hash", tag ], repositoryFileURL: repositoryFileURL)
 		.map { string in string.trimmingCharacters(in: .whitespacesAndNewlines) }
 		.mapError { error in CarthageError.repositoryCheckoutFailed(workingDirectoryURL: repositoryFileURL, reason: "No tag named \"\(tag)\" exists", underlyingError: error as NSError) }
@@ -528,7 +528,7 @@ internal func resolveTagInRepository(repositoryFileURL: URL, _ tag: String) -> S
 
 /// Attempts to determine whether the given directory represents a Git
 /// repository.
-public func isGitRepository(directoryURL: URL) -> SignalProducer<Bool, NoError> {
+public func isGitRepository(_ directoryURL: URL) -> SignalProducer<Bool, NoError> {
 	return ensureDirectoryExistsAtURL(directoryURL)
 		.then(launchGitTask([ "rev-parse", "--git-dir", ], repositoryFileURL: directoryURL))
 		.map { outputIncludingLineEndings in
@@ -548,7 +548,7 @@ public func isGitRepository(directoryURL: URL) -> SignalProducer<Bool, NoError> 
 
 /// Adds the given submodule to the given repository, cloning from `fetchURL` if
 /// the desired revision does not exist or the submodule needs to be cloned.
-public func addSubmoduleToRepository(repositoryFileURL: URL, _ submodule: Submodule, _ fetchURL: GitURL) -> SignalProducer<(), CarthageError> {
+public func addSubmoduleToRepository(_ repositoryFileURL: URL, _ submodule: Submodule, _ fetchURL: GitURL) -> SignalProducer<(), CarthageError> {
 	let submoduleDirectoryURL = repositoryFileURL.appendingPathComponent(submodule.path, isDirectory: true)
 
 	return isGitRepository(submoduleDirectoryURL)
@@ -587,7 +587,7 @@ public func addSubmoduleToRepository(repositoryFileURL: URL, _ submodule: Submod
 /// repository is not found.
 ///
 /// Sends the new URL of the item after moving.
-public func moveItemInPossibleRepository(repositoryFileURL: URL, fromPath: String, toPath: String) -> SignalProducer<URL, CarthageError> {
+public func moveItemInPossibleRepository(_ repositoryFileURL: URL, fromPath: String, toPath: String) -> SignalProducer<URL, CarthageError> {
 	let toURL = repositoryFileURL.appendingPathComponent(toPath)
 	let parentDirectoryURL = toURL.deletingLastPathComponent()
 

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -53,7 +53,7 @@ extension Repository {
 	/// Parses repository information out of a string of the form "owner/name"
 	/// for the github.com, or the form "http(s)://hostname/owner/name" for
 	/// Enterprise instances.
-	public static func fromIdentifier(identifier: String) -> Result<Repository, CarthageError> {
+	public static func fromIdentifier(_ identifier: String) -> Result<Repository, CarthageError> {
 		// GitHub.com
 		let range = NSRange(location: 0, length: identifier.utf16.count)
 		if let match = NWORegex.firstMatch(in: identifier, range: range) {

--- a/Source/CarthageKit/ProducerQueue.swift
+++ b/Source/CarthageKit/ProducerQueue.swift
@@ -29,7 +29,7 @@ internal final class ProducerQueue {
 	/// Creates a SignalProducer that will enqueue the given producer when
 	/// started, wait until the queue is empty to begin work, and block other
 	/// work while executing.
-	func enqueue<T, Error>(producer: SignalProducer<T, Error>) -> SignalProducer<T, Error> {
+	func enqueue<T, Error>(_ producer: SignalProducer<T, Error>) -> SignalProducer<T, Error> {
 		return SignalProducer { observer, disposable in
 			dispatch_async(self.queue) {
 				if disposable.isDisposed {
@@ -58,7 +58,7 @@ internal final class ProducerQueue {
 
 extension SignalProducerProtocol {
 	/// Shorthand for enqueuing the given producer upon the given queue.
-	internal func startOnQueue(queue: ProducerQueue) -> SignalProducer<Value, Error> {
+	internal func startOnQueue(_ queue: ProducerQueue) -> SignalProducer<Value, Error> {
 		return queue.enqueue(self.producer)
 	}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -180,7 +180,7 @@ public final class Project {
 		let cartfileURL = directoryURL.appendingPathComponent(CarthageProjectCartfilePath, isDirectory: false)
 		let privateCartfileURL = directoryURL.appendingPathComponent(CarthageProjectPrivateCartfilePath, isDirectory: false)
 
-		func isNoSuchFileError(error: CarthageError) -> Bool {
+		func isNoSuchFileError(_ error: CarthageError) -> Bool {
 			switch error {
 			case let .readFailed(_, underlyingError):
 				if let underlyingError = underlyingError {
@@ -244,7 +244,7 @@ public final class Project {
 	}
 
 	/// Writes the given Cartfile.resolved out to the project's directory.
-	public func writeResolvedCartfile(resolvedCartfile: ResolvedCartfile) -> Result<(), CarthageError> {
+	public func writeResolvedCartfile(_ resolvedCartfile: ResolvedCartfile) -> Result<(), CarthageError> {
 		do {
 			try resolvedCartfile.description.write(to: resolvedCartfileURL, atomically: true, encoding: .utf8)
 			return .success(())
@@ -270,7 +270,7 @@ public final class Project {
 	///
 	/// Returns a signal which will send the URL to the repository's folder on
 	/// disk once cloning or fetching has completed.
-	private func cloneOrFetchDependency(project: ProjectIdentifier, commitish: String? = nil) -> SignalProducer<URL, CarthageError> {
+	private func cloneOrFetchDependency(_ project: ProjectIdentifier, commitish: String? = nil) -> SignalProducer<URL, CarthageError> {
 		return cloneOrFetchProject(project, preferHTTPS: self.preferHTTPS, commitish: commitish)
 			.on(next: { event, _ in
 				if let event = event {
@@ -332,7 +332,7 @@ public final class Project {
 	}
 
 	/// Attempts to resolve a Git reference to a version.
-	private func resolvedGitReference(project: ProjectIdentifier, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {
+	private func resolvedGitReference(_ project: ProjectIdentifier, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {
 		let repositoryURL = repositoryFileURLForProject(project)
 		return cloneOrFetchDependency(project, commitish: reference)
 			.flatMap(.concat) { _ in
@@ -353,7 +353,7 @@ public final class Project {
 	///
 	/// This will fetch dependency repositories as necessary, but will not check
 	/// them out into the project's working directory.
-	public func updatedResolvedCartfile(dependenciesToUpdate: [String]? = nil) -> SignalProducer<ResolvedCartfile, CarthageError> {
+	public func updatedResolvedCartfile(_ dependenciesToUpdate: [String]? = nil) -> SignalProducer<ResolvedCartfile, CarthageError> {
 		let resolver = Resolver(versionsForDependency: versions(for:), dependenciesForDependency: dependencies(for:), resolvedGitReference: resolvedGitReference)
 
 		let resolvedCartfile: SignalProducer<ResolvedCartfile?, CarthageError> = loadResolvedCartfile()
@@ -379,7 +379,7 @@ public final class Project {
 	///
 	/// This will fetch dependency repositories as necessary, but will not check
 	/// them out into the project's working directory.
-	public func outdatedDependencies(includeNestedDependencies: Bool) -> SignalProducer<[(Dependency<PinnedVersion>, Dependency<PinnedVersion>)], CarthageError> {
+	public func outdatedDependencies(_ includeNestedDependencies: Bool) -> SignalProducer<[(Dependency<PinnedVersion>, Dependency<PinnedVersion>)], CarthageError> {
 		typealias PinnedDependency = Dependency<PinnedVersion>
 		typealias OutdatedDependency = (PinnedDependency, PinnedDependency)
 
@@ -432,7 +432,7 @@ public final class Project {
 	/// Installs binaries and debug symbols for the given project, if available.
 	///
 	/// Sends a boolean indicating whether binaries were installed.
-	private func installBinariesForProject(project: ProjectIdentifier, atRevision revision: String) -> SignalProducer<Bool, CarthageError> {
+	private func installBinariesForProject(_ project: ProjectIdentifier, atRevision revision: String) -> SignalProducer<Bool, CarthageError> {
 		return SignalProducer.attempt {
 				return .success(self.useBinaries)
 			}
@@ -488,7 +488,7 @@ public final class Project {
 	///
 	/// Sends the URL to each downloaded zip, after it has been moved to a
 	/// less temporary location.
-	private func downloadMatchingBinariesForProject(project: ProjectIdentifier, atRevision revision: String, fromRepository repository: Repository, client: Client) -> SignalProducer<URL, CarthageError> {
+	private func downloadMatchingBinariesForProject(_ project: ProjectIdentifier, atRevision revision: String, fromRepository repository: Repository, client: Client) -> SignalProducer<URL, CarthageError> {
 		return client.release(forTag: revision, in: repository)
 			.map { _, release in release }
 			.filter { release in
@@ -538,7 +538,7 @@ public final class Project {
 	/// folder.
 	///
 	/// Sends the URL to the framework after copying.
-	private func copyFrameworkToBuildFolder(frameworkURL: URL) -> SignalProducer<URL, CarthageError> {
+	private func copyFrameworkToBuildFolder(_ frameworkURL: URL) -> SignalProducer<URL, CarthageError> {
 		return platformForFramework(frameworkURL)
 			.flatMap(.merge) { platform -> SignalProducer<URL, CarthageError> in
 				let platformFolderURL = self.directoryURL.appendingPathComponent(platform.relativePath, isDirectory: true)
@@ -553,7 +553,7 @@ public final class Project {
 	/// If no dSYM is found for the given framework, completes with no values.
 	///
 	/// Sends the URL of the dSYM after copying.
-	public func copyDSYMToBuildFolderForFramework(frameworkURL: URL, fromDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+	public func copyDSYMToBuildFolderForFramework(_ frameworkURL: URL, fromDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 		let destinationDirectoryURL = frameworkURL.deletingLastPathComponent()
 		return dSYMForFramework(frameworkURL, inDirectoryURL:directoryURL)
 			.copyFileURLsIntoDirectory(destinationDirectoryURL)
@@ -567,7 +567,7 @@ public final class Project {
 	/// no values.
 	///
 	/// Sends the URLs of the bcsymbolmap files after copying.
-	public func copyBCSymbolMapsToBuildFolderForFramework(frameworkURL: URL, fromDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+	public func copyBCSymbolMapsToBuildFolderForFramework(_ frameworkURL: URL, fromDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 		let destinationDirectoryURL = frameworkURL.deletingLastPathComponent()
 		return BCSymbolMapsForFramework(frameworkURL, inDirectoryURL: directoryURL)
 			.copyFileURLsIntoDirectory(destinationDirectoryURL)
@@ -575,7 +575,7 @@ public final class Project {
 
 	/// Checks out the given dependency into its intended working directory,
 	/// cloning it first if need be.
-	private func checkoutOrCloneDependency(dependency: Dependency<PinnedVersion>, submodulesByPath: [String: Submodule]) -> SignalProducer<(), CarthageError> {
+	private func checkoutOrCloneDependency(_ dependency: Dependency<PinnedVersion>, submodulesByPath: [String: Submodule]) -> SignalProducer<(), CarthageError> {
 		let project = dependency.project
 		let revision = dependency.version.commitish
 		return cloneOrFetchDependency(project, commitish: revision)
@@ -607,7 +607,7 @@ public final class Project {
 			})
 	}
 	
-	public func buildOrderForResolvedCartfile(cartfile: ResolvedCartfile, dependenciesToInclude: [String]? = nil) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
+	public func buildOrderForResolvedCartfile(_ cartfile: ResolvedCartfile, dependenciesToInclude: [String]? = nil) -> SignalProducer<Dependency<PinnedVersion>, CarthageError> {
 		typealias DependencyGraph = [ProjectIdentifier: Set<ProjectIdentifier>]
 		// A resolved cartfile already has all the recursive dependencies. All we need to do is sort
 		// out the relationships between them. Loading the cartfile will each will give us its
@@ -644,7 +644,7 @@ public final class Project {
 
 	/// Checks out the dependencies listed in the project's Cartfile.resolved,
 	/// optionally they are limited by the given list of dependency names.
-	public func checkoutResolvedDependencies(dependenciesToCheckout: [String]? = nil) -> SignalProducer<(), CarthageError> {
+	public func checkoutResolvedDependencies(_ dependenciesToCheckout: [String]? = nil) -> SignalProducer<(), CarthageError> {
 		/// Determine whether the repository currently holds any submodules (if
 		/// it even is a repository).
 		let submodulesSignal = submodulesInRepository(self.directoryURL)
@@ -689,7 +689,7 @@ public final class Project {
 	}
 
 	/// Creates symlink between the dependency checkouts and the root checkouts
-	private func symlinkCheckoutPathsForDependencyProject(dependency: ProjectIdentifier, subDependencies: Set<ProjectIdentifier>, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+	private func symlinkCheckoutPathsForDependencyProject(_ dependency: ProjectIdentifier, subDependencies: Set<ProjectIdentifier>, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 		let rootCheckoutsURL = rootDirectoryURL.appendingPathComponent(CarthageProjectCheckoutsPath, isDirectory: true).resolvingSymlinksInPath()
 		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 		let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
@@ -739,7 +739,7 @@ public final class Project {
 	/// optionally they are limited by the given list of dependency names.
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
-	public func buildCheckedOutDependenciesWithOptions(options: BuildOptions, dependenciesToBuild: [String]? = nil, sdkFilter: SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	public func buildCheckedOutDependenciesWithOptions(_ options: BuildOptions, dependenciesToBuild: [String]? = nil, sdkFilter: SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 		return loadResolvedCartfile()
 			.flatMap(.merge) { resolvedCartfile in
 				return self.buildOrderForResolvedCartfile(resolvedCartfile, dependenciesToInclude: dependenciesToBuild)
@@ -770,7 +770,7 @@ public final class Project {
 
 /// Constructs a file URL to where the binary corresponding to the given
 /// arguments should live.
-private func fileURLToCachedBinary(project: ProjectIdentifier, _ release: Release, _ asset: Release.Asset) -> URL {
+private func fileURLToCachedBinary(_ project: ProjectIdentifier, _ release: Release, _ asset: Release.Asset) -> URL {
 	// ~/Library/Caches/org.carthage.CarthageKit/binaries/ReactiveCocoa/v2.3.1/1234-ReactiveCocoa.framework.zip
 	return CarthageDependencyAssetsURL.appendingPathComponent("\(project.name)/\(release.tag)/\(asset.ID)-\(asset.name)", isDirectory: false)
 }
@@ -779,7 +779,7 @@ private func fileURLToCachedBinary(project: ProjectIdentifier, _ release: Releas
 /// given.
 ///
 /// Sends the final file URL upon .success.
-private func cacheDownloadedBinary(downloadURL: URL, toURL cachedURL: URL) -> SignalProducer<URL, CarthageError> {
+private func cacheDownloadedBinary(_ downloadURL: URL, toURL cachedURL: URL) -> SignalProducer<URL, CarthageError> {
 	return SignalProducer(value: cachedURL)
 		.attempt { fileURL in
 			let parentDirectoryURL = fileURL.deletingLastPathComponent()
@@ -821,7 +821,7 @@ private func cacheDownloadedBinary(downloadURL: URL, toURL cachedURL: URL) -> Si
 
 /// Sends the URL to each file found in the given directory conforming to the
 /// given type identifier. If no type identifier is provided, all files are sent.
-private func filesInDirectory(directoryURL: URL, _ typeIdentifier: String? = nil) -> SignalProducer<URL, CarthageError> {
+private func filesInDirectory(_ directoryURL: URL, _ typeIdentifier: String? = nil) -> SignalProducer<URL, CarthageError> {
 	let producer = FileManager.`default`.carthage_enumerator(at: directoryURL, includingPropertiesForKeys: [ .typeIdentifierKey ], options: [ .skipsHiddenFiles, .skipsPackageDescendants ], catchErrors: true)
 		.map { enumerator, url in url }
 	if let typeIdentifier = typeIdentifier {
@@ -838,14 +838,14 @@ private func filesInDirectory(directoryURL: URL, _ typeIdentifier: String? = nil
 }
 
 /// Sends the platform specified in the given Info.plist.
-private func platformForFramework(frameworkURL: URL) -> SignalProducer<Platform, CarthageError> {
+private func platformForFramework(_ frameworkURL: URL) -> SignalProducer<Platform, CarthageError> {
 	return SignalProducer(value: frameworkURL)
 		// Neither DTPlatformName nor CFBundleSupportedPlatforms can not be used
 		// because Xcode 6 and below do not include either in macOS frameworks.
 		.attemptMap { url -> Result<String, CarthageError> in
 			let bundle = Bundle(url: url)
 
-			func readFailed(message: String) -> CarthageError {
+			func readFailed(_ message: String) -> CarthageError {
 				let error = Result<(), NSError>.error(message)
 				return .readFailed(frameworkURL, error)
 			}
@@ -867,7 +867,7 @@ private func platformForFramework(frameworkURL: URL) -> SignalProducer<Platform,
 }
 
 /// Sends the URL to each framework bundle found in the given directory.
-private func frameworksInDirectory(directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+private func frameworksInDirectory(_ directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 	return filesInDirectory(directoryURL, kUTTypeFramework as String)
 		.filter { url in
 			// Skip nested frameworks
@@ -879,13 +879,13 @@ private func frameworksInDirectory(directoryURL: URL) -> SignalProducer<URL, Car
 }
 
 /// Sends the URL to each dSYM found in the given directory
-private func dSYMsInDirectory(directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+private func dSYMsInDirectory(_ directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 	return filesInDirectory(directoryURL, "com.apple.xcode.dsym")
 }
 
 /// Sends the URL of the dSYM whose UUIDs match those of the given framework, or
 /// errors if there was an error parsing a dSYM contained within the directory.
-private func dSYMForFramework(frameworkURL: URL, inDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+private func dSYMForFramework(_ frameworkURL: URL, inDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 	return UUIDsForFramework(frameworkURL)
 		.flatMap(.concat) { frameworkUUIDs in
 			return dSYMsInDirectory(directoryURL)
@@ -901,20 +901,20 @@ private func dSYMForFramework(frameworkURL: URL, inDirectoryURL directoryURL: UR
 }
 
 /// Sends the URL to each bcsymbolmap found in the given directory.
-private func BCSymbolMapsInDirectory(directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+private func BCSymbolMapsInDirectory(_ directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 	return filesInDirectory(directoryURL)
 		.filter { url in url.pathExtension == "bcsymbolmap" }
 }
 
 /// Sends the URLs of the bcsymbolmap files that match the given framework and are
 /// located somewhere within the given directory.
-private func BCSymbolMapsForFramework(frameworkURL: URL, inDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+private func BCSymbolMapsForFramework(_ frameworkURL: URL, inDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 	return UUIDsForFramework(frameworkURL)
 		.flatMap(.merge) { uuids -> SignalProducer<URL, CarthageError> in
 			if uuids.isEmpty {
 				return .empty
 			}
-			func filterUUIDs(signal: Signal<URL, CarthageError>) -> Signal<URL, CarthageError> {
+			func filterUUIDs(_ signal: Signal<URL, CarthageError>) -> Signal<URL, CarthageError> {
 				var remainingUUIDs = uuids
 				let count = remainingUUIDs.count
 				return signal
@@ -935,13 +935,13 @@ private func BCSymbolMapsForFramework(frameworkURL: URL, inDirectoryURL director
 
 /// Returns the file URL at which the given project's repository will be
 /// located.
-private func repositoryFileURLForProject(project: ProjectIdentifier, baseURL: URL = CarthageDependencyRepositoriesURL) -> URL {
+private func repositoryFileURLForProject(_ project: ProjectIdentifier, baseURL: URL = CarthageDependencyRepositoriesURL) -> URL {
 	return baseURL.appendingPathComponent(project.name, isDirectory: true)
 }
 
 
 /// Returns the URL that the project's remote repository exists at.
-private func repositoryURLForProject(project: ProjectIdentifier, preferHTTPS: Bool) -> GitURL {
+private func repositoryURLForProject(_ project: ProjectIdentifier, preferHTTPS: Bool) -> GitURL {
 	switch project {
 	case let .gitHub(repository):
 		if preferHTTPS {
@@ -956,7 +956,7 @@ private func repositoryURLForProject(project: ProjectIdentifier, preferHTTPS: Bo
 }
 
 /// Returns the string representing a relative path from a dependency project back to the root
-internal func relativeLinkDestinationForDependencyProject(dependency: ProjectIdentifier, subdirectory: String) -> String {
+internal func relativeLinkDestinationForDependencyProject(_ dependency: ProjectIdentifier, subdirectory: String) -> String {
 	let dependencySubdirectoryPath = (dependency.relativePath as NSString).appendingPathComponent(subdirectory)
 	let componentsForGettingTheHellOutOfThisRelativePath = Array(count: (dependencySubdirectoryPath as NSString).pathComponents.count - 1, repeatedValue: "..")
 
@@ -975,7 +975,7 @@ internal func relativeLinkDestinationForDependencyProject(dependency: ProjectIde
 /// Returns a signal which will send the operation type once started, and
 /// the URL to where the repository's folder will exist on disk, then complete
 /// when the operation completes.
-public func cloneOrFetchProject(project: ProjectIdentifier, preferHTTPS: Bool, destinationURL: URL = CarthageDependencyRepositoriesURL, commitish: String? = nil) -> SignalProducer<(ProjectEvent?, URL), CarthageError> {
+public func cloneOrFetchProject(_ project: ProjectIdentifier, preferHTTPS: Bool, destinationURL: URL = CarthageDependencyRepositoriesURL, commitish: String? = nil) -> SignalProducer<(ProjectEvent?, URL), CarthageError> {
 	let fileManager = FileManager.`default`
 	let repositoryURL = repositoryFileURLForProject(project, baseURL: destinationURL)
 

--- a/Source/CarthageKit/ProjectLocator.swift
+++ b/Source/CarthageKit/ProjectLocator.swift
@@ -102,7 +102,7 @@ public enum ProjectLocator: Comparable {
 	}
 }
 
-public func ==(lhs: ProjectLocator, rhs: ProjectLocator) -> Bool {
+public func ==(_ lhs: ProjectLocator, _ rhs: ProjectLocator) -> Bool {
 	switch (lhs, rhs) {
 	case let (.workspace(left), .workspace(right)):
 		return left == right
@@ -115,7 +115,7 @@ public func ==(lhs: ProjectLocator, rhs: ProjectLocator) -> Bool {
 	}
 }
 
-public func <(lhs: ProjectLocator, rhs: ProjectLocator) -> Bool {
+public func <(_ lhs: ProjectLocator, _ rhs: ProjectLocator) -> Bool {
 	// Prefer top-level directories
 	let leftLevel = lhs.level
 	let rightLevel = rhs.level

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -136,7 +136,7 @@ public struct Resolver {
 	/// In other words, this attempts to create one transformed graph for each
 	/// possible permutation of the dependencies for the given node (chosen from
 	/// among the verisons that actually exist for each).
-	private func graphsForDependenciesOfNode(node: DependencyNode, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
+	private func graphsForDependenciesOfNode(_ node: DependencyNode, basedOnGraph inputGraph: DependencyGraph) -> SignalProducer<DependencyGraph, CarthageError> {
 		let scheduler = QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "org.carthage.CarthageKit.Resolver.graphsForDependenciesOfNode")
 
 		return dependenciesForDependency(node.dependencyVersion)
@@ -272,7 +272,7 @@ private struct DependencyGraph: Equatable {
 	/// Returns the node as actually inserted into the graph (which may be
 	/// different from the node passed in), or an error if this addition would
 	/// make the graph inconsistent.
-	mutating func addNode(node: DependencyNode, dependencyOf: DependencyNode?) -> Result<DependencyNode, CarthageError> {
+	mutating func addNode(_ node: DependencyNode, dependencyOf: DependencyNode?) -> Result<DependencyNode, CarthageError> {
 		var node = node
 
 		if let index = allNodes.index(of: node) {
@@ -361,7 +361,7 @@ private struct DependencyGraph: Equatable {
 
 	/// Whether the given node is included or not in the nested dependencies of
 	/// the given dependencies.
-	func dependencies(dependencies: [String], containsNestedDependencyOfNode node: DependencyNode) -> Bool {
+	func dependencies(_ dependencies: [String], containsNestedDependencyOfNode node: DependencyNode) -> Bool {
 		return edges.lazy
 			.filter { edge, nodeSet in
 				return dependencies.contains(edge.project.name) && nodeSet.contains(node)
@@ -371,7 +371,7 @@ private struct DependencyGraph: Equatable {
 	}
 }
 
-private func ==(lhs: DependencyGraph, rhs: DependencyGraph) -> Bool {
+private func ==(_ lhs: DependencyGraph, _ rhs: DependencyGraph) -> Bool {
 	if lhs.edges.count != rhs.edges.count || lhs.roots.count != rhs.roots.count {
 		return false
 	}
@@ -489,7 +489,7 @@ private class DependencyNode: Comparable {
 	}
 }
 
-private func <(lhs: DependencyNode, rhs: DependencyNode) -> Bool {
+private func <(_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
 	let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
 	let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
 
@@ -497,7 +497,7 @@ private func <(lhs: DependencyNode, rhs: DependencyNode) -> Bool {
 	return leftSemantic > rightSemantic
 }
 
-private func ==(lhs: DependencyNode, rhs: DependencyNode) -> Bool {
+private func ==(_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
 	return lhs.project == rhs.project
 }
 

--- a/Source/CarthageKit/SDK.swift
+++ b/Source/CarthageKit/SDK.swift
@@ -32,7 +32,7 @@ public enum SDK: String {
 	}
 
 	/// Split the given SDKs into simulator ones and device ones.
-	internal static func splitSDKs<S: SequenceType where S.Generator.Element == SDK>(sdks: S) -> (simulators: [SDK], devices: [SDK]) {
+	internal static func splitSDKs<S: SequenceType where S.Generator.Element == SDK>(_ sdks: S) -> (simulators: [SDK], devices: [SDK]) {
 		return (
 			simulators: sdks.filter { $0.isSimulator },
 			devices: sdks.filter { !$0.isSimulator }

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -105,11 +105,11 @@ extension SemanticVersion: Scannable {
 	}
 }
 
-public func <(lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+public func <(_ lhs: SemanticVersion, _ rhs: SemanticVersion) -> Bool {
 	return lhs.components.lexicographicalCompare(rhs.components)
 }
 
-public func ==(lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+public func ==(_ lhs: SemanticVersion, _ rhs: SemanticVersion) -> Bool {
 	return lhs.components == rhs.components
 }
 
@@ -139,7 +139,7 @@ public struct PinnedVersion: VersionType {
 	}
 }
 
-public func ==(lhs: PinnedVersion, rhs: PinnedVersion) -> Bool {
+public func ==(_ lhs: PinnedVersion, _ rhs: PinnedVersion) -> Bool {
 	return lhs.commitish == rhs.commitish
 }
 
@@ -179,7 +179,7 @@ public enum VersionSpecifier: VersionType {
 
 	/// Determines whether the given version satisfies this version specifier.
 	public func isSatisfied(by version: PinnedVersion) -> Bool {
-		func withSemanticVersion(predicate: (SemanticVersion) -> Bool) -> Bool {
+		func withSemanticVersion(_ predicate: (SemanticVersion) -> Bool) -> Bool {
 			if let semanticVersion = SemanticVersion.from(version).value {
 				return predicate(semanticVersion)
 			} else {
@@ -231,7 +231,7 @@ public enum VersionSpecifier: VersionType {
 	}
 }
 
-public func ==(lhs: VersionSpecifier, rhs: VersionSpecifier) -> Bool {
+public func ==(_ lhs: VersionSpecifier, _ rhs: VersionSpecifier) -> Bool {
 	switch (lhs, rhs) {
 	case (.any, .any):
 		return true
@@ -331,7 +331,7 @@ private func intersection(compatibleWith compatibleWith: SemanticVersion, exactl
 ///
 /// In other words, any version that satisfies the returned specifier will
 /// satisfy _both_ of the given specifiers.
-public func intersection(lhs: VersionSpecifier, _ rhs: VersionSpecifier) -> VersionSpecifier? {
+public func intersection(_ lhs: VersionSpecifier, _ rhs: VersionSpecifier) -> VersionSpecifier? {
 	switch (lhs, rhs) {
 	// Unfortunately, patterns with a wildcard _ are not considered exhaustive,
 	// so do the same thing manually.
@@ -407,7 +407,7 @@ public func intersection(lhs: VersionSpecifier, _ rhs: VersionSpecifier) -> Vers
 ///
 /// In other words, any version that satisfies the returned specifier will
 /// satisfy _all_ of the given specifiers.
-public func intersection<S: SequenceType where S.Generator.Element == VersionSpecifier>(specs: S) -> VersionSpecifier? {
+public func intersection<S: SequenceType where S.Generator.Element == VersionSpecifier>(_ specs: S) -> VersionSpecifier? {
 	return specs.reduce(nil) { (left: VersionSpecifier?, right: VersionSpecifier) -> VersionSpecifier? in
 		if let left = left {
 			return intersection(left, right)

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -23,7 +23,7 @@ public struct ArchiveCommand: CommandType {
 		public let colorOptions: ColorOptions
 		public let frameworkNames: [String]
 
-		static func create(outputPath: String?) -> (String) -> (ColorOptions) -> ([String]) -> Options {
+		static func create(_ outputPath: String?) -> (String) -> (ColorOptions) -> ([String]) -> Options {
 			return { directoryPath in { colorOptions in { frameworkNames in
 				return self.init(outputPath: outputPath, directoryPath: directoryPath, colorOptions: colorOptions, frameworkNames: frameworkNames)
 			} } }
@@ -135,7 +135,7 @@ public struct ArchiveCommand: CommandType {
 
 /// Returns an appropriate output file path for the resulting zip file using
 /// the given option and frameworks.
-private func outputPathWithOptions(options: ArchiveCommand.Options, frameworks: [String]) -> String {
+private func outputPathWithOptions(_ options: ArchiveCommand.Options, frameworks: [String]) -> String {
 	let defaultOutputPath = "\(frameworks.first!).zip"
 
 	return options.outputPath.map { path -> String in

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -20,7 +20,7 @@ public struct BootstrapCommand: CommandType {
 	public let verb = "bootstrap"
 	public let function = "Check out and build the project's dependencies"
 
-	public func run(options: UpdateCommand.Options) -> Result<(), CarthageError> {
+	public func run(_ options: UpdateCommand.Options) -> Result<(), CarthageError> {
 		// Reuse UpdateOptions, since all `bootstrap` flags should correspond to
 		// `update` flags.
 		return options.loadProject()

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -18,7 +18,7 @@ import ReactiveCocoa
 import ReactiveTask
 
 extension BuildOptions: OptionsType {
-	public static func create(configuration: String) -> (BuildPlatform) -> (String?) -> (String?) -> BuildOptions {
+	public static func create(_ configuration: String) -> (BuildPlatform) -> (String?) -> (String?) -> BuildOptions {
 		return { buildPlatform in { toolchain in { derivedDataPath in
 			return self.init(configuration: configuration, platforms: buildPlatform.platforms, toolchain: toolchain, derivedDataPath: derivedDataPath)
 		} } }
@@ -46,7 +46,7 @@ public struct BuildCommand: CommandType {
 		public let directoryPath: String
 		public let dependenciesToBuild: [String]?
 
-		public static func create(buildOptions: BuildOptions) -> (Bool) -> (ColorOptions) -> (Bool) -> (String) -> ([String]) -> Options {
+		public static func create(_ buildOptions: BuildOptions) -> (Bool) -> (ColorOptions) -> (Bool) -> (String) -> ([String]) -> Options {
 			return { skipCurrent in { colorOptions in { isVerbose in { directoryPath in { dependenciesToBuild in
 				let dependenciesToBuild: [String]? = dependenciesToBuild.isEmpty ? nil : dependenciesToBuild
 				return self.init(buildOptions: buildOptions, skipCurrent: skipCurrent, colorOptions: colorOptions, isVerbose: isVerbose, directoryPath: directoryPath, dependenciesToBuild: dependenciesToBuild)
@@ -73,7 +73,7 @@ public struct BuildCommand: CommandType {
 	}
 
 	/// Builds a project with the given options.
-	public func buildWithOptions(options: Options) -> SignalProducer<(), CarthageError> {
+	public func buildWithOptions(_ options: Options) -> SignalProducer<(), CarthageError> {
 		return self.openLoggingHandle(options)
 			.flatMap(.merge) { (stdoutHandle, temporaryURL) -> SignalProducer<(), CarthageError> in
 				let directoryURL = URL(fileURLWithPath: options.directoryPath, isDirectory: true)
@@ -133,7 +133,7 @@ public struct BuildCommand: CommandType {
 	/// Builds the project in the given directory, using the given options.
 	///
 	/// Returns a producer of producers, representing each scheme being built.
-	private func buildProjectInDirectoryURL(directoryURL: URL, options: Options) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	private func buildProjectInDirectoryURL(_ directoryURL: URL, options: Options) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 		let project = Project(directoryURL: directoryURL)
 
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
@@ -198,7 +198,7 @@ public struct BuildCommand: CommandType {
 
 	/// Opens a file handle for logging, returning the handle and the URL to any
 	/// temporary file on disk.
-	private func openLoggingHandle(options: Options) -> SignalProducer<(FileHandle, URL?), CarthageError> {
+	private func openLoggingHandle(_ options: Options) -> SignalProducer<(FileHandle, URL?), CarthageError> {
 		if options.isVerbose {
 			let out: (FileHandle, URL?) = (FileHandle.standardOutput, nil)
 			return SignalProducer(value: out)
@@ -259,7 +259,7 @@ public enum BuildPlatform: Equatable {
 	}
 }
 
-public func ==(lhs: BuildPlatform, rhs: BuildPlatform) -> Bool {
+public func ==(_ lhs: BuildPlatform, _ rhs: BuildPlatform) -> Bool {
 	switch (lhs, rhs) {
 	case let (.multiple(left), .multiple(right)):
 		return left == right

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -25,7 +25,7 @@ public struct CheckoutCommand: CommandType {
 		public let directoryPath: String
 		public let dependenciesToCheckout: [String]?
 
-		public static func create(useSSH: Bool) -> (Bool) -> (Bool) -> (ColorOptions) -> (String) -> ([String]) -> Options {
+		public static func create(_ useSSH: Bool) -> (Bool) -> (Bool) -> (ColorOptions) -> (String) -> ([String]) -> Options {
 			return { useSubmodules in { useBinaries in { colorOptions in { directoryPath in { dependenciesToCheckout in
 				// Disable binary downloads when using submodules.
 				// See https://github.com/Carthage/Carthage/issues/419.
@@ -76,7 +76,7 @@ public struct CheckoutCommand: CommandType {
 	}
 
 	/// Checks out dependencies with the given options.
-	public func checkoutWithOptions(options: Options) -> SignalProducer<(), CarthageError> {
+	public func checkoutWithOptions(_ options: Options) -> SignalProducer<(), CarthageError> {
 		return options.loadProject()
 			.flatMap(.merge) { $0.checkoutResolvedDependencies(options.dependenciesToCheckout) }
 	}

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -21,7 +21,7 @@ public struct CopyFrameworksCommand: CommandType {
 	public let verb = "copy-frameworks"
 	public let function = "In a Run Script build phase, copies each framework specified by a SCRIPT_INPUT_FILE environment variable into the built app bundle"
 
-	public func run(options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
+	public func run(_ options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
 		return inputFiles()
 			.flatMap(.concat) { frameworkPath -> SignalProducer<(), CarthageError> in
 				let frameworkName = (frameworkPath as NSString).lastPathComponent
@@ -49,7 +49,7 @@ public struct CopyFrameworksCommand: CommandType {
 	}
 }
 
-private func copyFramework(source: URL, target: URL, validArchitectures: [String]) -> SignalProducer<(), CarthageError> {
+private func copyFramework(_ source: URL, target: URL, validArchitectures: [String]) -> SignalProducer<(), CarthageError> {
 	return SignalProducer.combineLatest(copyProduct(source, target), codeSigningIdentity())
 		.flatMap(.merge) { (url, codesigningIdentity) -> SignalProducer<(), CarthageError> in
 			let strip = stripFramework(url, keepingArchitectures: validArchitectures, codesigningIdentity: codesigningIdentity)
@@ -63,7 +63,7 @@ private func copyFramework(source: URL, target: URL, validArchitectures: [String
 	}
 }
 
-private func shouldIgnoreFramework(framework: URL, validArchitectures: [String]) -> SignalProducer<Bool, CarthageError> {
+private func shouldIgnoreFramework(_ framework: URL, validArchitectures: [String]) -> SignalProducer<Bool, CarthageError> {
 	return architecturesInPackage(framework)
 		.collect()
 		.map { architectures in
@@ -76,7 +76,7 @@ private func shouldIgnoreFramework(framework: URL, validArchitectures: [String])
 		}
 }
 
-private func copyDebugSymbolsForFramework(source: URL, validArchitectures: [String]) -> SignalProducer<(), CarthageError> {
+private func copyDebugSymbolsForFramework(_ source: URL, validArchitectures: [String]) -> SignalProducer<(), CarthageError> {
 	return SignalProducer(result: appropriateDestinationFolder())
 		.flatMap(.merge) { destinationURL in
 			return SignalProducer(value: source)
@@ -89,7 +89,7 @@ private func copyDebugSymbolsForFramework(source: URL, validArchitectures: [Stri
 
 }
 
-private func copyBCSymbolMapsForFramework(frameworkURL: URL, fromDirectory directoryURL: URL) -> SignalProducer<URL, CarthageError> {
+private func copyBCSymbolMapsForFramework(_ frameworkURL: URL, fromDirectory directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 	// This should be called only when `buildActionIsArchiveOrInstall()` is true.
 	return SignalProducer(result: builtProductsFolder())
 		.flatMap(.merge) { builtProductsURL in

--- a/Source/carthage/Environment.swift
+++ b/Source/carthage/Environment.swift
@@ -10,7 +10,7 @@ import CarthageKit
 import Foundation
 import Result
 
-internal func getEnvironmentVariable(variable: String) -> Result<String, CarthageError> {
+internal func getEnvironmentVariable(_ variable: String) -> Result<String, CarthageError> {
 	let environment = ProcessInfo.processInfo.environment
 
 	if let value = environment[variable] {

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -39,14 +39,14 @@ internal func println() {
 }
 
 /// A thread-safe version of Swift's standard println().
-internal func println<T>(object: T) {
+internal func println<T>(_ object: T) {
 	dispatch_async(outputQueue) {
 		Swift.print(object)
 	}
 }
 
 /// A thread-safe version of Swift's standard print().
-internal func print<T>(object: T) {
+internal func print<T>(_ object: T) {
 	dispatch_async(outputQueue) {
 		Swift.print(object, terminator: "")
 	}
@@ -96,7 +96,7 @@ internal struct ProjectEventSink {
 		self.colorOptions = colorOptions
 	}
 	
-	mutating func put(event: ProjectEvent) {
+	mutating func put(_ event: ProjectEvent) {
 		let formatting = colorOptions.formatting
 		
 		switch event {

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -21,7 +21,7 @@ public struct FetchCommand: CommandType {
 		public let colorOptions: ColorOptions
 		public let repositoryURL: GitURL
 
-		static func create(colorOptions: ColorOptions) -> (GitURL) -> Options {
+		static func create(_ colorOptions: ColorOptions) -> (GitURL) -> Options {
 			return { repositoryURL in
 				return self.init(colorOptions: colorOptions, repositoryURL: repositoryURL)
 			}

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -13,7 +13,7 @@ import Result
 import PrettyColors
 
 /// Wraps a string with terminal colors and formatting or passes it through, depending on `isColorful`.
-private func wrap(isColorful: Bool, wrap: Color.Wrap) -> (String) -> String {
+private func wrap(_ isColorful: Bool, wrap: Color.Wrap) -> (String) -> String {
 	return { string in
 		return isColorful ? wrap.wrap(string) : string
 	}
@@ -82,17 +82,17 @@ public struct ColorOptions: OptionsType {
 		}
 
 		/// Wraps a string in bullets, one space of padding, and formatting.
-		func bulletinTitle(string: String) -> String {
+		func bulletinTitle(_ string: String) -> String {
 			return bulletin(string: "*** " + string + " ***")
 		}
 
 		/// Wraps a string in quotation marks and formatting.
-		func quote(string: String, quotationMark: String = "\"") -> String {
+		func quote(_ string: String, quotationMark: String = "\"") -> String {
 			return wrap(isColorful, wrap: Color.Wrap(foreground: .green))(quotationMark + string + quotationMark)
 		}
 	}
 	
-	public static func create(argument: ColorArgument) -> ColorOptions {
+	public static func create(_ argument: ColorArgument) -> ColorOptions {
 		return self.init(argument: argument, formatting: Formatting(argument.isColorful))
 	}
 	

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -23,7 +23,7 @@ public struct OutdatedCommand: CommandType {
 		public let colorOptions: ColorOptions
 		public let directoryPath: String
 		
-		public static func create(useSSH: Bool) -> (Bool) -> (ColorOptions) -> (String) -> Options {
+		public static func create(_ useSSH: Bool) -> (Bool) -> (ColorOptions) -> (String) -> Options {
 			return { isVerbose in { colorOptions in { directoryPath in
 				return self.init(useSSH: useSSH, isVerbose: isVerbose, colorOptions: colorOptions, directoryPath: directoryPath)
 			} } }

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -42,7 +42,7 @@ public struct UpdateCommand: CommandType {
 			}
 		}
 
-		public static func create(checkoutAfterUpdate: Bool) -> (Bool) -> (Bool) -> (BuildOptions) -> (CheckoutCommand.Options) -> Options {
+		public static func create(_ checkoutAfterUpdate: Bool) -> (Bool) -> (Bool) -> (BuildOptions) -> (CheckoutCommand.Options) -> Options {
 			return { buildAfterUpdate in { isVerbose in {  buildOptions in { checkoutOptions in
 				return self.init(checkoutAfterUpdate: checkoutAfterUpdate, buildAfterUpdate: buildAfterUpdate, isVerbose: isVerbose, buildOptions: buildOptions, checkoutOptions: checkoutOptions, dependenciesToUpdate: checkoutOptions.dependenciesToCheckout)
 			} } } }

--- a/Source/carthage/Version.swift
+++ b/Source/carthage/Version.swift
@@ -15,7 +15,7 @@ public struct VersionCommand: CommandType {
 	public let verb = "version"
 	public let function = "Display the current version of Carthage"
 
-	public func run(options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
+	public func run(_ options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
 		let versionString = Bundle(identifier: CarthageKitBundleIdentifier)?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
 		carthage.println(versionString)
 		return .success(())


### PR DESCRIPTION
#1558 

We would/should revisit following API Design Guidelines once we have done Swift 3 migration.
