### PR TITLE
Use Dictionary instead of Dependency in cartfiles

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -18,9 +18,9 @@ public let CarthageProjectCheckoutsPath = "Carthage/Checkouts"
 /// and any other settings Carthage needs to build it.
 public struct Cartfile {
 	/// The dependencies listed in the Cartfile.
-	public var dependencies: Set<Dependency<VersionSpecifier>>
+	public var dependencies: [ProjectIdentifier: VersionSpecifier]
 
-	public init(dependencies: Set<Dependency<VersionSpecifier>> = []) {
+	public init(dependencies: [ProjectIdentifier: VersionSpecifier] = [:]) {
 		self.dependencies = dependencies
 	}
 
@@ -32,7 +32,8 @@ public struct Cartfile {
 
 	/// Attempts to parse Cartfile information from a string.
 	public static func from(string: String) -> Result<Cartfile, CarthageError> {
-		var dependencies: [Dependency<VersionSpecifier>] = []
+		var dependencies: [ProjectIdentifier: VersionSpecifier] = [:]
+		var duplicates: [ProjectIdentifier] = []
 		var result: Result<(), CarthageError> = .success(())
 
 		let commentIndicator = "#"
@@ -49,14 +50,18 @@ public struct Cartfile {
 				return
 			}
 
-			switch Dependency<VersionSpecifier>.from(scanner) {
-			case let .success(dep):
-				if case .binary = dep.project, case .gitReference = dep.version {
+			switch ProjectIdentifier.from(scanner).fanout(VersionSpecifier.from(scanner)) {
+			case let .success((dependency, version)):
+				if case .binary = dependency, case .gitReference = version {
 					result = .failure(CarthageError.parseError(description: "binary dependencies cannot have a git reference for the version specifier in line: \(scanner.currentLine)"))
 					stop = true
 					return
 				}
-				dependencies.append(dep)
+				if dependencies[dependency] == nil {
+					dependencies[dependency] = version
+				} else {
+					duplicates.append(dependency)
+				}
 
 			case let .failure(error):
 				result = .failure(CarthageError(scannableError: error))
@@ -76,15 +81,10 @@ public struct Cartfile {
 		}
 
 		return result.flatMap { _ in
-			let dupes = buildCountedSet(dependencies.map { $0.project })
-				.filter { $0.1 > 1 }
-				.map { $0.0 }
-				.map { DuplicateDependency(project: $0, locations: []) }
-			
-			if !dupes.isEmpty {
-				return .failure(.duplicateDependencies(dupes))
+			if !duplicates.isEmpty {
+				return .failure(.duplicateDependencies(duplicates.map { DuplicateDependency(project: $0, locations: []) }))
 			}
-			return .success(Cartfile(dependencies: Set(dependencies)))
+			return .success(Cartfile(dependencies: dependencies))
 		}
 	}
 
@@ -115,7 +115,9 @@ public struct Cartfile {
 
 	/// Appends the contents of another Cartfile to that of the receiver.
 	public mutating func append(_ cartfile: Cartfile) {
-		dependencies.formUnion(cartfile.dependencies)
+		for (dependency, version) in cartfile.dependencies {
+			dependencies[dependency] = version
+		}
 	}
 }
 
@@ -128,8 +130,8 @@ extension Cartfile: CustomStringConvertible {
 /// Returns an array containing projects that are listed as dependencies
 /// in both arguments.
 public func duplicateProjectsIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [ProjectIdentifier] {
-	let projects1 = cartfile1.dependencies.map { $0.project }
-	let projects2 = cartfile2.dependencies.map { $0.project }
+	let projects1 = cartfile1.dependencies.keys
+	let projects2 = cartfile2.dependencies.keys
 	return Array(Set(projects1).intersection(Set(projects2)))
 }
 
@@ -137,18 +139,9 @@ public func duplicateProjectsIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile) ->
 /// checked out for each dependency.
 public struct ResolvedCartfile {
 	/// The dependencies listed in the Cartfile.resolved.
-	public var dependencies: Set<Dependency<PinnedVersion>>
+	public var dependencies: [ProjectIdentifier: PinnedVersion]
 	
-	/// The version of each project
-	public var versions: [ProjectIdentifier: PinnedVersion] {
-		var versions: [ProjectIdentifier: PinnedVersion] = [:]
-		for dependency in dependencies {
-			versions[dependency.project] = dependency.version
-		}
-		return versions
-	}
-
-	public init(dependencies: Set<Dependency<PinnedVersion>>) {
+	public init(dependencies: [ProjectIdentifier: PinnedVersion]) {
 		self.dependencies = dependencies
 	}
 
@@ -160,14 +153,14 @@ public struct ResolvedCartfile {
 
 	/// Attempts to parse Cartfile.resolved information from a string.
 	public static func from(string: String) -> Result<ResolvedCartfile, CarthageError> {
-		var cartfile = self.init(dependencies: [])
+		var cartfile = self.init(dependencies: [:])
 		var result: Result<(), CarthageError> = .success(())
 
 		let scanner = Scanner(string: string)
 		scannerLoop: while !scanner.isAtEnd {
-			switch Dependency<PinnedVersion>.from(scanner) {
-			case let .success(dep):
-				cartfile.dependencies.insert(dep)
+			switch ProjectIdentifier.from(scanner).fanout(PinnedVersion.from(scanner)) {
+			case let .success((dep, version)):
+				cartfile.dependencies[dep] = version
 
 			case let .failure(error):
 				result = .failure(CarthageError(scannableError: error))
@@ -182,8 +175,8 @@ public struct ResolvedCartfile {
 extension ResolvedCartfile: CustomStringConvertible {
 	public var description: String {
 		return dependencies
-			.sorted { $0.project.description < $1.project.description }
-			.map { $0.description + "\n" }
+			.sorted { $0.key.description < $1.key.description }
+			.map { "\($0.key) \($0.value)\n" }
 			.joined(separator: "")
 	}
 }

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -24,50 +24,23 @@ class CartfileSpec: QuickSpec {
 
 			let cartfile = result.value!
 
-			let depReactiveCocoa = Dependency<VersionSpecifier>(
-				project: ProjectIdentifier.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")),
-				version: .atLeast(SemanticVersion(major: 2, minor: 3, patch: 1))
-			)
-
-			let depMantle = Dependency<VersionSpecifier>(
-				project: .gitHub(Repository(owner: "Mantle", name: "Mantle")),
-				version: .compatibleWith(SemanticVersion(major: 1, minor: 0, patch: 0))
-			)
-
-			let depLibextobjc = Dependency<VersionSpecifier>(
-				project: .gitHub(Repository(owner: "jspahrsummers", name: "libextobjc")),
-				version: .exactly(SemanticVersion(major: 0, minor: 4, patch: 1))
-			)
-
-			let depConfigs = Dependency<VersionSpecifier>(
-				project: .gitHub(Repository(owner: "jspahrsummers", name: "xcconfigs")),
-				version: .any
-			)
-
-			let depCharts = Dependency<VersionSpecifier>(
-				project: .gitHub(Repository(owner: "danielgindi", name: "ios-charts")),
-				version: .any
-			)
-
-			let depErrorTranslations = Dependency<VersionSpecifier>(
-				project: .gitHub(Repository(server: .enterprise(url: URL(string: "https://enterprise.local/ghe")!), owner: "desktop", name: "git-error-translations")),
-				version: .any
-			)
-
-			let depErrorTranslations2 = Dependency<VersionSpecifier>(
-				project: .git(GitURL("https://enterprise.local/desktop/git-error-translations2.git")),
-				version: .gitReference("development")
-			)
+			let reactiveCocoa = ProjectIdentifier.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa"))
+			let mantle = ProjectIdentifier.gitHub(Repository(owner: "Mantle", name: "Mantle"))
+			let libextobjc = ProjectIdentifier.gitHub(Repository(owner: "jspahrsummers", name: "libextobjc"))
+			let xcconfigs = ProjectIdentifier.gitHub(Repository(owner: "jspahrsummers", name: "xcconfigs"))
+			let iosCharts = ProjectIdentifier.gitHub(Repository(owner: "danielgindi", name: "ios-charts"))
+			let errorTranslations = ProjectIdentifier.gitHub(Repository(server: .enterprise(url: URL(string: "https://enterprise.local/ghe")!), owner: "desktop", name: "git-error-translations"))
+			let errorTranslations2 = ProjectIdentifier.git(GitURL("https://enterprise.local/desktop/git-error-translations2.git"))
 			
-			expect(cartfile.dependencies) == Set([
-				depReactiveCocoa,
-				depMantle,
-				depLibextobjc,
-				depConfigs,
-				depCharts,
-				depErrorTranslations,
-				depErrorTranslations2,
-			])
+			expect(cartfile.dependencies) == [
+				reactiveCocoa: .atLeast(SemanticVersion(major: 2, minor: 3, patch: 1)),
+				mantle: .compatibleWith(SemanticVersion(major: 1, minor: 0, patch: 0)),
+				libextobjc: .exactly(SemanticVersion(major: 0, minor: 4, patch: 1)),
+				xcconfigs: .any,
+				iosCharts: .any,
+				errorTranslations: .any,
+				errorTranslations2: .gitReference("development"),
+			]
 		}
 
 		it("should parse a Cartfile.resolved") {
@@ -79,14 +52,8 @@ class CartfileSpec: QuickSpec {
 
 			let resolvedCartfile = result.value!
 			expect(resolvedCartfile.dependencies) == [
-				Dependency(
-					project: .gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")),
-					version: PinnedVersion("v2.3.1")
-				),
-				Dependency(
-					project: .git(GitURL("https://github.com/Mantle/Mantle.git")),
-					version: PinnedVersion("40abed6e58b4864afac235c3bb2552e23bc9da47")
-				),
+				.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")): PinnedVersion("v2.3.1"),
+				.git(GitURL("https://github.com/Mantle/Mantle.git")): PinnedVersion("40abed6e58b4864afac235c3bb2552e23bc9da47"),
 			]
 		}
 
@@ -105,7 +72,7 @@ class CartfileSpec: QuickSpec {
 			let projects = dupes
 				.map { $0.project }
 				.sorted { $0.description < $1.description }
-			expect(dupes.count) == 2
+			expect(dupes.count) == 3
 			
 			let self2Dupe = projects[0]
 			expect(self2Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self2", name: "self2"))
@@ -160,19 +127,11 @@ class ResolvedCartfileSpec: QuickSpec {
 	override func spec() {
 		describe("description") {
 			it("should output dependencies alphabetically") {
-				let result = Dependency(
-					project: .gitHub(Repository(owner: "antitypical", name: "Result")),
-					version: PinnedVersion("3.0.0")
-				)
-				let reactiveCocoa = Dependency(
-					project: .gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")),
-					version: PinnedVersion("v2.3.1")
-				)
-				let reactiveSwift = Dependency(
-					project: .gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveSwift")),
-					version: PinnedVersion("v1.0.0")
-				)
-				let resolvedCartfile = ResolvedCartfile(dependencies: [ result, reactiveSwift, reactiveCocoa ])
+				let resolvedCartfile = ResolvedCartfile(dependencies: [
+					.gitHub(Repository(owner: "antitypical", name: "Result")): PinnedVersion("3.0.0"),
+					.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveSwift")): PinnedVersion("v1.0.0"),
+					.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")): PinnedVersion("v2.3.1"),
+				])
 				
 				expect(resolvedCartfile.description) == "github \"ReactiveCocoa/ReactiveCocoa\" \"v2.3.1\"\ngithub \"ReactiveCocoa/ReactiveSwift\" \"v1.0.0\"\ngithub \"antitypical/Result\" \"3.0.0\"\n"
 			}

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -135,7 +135,7 @@ class ProjectSpec: QuickSpec {
 				
 				let dependencies = result?.value?.dependencies
 				expect(dependencies?.count) == 1
-				expect(dependencies?.first?.project.name) == "Carthage"
+				expect(dependencies?.keys.first?.name) == "Carthage"
 			}
 
 			it("should load a combined Cartfile when only a Cartfile.private is present") {
@@ -146,7 +146,7 @@ class ProjectSpec: QuickSpec {
 
 				let dependencies = result?.value?.dependencies
 				expect(dependencies?.count) == 1
-				expect(dependencies?.first?.project.name) == "Carthage"
+				expect(dependencies?.keys.first?.name) == "Carthage"
 			}
 
 			it("should detect duplicate dependencies across Cartfile and Cartfile.private") {

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -32,7 +32,7 @@ public struct BootstrapCommand: CommandProtocol {
 					checkDependencies = project
 						.loadResolvedCartfile()
 						.flatMap(.concat) { resolvedCartfile -> SignalProducer<(), CarthageError> in
-							let resolvedDependencyNames = resolvedCartfile.dependencies.map { $0.project.name.lowercased() }
+							let resolvedDependencyNames = resolvedCartfile.dependencies.keys.map { $0.name.lowercased() }
 							let unresolvedDependencyNames = Set(depsToUpdate.map { $0.lowercased() }).subtracting(resolvedDependencyNames)
 							
 							if !unresolvedDependencyNames.isEmpty {

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -58,8 +58,8 @@ public struct OutdatedCommand: CommandProtocol {
 
 				if !outdatedDependencies.isEmpty {
 					carthage.println(formatting.path("The following dependencies are outdated:"))
-					for (currentDependency, updatedDependency) in outdatedDependencies {
-						carthage.println(formatting.projectName(currentDependency.project.name) + " \(currentDependency.version) -> \(updatedDependency.version)")
+					for (project, current, updated) in outdatedDependencies {
+						carthage.println(formatting.projectName(project.name) + " \(current) -> \(updated)")
 					}
 				} else {
 					carthage.println("All dependencies are up to date.")

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -81,7 +81,7 @@ public struct UpdateCommand: CommandProtocol {
 					checkDependencies = project
 						.loadCombinedCartfile()
 						.flatMap(.concat) { cartfile -> SignalProducer<(), CarthageError> in
-							let dependencyNames = cartfile.dependencies.map { $0.project.name.lowercased() }
+							let dependencyNames = cartfile.dependencies.keys.map { $0.name.lowercased() }
 							let unknownDependencyNames = Set(depsToUpdate.map { $0.lowercased() }).subtracting(dependencyNames)
 							
 							if !unknownDependencyNames.isEmpty {


### PR DESCRIPTION
I’m on a quest to remove `Dependency`. I think it provides little value and takes up a valuable name.

This is the first step: changing the Cartfiles to use `[ProjectIdentifier: <Version>]` instead of `Set<Dependency<Version>>`.

I will follow this up with more PRs to remove `Dependency`. Then I plan to rename `ProjectIdentifier` to `Dependency` to better explain its role (in contrast to `Project` and `ProjectLocator`).