### PR TITLE
Fix crashing URL unwrapping received from git top level

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -447,8 +447,14 @@ public func gitRootDirectoryForRepository(_ repositoryFileURL: URL) -> SignalPro
 				return SignalProducer(value: repositoryFileURL)
 			} else {
 				return launchGitTask([ "rev-parse", "--show-toplevel" ], repositoryFileURL: repositoryFileURL)
-					.map { $0.trimmingCharacters(in: .newlines) }
-					.map { URL(string: $0)! }
+					.attemptMap { output in
+						let trimmedPath = output.trimmingCharacters(in: .newlines)
+						guard FileManager.default.isReadableFile(atPath: trimmedPath) else {
+							// can’t return `.readFailed` because we might crash when initializing the URL to give it.
+							return .failure(.internalError(description: "Unreadable file path output from git: " + output.debugDescription))
+						}
+						return .success(URL(fileURLWithPath: trimmedPath))
+					}
 			}
 		}
 }


### PR DESCRIPTION
*Potentially, fixes #1787 — I was seeing very similar crash reports…*

Use `URL(fileURLWithPath:)` for top level output from git.

`URL(string:)` can sometimes return nil in cases where `URL(fileURLWithPath:)` and `FileManager.isReadableFile(atPath:)` both validate the path.

- - -

```swift
Welcome to Apple Swift version 3.0.2 (swiftlang-800.0.63 clang-800.0.42.1). Type :help for assistance.
  1> import Foundation
  2>
  3> let url = "/Users/jdhealy/Code/Scratch/Result·Illegal·Hardware·Instruction\n"
url: String = "/Users/jdhealy/Code/Scratch/Result·Illegal·Hardware·Instruction\n"
  4>
  5> URL(string: url.trimmingCharacters(in: .newlines))
$R0: URL? = nil
  6>
  7> url.trimmingCharacters(in: .newlines)
$R1: String = "/Users/jdhealy/Code/Scratch/Result·Illegal·Hardware·Instruction"
  8>
  9> FileManager.default.isReadableFile(atPath: )
$R2: (String) -> Bool = 0x00000001005ebd20 $__lldb_expr10`_TPA__TTOFCSo11FileManager14isReadableFilefT6atPathSS_Sb at repl9.swift
 10> FileManager.default.isReadableFile(atPath: $R1)
$R3: Bool = true
```

