### PR TITLE
Change md5 to sha256

### DIFF
--- a/Documentation/VersionFile.md
+++ b/Documentation/VersionFile.md
@@ -13,7 +13,7 @@ Each version file contains JSON data in a format similar to that of the version 
       "xcodeVersion" : "Xcode 8.2.1\nBuild version 8C1002",
       "Mac" : [
        {
-           "md5" : "ad4c4bfe83c546d18418825b8c481df11b3910cc",
+           "hash" : "de07bfdba346deb20705712c2ea07e7191d57f07d793c8c0698ded085bdb5cce",
            "name" : "Prelude"
        }
       ]
@@ -21,8 +21,8 @@ Each version file contains JSON data in a format similar to that of the version 
 
 #### Caching builds with version files
 
-When a project is built, a version file is created with the dependency's commitish and the current Xcode version. An entry is added in the version file for each platform that was built, even if no frameworks are produced (in which case the given platform key is associated with an empty array).  For each platform, the name and MD5 for each produced framework are recorded.
+When a project is built, a version file is created with the dependency's commitish and the current Xcode version. An entry is added in the version file for each platform that was built, even if no frameworks are produced (in which case the given platform key is associated with an empty array).  For each platform, the name and hash (SHA256) for each produced framework are recorded.
 
-Before a project is built, if a version file already exists, it will be used to determine whether Carthage can skip building the project.  For a given platform, if the comitish matches and the recorded MD5 of each associated framework matches the MD5 of those frameworks in the Build folder, that platform is considered cached.  If no platforms are provided as build options (via `--platform`), a dependency will be considered cached if all platforms are listed in the version file and considered cached. If platforms are provided as build options, a dependency will be considered cached if the version file contains an entry for every provided platform and each of those platforms are considered cached.
+Before a project is built, if a version file already exists, it will be used to determine whether Carthage can skip building the project.  For a given platform, if the comitish matches and the recorded hash of each associated framework matches the hash of those frameworks in the Build folder, that platform is considered cached.  If no platforms are provided as build options (via `--platform`), a dependency will be considered cached if all platforms are listed in the version file and considered cached. If platforms are provided as build options, a dependency will be considered cached if the version file contains an entry for every provided platform and each of those platforms are considered cached.
 
 Version files will be ignored and all dependencies will be built unless `--cache-builds` is provided as a build option.  Version files may also be manually deleted in order to clear Carthage’s cache data.  Version files are always produced after a project has been built.

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -17,15 +17,15 @@ import XCDBLD
 
 struct CachedFramework {
 	let name: String
-	let md5: String
+	let hash: String
 	
 	static let nameKey = "name"
-	static let md5Key = "md5"
+	static let hashKey = "hash"
 	
 	func toJSONObject() -> Any {
 		return [
 			CachedFramework.nameKey: name,
-			CachedFramework.md5Key: md5
+			CachedFramework.hashKey: hash
 		]
 	}
 }
@@ -34,7 +34,7 @@ extension CachedFramework: Decodable {
 	static func decode(_ j: JSON) -> Decoded<CachedFramework> {
 		return curry(self.init)
 			<^> j <| CachedFramework.nameKey
-			<*> j <| CachedFramework.md5Key
+			<*> j <| CachedFramework.hashKey
 	}
 }
 
@@ -91,12 +91,12 @@ struct VersionFile {
 			let jsonData = try? Data(contentsOf: url),
 			let json = try? JSONSerialization.jsonObject(with: jsonData, options: .allowFragments),
 			let versionFile: VersionFile = Argo.decode(json) else {
-			return nil
+				return nil
 		}
 		self = versionFile
 	}
 	
