### PR TITLE
Don't filter output so it still makes it to the log file

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -75,24 +75,13 @@ public struct BuildCommand: CommandProtocol {
 			.flatMap(.merge) { (stdoutHandle, temporaryURL) -> SignalProducer<(), CarthageError> in
 				let directoryURL = URL(fileURLWithPath: options.directoryPath, isDirectory: true)
 
-				var buildProgress = self.buildProjectInDirectoryURL(directoryURL, options: options)
+				let buildProgress = self.buildProjectInDirectoryURL(directoryURL, options: options)
 					.flatten(.concat)
 
-				let stderrHandle = FileHandle.standardError
+				let stderrHandle = options.isVerbose ? FileHandle.standardError : stdoutHandle
 
 				let formatting = options.colorOptions.formatting
 				
-				if !options.isVerbose {
-					buildProgress = buildProgress.filter { event in
-						switch event {
-						case .launch, .success:
-							return true
-						case .standardOutput, .standardError:
-							return false
-						}
-					}
-				}
-
 				return buildProgress
 					.mapError { error -> CarthageError in
 						if case let .buildFailed(taskError, _) = error {


### PR DESCRIPTION
This fixes an issue I found, caused by the changes for Carthage/Carthage#1718

1718 filtered the output when !verbose, unfortunately this filtered it out from writing to the log file either, so when in non-verbose mode, you get no xcode output at all.

This instead just routes errors -> stdout when not verbose, thus sending all messages to the log file.
