### PR TITLE
Execute `git ls-tree` to list just the directory contents, without recursion

### DIFF
--- a/Source/CarthageIntegration/Utilities/TestFramework.bash
+++ b/Source/CarthageIntegration/Utilities/TestFramework.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load "Utilities/git-commit"
+
+extract-test-frameworks-one-and-two() {
+	unzip ${BATS_TEST_DIRNAME:?}/../CarthageKitTests/fixtures/DependencyTest.zip 'DependencyTest/SourceRepos/TestFramework[12]/*' -d "${BATS_TMPDIR:?}"
+}
+
+branch-test-frameworks-one-and-two() {
+	directory_to_return_into="${PWD:?}"
+	branch="${1:?}" # parameter 1: branch name used in git repositories for both `TestFramework`s.
+
+	# - - - - - - -
+
+	cd ${extracted_directory:?}/SourceRepos/TestFramework2
+	git checkout -b ${branch} master
+
+	rm -v Cartfile Cartfile.resolved
+	git-commit 'Remove dependencies.'
+
+	# - - - - - - -
+
+	cd ${extracted_directory:?}/SourceRepos/TestFramework1
+	git checkout -b ${branch} master
+
+	# overwrite Cartfile
+	cat >| Cartfile <<-EOF
+		git "file://${extracted_directory:?}/SourceRepos/TestFramework2" "${branch}"
+	EOF
+
+	rm -v Cartfile.resolved
+	git-commit 'Set Cartfile based on file URLs and branch.'
+
+	# - - - - - - -
+
+	cd ${directory_to_return_into:?}
+}

--- a/Source/CarthageIntegration/Utilities/git-commit.bash
+++ b/Source/CarthageIntegration/Utilities/git-commit.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+git-commit() {
+	git add --all && git commit --author='Carthage Integration Tests <>' -m "${1:?}"
+}

--- a/Source/CarthageIntegration/checked-in-conflicting-differing-directory.bats
+++ b/Source/CarthageIntegration/checked-in-conflicting-differing-directory.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load "Utilities/git-commit"
+load "Utilities/TestFramework"
+
+### older version of carthage wrote this directory?
+### user wrote this directory, unaware of the precedent not to circumvent carthage’s management?
+### directory exists as the result of rogue process or gamma ray?
+
+### TODO: explore possibility of messaging user, informing that deleting said directory will result
+### in symlink creation with carthage versions greater than 0.20.0, maybe with more broad advice on
+### “from scratch” reproducability.
+
+extracted_directory="${BATS_TMPDIR}/DependencyTest"
+
+project_directory() {
+	if [[ -z ${CI+x} ]]; then
+		echo -n "${BATS_TMPDIR:?}"
+	else
+		echo -n "${HOME:?}/Library/Caches/org.carthage.CarthageIntegration"
+	fi
+
+	echo -n "/IntegrationTestProject"
+}
+
+setup() {
+	extract-test-frameworks-one-and-two
+
+	export GITCONFIG='/dev/null'
+	branch-test-frameworks-one-and-two 'checked-in-conflicting-differing-directory'
+
+	cd ${extracted_directory}/SourceRepos/TestFramework1
+
+	mkdir -p ${PWD}/'Carthage/Checkouts'
+	ditto 'TestFramework1.xcodeproj/project.xcworkspace/' 'Carthage/Checkouts/TestFramework2'
+	git-commit 'Add (for nonsensical reasons) conflicting directory at «Carthage/Checkouts/TestFramework2».'
+
+	mkdir -p "$(project_directory)" && cd "$(project_directory)"
+
+	cat > Cartfile <<-EOF
+		git "file://${extracted_directory}/SourceRepos/TestFramework1" "checked-in-conflicting-differing-directory"
+	EOF
+
+	# Optionally, only if environment variable `CARTHAGE_INTEGRATION_CLEAN_DEPENDENCIES_CACHE` is manually set:
+	[[ -n ${CARTHAGE_INTEGRATION_CLEAN_DEPENDENCIES_CACHE+x} ]] || rm -rf ~/Library/Caches/org.carthage.CarthageKit/dependencies/
+}
+
+teardown() {
+	[[ ! -d "$(project_directory)" ]] || rm -rf "$(project_directory)"
+	[[ ! -d ${extracted_directory} ]] || rm -rf ${extracted_directory}
+	cd $BATS_TEST_DIRNAME
+}
+
+carthage-and-check-project-directory() {
+	carthage $@
+	[[ -d "$(project_directory)/Carthage/Checkouts/TestFramework1/Carthage/Checkouts/TestFramework2" ]]
+}
+
+@test "with conflicting checked-in directory in «Carthage/Checkouts» of dependency, carthage bootstrap should avoid writing there" {
+	carthage-and-check-project-directory bootstrap --no-build --no-use-binaries
+}
+
+@test "with conflicting checked-in directory in «Carthage/Checkouts» of dependency, carthage «bootstrap, update, update» should avoid writing there" {
+	carthage-and-check-project-directory bootstrap --no-build --no-use-binaries
+
+	carthage-and-check-project-directory update --no-build --no-use-binaries
+
+	carthage-and-check-project-directory update --no-build --no-use-binaries
+}
+
+@test "with conflicting checked-in directory in «Carthage/Checkouts» of dependency of git-controlled project, carthage bootstrap should avoid writing there" {
+	echo 'Carthage/Build' > .gitignore
+	git init && git-commit 'Initialize project.'
+
+	carthage-and-check-project-directory bootstrap --no-build --no-use-binaries
+}

