### PR TITLE
Copy frameworks concurrently (~4x speedup)

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -41,7 +41,7 @@ public struct CopyFrameworksCommand: CommandProtocol {
 						}
 					}
 					// Copy as many frameworks as possible in parallel.
-					.observe(on: QueueScheduler(name: "org.carthage.CarthageKit.CopyFrameworks.copy"))
+					.start(on: QueueScheduler(name: "org.carthage.CarthageKit.CopyFrameworks.copy"))
 			}
 			.waitOnCommand()
 	}

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -19,7 +19,7 @@ public struct CopyFrameworksCommand: CommandProtocol {
 
 	public func run(_ options: NoOptions<CarthageError>) -> Result<(), CarthageError> {
 		return inputFiles()
-			.flatMap(.concat) { frameworkPath -> SignalProducer<(), CarthageError> in
+			.flatMap(.merge) { frameworkPath -> SignalProducer<(), CarthageError> in
 				let frameworkName = (frameworkPath as NSString).lastPathComponent
 
 				let source = Result(URL(fileURLWithPath: frameworkPath, isDirectory: true), failWith: CarthageError.invalidArgument(description: "Could not find framework \"\(frameworkName)\" at path \(frameworkPath). Ensure that the given path is appropriately entered and that your \"Input Files\" have been entered correctly."))
@@ -39,7 +39,9 @@ public struct CopyFrameworksCommand: CommandProtocol {
 										.then(SignalProducer<(), CarthageError>.empty)
 								}
 						}
-				}
+					}
+					// Copy as many frameworks as possible in parallel.
+					.observe(on: QueueScheduler(name: "org.carthage.CarthageKit.CopyFrameworks.copy"))
 			}
 			.waitOnCommand()
 	}


### PR DESCRIPTION
From a quick test on a project with 30 frameworks, this speeds up the copy frameworks step for the device target in our application by nearly 4x on a quad-core machine. Before this change, the copy frameworks step takes ~40s, and after this change it takes ~10s.