### PR TITLE
Readme: Added leading slash for shell example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 1. Create a [Cartfile][] that lists the frameworks you’d like to use in your project.
 1. Run `carthage update`. This will fetch dependencies into a [Carthage/Checkouts][] folder, then build each one or download a pre-compiled framework.
 1. On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop each framework you want to use from the [Carthage/Build][] folder on disk.
-1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `bin/sh`), add the following contents to the script area below the shell:
+1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
   ```sh
   /usr/local/bin/carthage copy-frameworks


### PR DESCRIPTION
Turns out `bin/sh` does not work, and will make you tear your hair out for 15 minutes until you notice the missing leading slash. This readme change will hopefully spare some people their sanity 🙂