--- a/Source/CarthageIntegration/checked-in-conflicting-differing-symlink.bats
+++ b/Source/CarthageIntegration/checked-in-conflicting-differing-symlink.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load "Utilities/git-commit"
+load "Utilities/TestFramework"
+
+extracted_directory="${BATS_TMPDIR}/DependencyTest"
+
+project_directory() {
+	if [[ -z ${CI+x} ]]; then
+		echo -n "${BATS_TMPDIR:?}"
+	else
+		echo -n "${HOME:?}/Library/Caches/org.carthage.CarthageIntegration"
+	fi
+
+	echo -n "/IntegrationTestProject"
+}
+
+setup() {
+	extract-test-frameworks-one-and-two
+
+	export GITCONFIG='/dev/null'
+	branch-test-frameworks-one-and-two 'checked-in-conflicting-differing-symlink'
+
+	cd ${extracted_directory}/SourceRepos/TestFramework1
+
+	mkdir -p ${PWD}/'Carthage/Checkouts'
+	ln -s 'TestFramework1.xcodeproj/project.xcworkspace/' 'Carthage/Checkouts/TestFramework2'
+	git-commit 'Add (for nonsensical reasons) conflicting symlink at «Carthage/Checkouts/TestFramework2».'
+
+	mkdir -p "$(project_directory)" && cd "$(project_directory)"
+
+	cat > Cartfile <<-EOF
+		git "file://${extracted_directory}/SourceRepos/TestFramework1" "checked-in-conflicting-differing-symlink"
+	EOF
+
+	# Optionally, only if environment variable `CARTHAGE_INTEGRATION_CLEAN_DEPENDENCIES_CACHE` is manually set:
+	[[ -n ${CARTHAGE_INTEGRATION_CLEAN_DEPENDENCIES_CACHE+x} ]] || rm -rf ~/Library/Caches/org.carthage.CarthageKit/dependencies/
+}
+
+teardown() {
+	[[ ! -d "$(project_directory)" ]] || rm -rf "$(project_directory)"
+	[[ ! -d ${extracted_directory} ]] || rm -rf ${extracted_directory}
+	cd $BATS_TEST_DIRNAME
+}
+
+check-symlink() {
+	if [[ -L "${1:?}" ]]; then
+		readlink "${1:?}"
+	else
+		echo "No symlink at path «${1:?}»."
+		return 1
+	fi
+}
+
+carthage-and-check-project-symlink() {
+	carthage $@
+	check-symlink "$(project_directory)/Carthage/Checkouts/TestFramework1/Carthage/Checkouts/TestFramework2"
+}
+
+@test "with conflicting checked-in symlink in «Carthage/Checkouts» of dependency, carthage bootstrap should avoid writing there" {
+	carthage-and-check-project-symlink bootstrap --no-build --no-use-binaries
+}
+
+@test "with conflicting checked-in symlink in «Carthage/Checkouts» of dependency, carthage «bootstrap, update, update» should avoid writing there" {
+	carthage-and-check-project-symlink bootstrap --no-build --no-use-binaries
+
+	carthage-and-check-project-symlink update --no-build --no-use-binaries
+
+	carthage-and-check-project-symlink update --no-build --no-use-binaries
+}
+
+@test "with conflicting checked-in symlink in «Carthage/Checkouts» of dependency of git-controlled project, carthage bootstrap should avoid writing there" {
+	echo 'Carthage/Build' > .gitignore
+	git init && git-commit 'Initialize project.'
+
+	carthage-and-check-project-symlink bootstrap --no-build --no-use-binaries
+}

