### PR TITLE
Update PrettyColors

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,6 @@
 github "Carthage/ReactiveTask" "96e1013e0a6782bf0faba27485fe2d0a1153b531"
 github "Carthage/Commandant" ~> 0.11.2
-github "jdhealy/PrettyColors" "6f54504f8715c5d51114bcff821c48fd87d8a8b7"
+github "jdhealy/PrettyColors" ~> 5.0
 github "ReactiveCocoa/ReactiveSwift" ~> 1.0
 github "mdiep/Tentacle" ~> 0.5
 github "thoughtbot/Runes" ~> 4.0.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "thoughtbot/Curry" "v3.0.0"
 github "Quick/Nimble" "v6.0.1"
-github "jdhealy/PrettyColors" "6f54504f8715c5d51114bcff821c48fd87d8a8b7"
+github "jdhealy/PrettyColors" "v5.0.0"
 github "Quick/Quick" "v1.0.0"
 github "antitypical/Result" "3.1.0"
 github "thoughtbot/Runes" "v4.0.1"


### PR DESCRIPTION
Update PrettyColors to [tagged version `v5.0.0`](https://github.com/jdhealy/PrettyColors/releases/tag/5.0.0).