-	func md5s(for cachedFrameworks: [CachedFramework], platform: Platform, binariesDirectoryURL: URL) -> SignalProducer<String?, CarthageError> {
+	func hashes(for cachedFrameworks: [CachedFramework], platform: Platform, binariesDirectoryURL: URL) -> SignalProducer<String?, CarthageError> {
 		return SignalProducer(cachedFrameworks)
 			.flatMap(.concat) { cachedFramework -> SignalProducer<String?, CarthageError> in
 				let frameworkName = cachedFramework.name
@@ -105,9 +105,9 @@ struct VersionFile {
 					.resolvingSymlinksInPath()
 					.appendingPathComponent("\(frameworkName).framework", isDirectory: true)
 					.appendingPathComponent("\(frameworkName)", isDirectory: false)
-				return md5ForFileAtURL(frameworkBinaryURL)
-					.map { md5 -> String? in
-						return md5
+				return hashForFileAtURL(frameworkBinaryURL)
+					.map { hash -> String? in
+						return hash
 					}
 					.flatMapError { _ in
 						return SignalProducer(value: nil)
@@ -120,24 +120,24 @@ struct VersionFile {
 			return SignalProducer(value: false)
 		}
 		
-		return self.md5s(for: cachedFrameworks, platform: platform, binariesDirectoryURL: binariesDirectoryURL)
+		return self.hashes(for: cachedFrameworks, platform: platform, binariesDirectoryURL: binariesDirectoryURL)
 			.collect()
-			.flatMap(.concat) { md5s in
-				return self.satisfies(platform: platform, commitish: commitish, xcodeVersion: xcodeVersion, md5s: md5s)
+			.flatMap(.concat) { hashes in
+				return self.satisfies(platform: platform, commitish: commitish, xcodeVersion: xcodeVersion, hashes: hashes)
 			}
 	}
 
-	func satisfies(platform: Platform, commitish: String, xcodeVersion: String, md5s: [String?]) -> SignalProducer<Bool, CarthageError> {
+	func satisfies(platform: Platform, commitish: String, xcodeVersion: String, hashes: [String?]) -> SignalProducer<Bool, CarthageError> {
 		guard let cachedFrameworks = self[platform], commitish == self.commitish, xcodeVersion == self.xcodeVersion else {
 			return SignalProducer(value: false)
 		}
 
-		return SignalProducer<(String?, CachedFramework), CarthageError>(Swift.zip(md5s, cachedFrameworks))
-			.map { (md5, cachedFramework) -> Bool in
-				guard let md5 = md5 else {
+		return SignalProducer<(String?, CachedFramework), CarthageError>(Swift.zip(hashes, cachedFrameworks))
+			.map { (hash, cachedFramework) -> Bool in
+				guard let hash = hash else {
 					return false
 				}
-				return md5 == cachedFramework.md5
+				return hash == cachedFramework.hash
 			}
 			.reduce(true) { (result, current) -> Bool in
 				return result && current
@@ -170,8 +170,8 @@ extension VersionFile: Decodable {
 
 /// Creates a version file for the current dependency in the
 /// Carthage/Build directory which associates its commitish with
-/// the MD5s of the built frameworks for each platform in order
-/// to allow those frameworks to be skipped in future builds.
+/// the hashes (e.g. SHA256) of the built frameworks for each platform
+/// in order to allow those frameworks to be skipped in future builds.
 ///
 /// Returns a signal that succeeds once the file has been created.
 public func createVersionFile(for dependency: Dependency<PinnedVersion>, platforms: Set<Platform>, buildProducts: [URL], rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
@@ -204,9 +204,9 @@ public func createVersionFile(for dependency: Dependency<PinnedVersion>, platfor
 				let platformName = url.deletingLastPathComponent().lastPathComponent
 				let frameworkName = url.deletingPathExtension().lastPathComponent
 				let frameworkURL = url.appendingPathComponent(frameworkName, isDirectory: false)
-				return md5ForFileAtURL(frameworkURL)
-					.on(value: { md5 in
-						let cachedFramework = CachedFramework(name: frameworkName, md5: md5)
+				return hashForFileAtURL(frameworkURL)
+					.on(value: { hash in
+						let cachedFramework = CachedFramework(name: frameworkName, hash: hash)
 						if var frameworks = platformCaches[platformName] {
 							frameworks.append(cachedFramework)
 							platformCaches[platformName] = frameworks
@@ -254,7 +254,7 @@ public func versionFileMatches(_ dependency: Dependency<PinnedVersion>, platform
 		}
 }
 
-private func md5ForFileAtURL(_ frameworkFileURL: URL) -> SignalProducer<String, CarthageError> {
+private func hashForFileAtURL(_ frameworkFileURL: URL) -> SignalProducer<String, CarthageError> {
 	guard FileManager.default.fileExists(atPath: frameworkFileURL.path) else {
 		return SignalProducer(error: .readFailed(frameworkFileURL, nil))
 	}

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -72,7 +72,7 @@ class ProjectSpec: QuickSpec {
 				expect(result3).to(equal(expected))
 			}
 			
-			it("should rebuild cached frameworks (and dependencies) whose md5 does not match the version file") {
+			it("should rebuild cached frameworks (and dependencies) whose hash does not match the version file") {
 				let expected: Set = ["TestFramework1_Mac", "TestFramework2_Mac", "TestFramework3_Mac"]
 				
 				let result1 = buildDependencyTest(platforms: [.macOS])

--- a/Source/CarthageKitTests/TestVersionFile
+++ b/Source/CarthageKitTests/TestVersionFile
@@ -4,17 +4,17 @@
   "iOS": [
     {
       "name": "TestFramework1",
-      "md5": "ios-framework1-md5"
+      "hash": "ios-framework1-hash"
     },
     {
       "name": "TestFramework2",
-      "md5": "ios-framework2-md5"
+      "hash": "ios-framework2-hash"
     }
   ],
   "Mac": [
     {
       "name": "TestFramework1",
-      "md5": "mac-framework1-md5"
+      "hash": "mac-framework1-hash"
     }
   ],
   "tvOS": []


### PR DESCRIPTION
This PR resolves issue #1807.

Other than previously stated [here](https://github.com/Carthage/Carthage/pull/1489#issuecomment-283006776), I used `/usr/bin/shasum -a 256` instead of `/usr/bin/openssl dgst -sha256`. It returns the hash before the path, so it is easier to parse, in case the path contains spaces.

I also renamed occurances of `md5` to `hash` (instead of `sha256`) in case the hashing function has to be replaced again some time in the future. Since this also included renaming the key in the VersionFile, I don't know if this causes trouble. @BobElDevil said in the issue above, that in case the hash doesn't match anymore, carthage will just rebuild the dependency, but what happens if the key doesn't match? I guess it will also just rebuild the dependencies, because it will fall through [this guard](https://github.com/Carthage/Carthage/blob/d21adfa7333764d257ead1513dff31aa99ac0f5c/Source/CarthageKit/VersionFile.swift#L235)