### PR TITLE
Fix printing of newIssueURL

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -39,8 +39,8 @@ extension Repository {
 	}
 
 	/// The URL for filing a new GitHub issue for this repository.
-	public var newIssueURL: NSURL {
-		return NSURL(string: "\(server)/\(owner)/\(name)/issues/new")!
+	public var newIssueURL: URL {
+		return URL(string: "\(server)/\(owner)/\(name)/issues/new")!
 	}
 	
 	/// Matches an identifier of the form "owner/name".


### PR DESCRIPTION
By making this a `URL`, `absoluteString` is no longer optional.

Output was:

> *** Skipped building libextobjc due to the error:
> Dependency "libextobjc" has no shared framework schemes for any of the platforms: iOS
> 
> If you believe this to be an error, please file an issue with the maintainers at Optional("https://github.com/jspahrsummers/libextobjc/issues/new")
> 

Now:

> *** Skipped building libextobjc due to the error:
> Dependency "libextobjc" has no shared framework schemes for any of the platforms: iOS
> 
> If you believe this to be an error, please file an issue with the maintainers at https://github.com/jspahrsummers/libextobjc/issues/new