### PR TITLE
Update README for cache and submodule incompatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Note that you should be [using submodules](#using-submodules-for-dependencies) b
 
 By default Carthage will rebuild a dependency regardless of whether it's the same resolved version as before. Passing the `--cache-builds` will cause carthage to avoid rebuilding a dependency if it can. See information on [version files][VersionFile] for details on how carthage performs this caching. 
 
+Note: At this time `--cache-builds` is incompatible with `--use-submodules`. Using both will result in working copy and committed changes to your submodule dependency not being correctly rebuilt. See [#1785](https://github.com/Carthage/Carthage/issues/1785) for details.
+
 ### Bash/Zsh/Fish completion
 
 Auto completion of Carthage commands and options are available as documented in [Bash/Zsh/Fish Completion][Bash/Zsh/Fish Completion].


### PR DESCRIPTION
Choosing the easy route from #1785 for starters.