### PR TITLE
Add support for .tar.gz binary archives

### DIFF
--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -36,9 +36,41 @@ public func unzip(archive fileURL: URL, to destinationDirectoryURL: URL) -> Sign
 		.then(SignalProducer<(), CarthageError>.empty)
 }
 
+/// Untars the gzipped archive at the given file URL, extracting into the given
+/// directory URL (which must already exist).
+public func untargz(archive fileURL: URL, to destinationDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+	precondition(fileURL.isFileURL)
+	precondition(destinationDirectoryURL.isFileURL)
+
+	let task = Task("/usr/bin/env", arguments: [ "tar", "-xzf", fileURL.carthage_path, "-C", destinationDirectoryURL.carthage_path ])
+	return task.launch()
+		.mapError(CarthageError.taskError)
+		.then(SignalProducer<(), CarthageError>.empty)
+}
+
+
 /// Unzips the archive at the given file URL into a temporary directory, then
 /// sends the file URL to that directory.
 public func unzip(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
+	return createTemporaryDirectory()
+		.flatMap(.merge) { directoryURL in
+			return unzip(archive: fileURL, to: directoryURL)
+				.then(SignalProducer<URL, CarthageError>(value: directoryURL))
+		}
+}
+
+
+/// Untars the gzipped archive at the given file URL into a temporary directory, 
+/// then sends the file URL to that directory.
+public func untargz(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
+	return createTemporaryDirectory()
+		.flatMap(.merge) { directoryURL in
+			return untargz(archive: fileURL, to: directoryURL)
+				.then(SignalProducer<URL, CarthageError>(value: directoryURL))
+		}
+}
+
+internal func createTemporaryDirectory() -> SignalProducer<URL, CarthageError> {
 	return SignalProducer.attempt { () -> Result<String, CarthageError> in
 			var temporaryDirectoryTemplate: ContiguousArray<CChar> = (NSTemporaryDirectory() as NSString).appendingPathComponent("carthage-archive.XXXXXX").utf8CString
 			let result: UnsafeMutablePointer<Int8>? = temporaryDirectoryTemplate.withUnsafeMutableBufferPointer { (template: inout UnsafeMutableBufferPointer<CChar>) -> UnsafeMutablePointer<CChar> in
@@ -54,10 +86,6 @@ public func unzip(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
 			}
 
 			return .success(temporaryPath)
-		}
-		.map { URL(fileURLWithPath: $0, isDirectory: true) }
-		.flatMap(.merge) { directoryURL in
-			return unzip(archive: fileURL, to: directoryURL)
-				.then(SignalProducer<URL, CarthageError>(value: directoryURL))
-		}
+			}
+			.map { URL(fileURLWithPath: $0, isDirectory: true) }
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -523,7 +523,13 @@ public final class Project {
 	/// Sends the temporary URL of the unzipped directory
 	private func unzipAndCopyBinaryFrameworks(zipFile: URL) -> SignalProducer<URL, CarthageError> {
 		return SignalProducer<URL, CarthageError>(value: zipFile)
-			.flatMap(.concat, transform: unzip(archive:))
+			.flatMap(.concat) { fileURL -> SignalProducer<URL, CarthageError> in
+				if fileURL.pathExtension == "gz" {
+					return untargz(archive: fileURL)
+				} else {
+					return unzip(archive: fileURL)
+				}
+			}
 			.flatMap(.concat) { directoryURL in
 				return frameworksInDirectory(directoryURL)
 					.flatMap(.merge) { url in

--- a/Source/CarthageKitTests/ArchiveSpec.swift
+++ b/Source/CarthageKitTests/ArchiveSpec.swift
@@ -25,7 +25,7 @@ class ArchiveSpec: QuickSpec {
 			let archiveURL = Bundle(for: type(of: self)).url(forResource: "CartfilePrivateOnly", withExtension: "zip")!
 
 			it("should unzip archive to a temporary directory") {
-				let result = unzip(archive: archiveURL).single()
+				let result = unarchive(archive: archiveURL).single()
 				expect(result).notTo(beNil())
 				expect(result?.error).to(beNil())
 
@@ -73,7 +73,7 @@ class ArchiveSpec: QuickSpec {
 				let result = zip(paths: [ innerFilePath, outerFilePath ], into: archiveURL, workingDirectory: temporaryURL.carthage_path).wait()
 				expect(result.error).to(beNil())
 
-				let unzipResult = unzip(archive: archiveURL).single()
+				let unzipResult = unarchive(archive: archiveURL).single()
 				expect(unzipResult).notTo(beNil())
 				expect(unzipResult?.error).to(beNil())
 
@@ -104,7 +104,7 @@ class ArchiveSpec: QuickSpec {
 				let result = zip(paths: [ symlinkPath, destinationPath ], into: archiveURL, workingDirectory: temporaryURL.carthage_path).wait()
 				expect(result.error).to(beNil())
 
-				let unzipResult = unzip(archive: archiveURL).single()
+				let unzipResult = unarchive(archive: archiveURL).single()
 				expect(unzipResult).notTo(beNil())
 				expect(unzipResult?.error).to(beNil())
 


### PR DESCRIPTION
Some organisations provide binary releases in .tar.gz archives rather than zips. With support for extracting these, it becomes easier for them or a third-party to provide the JSON files for binaries. 

This could be expanded to support BZIP etc.