--- a/Source/CarthageIntegration/relink-conflicting-not-checked-in-symlink.bats
+++ b/Source/CarthageIntegration/relink-conflicting-not-checked-in-symlink.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load "Utilities/git-commit"
+load "Utilities/TestFramework"
+
+extracted_directory="${BATS_TMPDIR}/DependencyTest"
+
+project_directory() {
+	if [[ -z ${CI+x} ]]; then
+		echo -n "${BATS_TMPDIR:?}"
+	else
+		echo -n "${HOME:?}/Library/Caches/org.carthage.CarthageIntegration"
+	fi
+
+	echo -n "/IntegrationTestProject"
+}
+
+setup() {
+	extract-test-frameworks-one-and-two
+
+	export GITCONFIG='/dev/null'
+	branch-test-frameworks-one-and-two 'relink-conflicting-not-checked-in-syminks'
+
+	mkdir -p "$(project_directory)" && cd "$(project_directory)"
+
+	cat > Cartfile <<-EOF
+		git "file://${extracted_directory}/SourceRepos/TestFramework1" "relink-conflicting-not-checked-in-syminks"
+	EOF
+
+	# Optionally, only if environment variable `CARTHAGE_INTEGRATION_CLEAN_DEPENDENCIES_CACHE` is manually set:
+	[[ -n ${CARTHAGE_INTEGRATION_CLEAN_DEPENDENCIES_CACHE+x} ]] || rm -rf ~/Library/Caches/org.carthage.CarthageKit/dependencies/
+}
+
+teardown() {
+	[[ ! -d "$(project_directory)" ]] || rm -rf "$(project_directory)"
+	[[ ! -d ${extracted_directory} ]] || rm -rf ${extracted_directory}
+	cd $BATS_TEST_DIRNAME
+}
+
+check-symlink() {
+	if [[ -L "${1:?}" ]]; then
+		readlink "${1:?}"
+	else
+		echo "No symlink at path «${1:?}»."
+		return 1
+	fi
+}
+
+carthage-and-check-project-symlink() {
+	carthage $@
+	check-symlink "$(project_directory)/Carthage/Checkouts/TestFramework1/Carthage/Checkouts/TestFramework2"
+}
+
+@test "with conflicting not-checked-in symlink in «Carthage/Checkouts» of dependency, carthage «bootstrap, update, update» should unlink, then write symlink there" {
+	carthage-and-check-project-symlink bootstrap --no-build --no-use-binaries
+	# carthage has now created a symlink at $(project_directory)/Carthage/Checkouts/TestFramework1/Carthage/Checkouts/TestFramework2
+
+	carthage-and-check-project-symlink update --no-build --no-use-binaries
+
+	carthage-and-check-project-symlink update --no-build --no-use-binaries
+}
+
+@test "with conflicting not-checked-in symlink in «Carthage/Checkouts» of dependency of git-controlled project, carthage «bootstrap, update, update» should unlink, then write symlink there" {
+	echo 'Carthage/Build' > .gitignore
+	git init && git-commit 'Initialize project.'
+
+	carthage-and-check-project-symlink bootstrap --no-build --no-use-binaries
+	# carthage has now created an unstaged symlink at $(project_directory)/Carthage/Checkouts/TestFramework1/Carthage/Checkouts/TestFramework2
+
+	carthage-and-check-project-symlink update --no-build --no-use-binaries
+
+	carthage-and-check-project-symlink update --no-build --no-use-binaries
+
+}

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -380,11 +380,15 @@ private func parseConfigEntries(_ contents: String, keyPrefix: String = "", keyS
 }
 
 /// Git’s representation of file system objects at a path relative to the repository root.
+///
+/// - parameter path: Path separators at the end of `path` have significance of outputting directory contents.
+///                   Thankfully, multiple contiguous path separators seem to have no adverse effects.
+/// - note: Previously, `path` was recursed through — now, just iterated.
 internal func list(treeish: String, atPath path: String, inRepository repositoryURL: URL) -> SignalProducer<String, CarthageError> {
 	return launchGitTask(
 		// `ls-tree`, because `ls-files` returns no output (for all instances I’ve seen) on bare repos.
 		// flag “-z” enables output separated by the nul character (`\0`).
-		[ "ls-tree", "-z", "-r", "--full-name", "--name-only", treeish, path ],
+		[ "ls-tree", "-z", "--full-name", "--name-only", treeish, path ],
 		repositoryFileURL: repositoryURL
 	)
 		.flatMap(.merge) { (output: String) -> SignalProducer<String, CarthageError> in

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -918,9 +918,9 @@ public final class Project {
 						.isDirectoryKey
 					])
 
-					if dependencyCheckoutURLResource?.isSymbolicLink == .some(true) {
+					if dependencyCheckoutURLResource?.isSymbolicLink == true {
 						_ = dependencyCheckoutURL.carthage_path.withCString(Darwin.unlink)
-					} else if dependencyCheckoutURLResource?.isDirectory == .some(true) {
+					} else if dependencyCheckoutURLResource?.isDirectory == true {
 						// older version of carthage wrote this directory?
 						// user wrote this directory, unaware of the precedent not to circumvent carthage’s management?
 						// directory exists as the result of rogue process or gamma ray?

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -879,20 +879,7 @@ public final class Project {
 		return self.dependencyProjects(for: dependency)
 			.zip(with: // file system objects which might conflict with symlinks
 				list(treeish: dependency.version.commitish, atPath: CarthageProjectCheckoutsPath, inRepository: repositoryURL)
-					.flatMap(.merge) { (path: String) -> SignalProducer<String, CarthageError> in
-						let componentsRelativeToDirectoryURL = {
-							return URL(string: $0, relativeTo: self.directoryURL)?.standardizedFileURL.pathComponents
-						}
-						if
-							let components = componentsRelativeToDirectoryURL(path),
-							let comparator = componentsRelativeToDirectoryURL(CarthageProjectCheckoutsPath),
-							Array(components.dropLast(1)) == comparator // file system object is contained (shallowly) by `CarthageProjectCheckoutsPath`
-						{
-							return .init(value: components.last!)
-						} else {
-							return .empty
-						}
-					}
+					.map { (path: String) in (path as NSString).lastPathComponent }
 					.collect()
 			)
 			.attemptMap { (dependencies: Set<ProjectIdentifier>, components: [String]) -> Result<(), CarthageError> in


### PR DESCRIPTION
*Hopefully, addresses most of #1794*

`git ls-tree -r` would list checked-in submodules, symlinks, the files inside recursed-through directories, but (problematically) not the directories themselves.

Instead, without recursion and with a trailing path separator, `ls-tree` lists just the directory contents, which is what should have been implemented to begin with.

Remove now unnecessary path shallowness check as the task now outputs only the desired depth.

Major apologies for introducing these errors in #1715.

### ~~TODO~~

- More Integration tests
  - [x] [Test in `/private` sub-directories](https://github.com/jdhealy/Carthage/commit/dcfd2444176dd42da3f4877faf95f28e8488d268#diff-45b1265a2399de422a4be9bc0dbcd748R6)
  - [x] [Test with conflicting `Carthage/Checkouts`-house directories, directories checked-in to `git`](https://github.com/jdhealy/Carthage/blob/dcfd2444176dd42da3f4877faf95f28e8488d268/Source/CarthageIntegration/checked-in-conflicting-differing-directory.bats)
  - [x] Test with conflicting `Carthage/Checkouts`-housed symlinks
   - conflicting in both the cases where 
      - [the symlink points to the same directory our symlink would](https://github.com/jdhealy/Carthage/commit/dcfd2444176dd42da3f4877faf95f28e8488d268#diff-469c149f42a15fb39e27c78049674004R68)
        - [x] Determine whether this errors or not
          - *It does, same write error.*
      - [the symlink points somewhere else entirely](https://github.com/jdhealy/Carthage/blob/dcfd2444176dd42da3f4877faf95f28e8488d268/Source/CarthageIntegration/checked-in-conflicting-differing-symlink.bats#L26-L28)
   - with these symlinks both coming from 
      - [a git repository checkout](https://github.com/jdhealy/Carthage/blob/dcfd2444176dd42da3f4877faf95f28e8488d268/Source/CarthageIntegration/checked-in-conflicting-differing-symlink.bats)
      - alternatively, from a post-`bootstrap` file-system write