### PR TITLE
Extract temporary directory creation into reactive FileManager extension

### DIFF
--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -58,10 +58,12 @@ private func untargz(archive fileURL: URL, to destinationDirectoryURL: URL) -> S
 		.then(SignalProducer<(), CarthageError>.empty)
 }
 
+private let ArchiveTemplate = "carthage-archive.XXXXXX"
+
 /// Unzips the archive at the given file URL into a temporary directory, then
 /// sends the file URL to that directory.
 private func unzip(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
-	return createTemporaryDirectory()
+	return FileManager.default.reactive.createTemporaryDirectoryWithTemplate(ArchiveTemplate)
 		.flatMap(.merge) { directoryURL in
 			return unzip(archive: fileURL, to: directoryURL)
 				.then(SignalProducer<URL, CarthageError>(value: directoryURL))
@@ -71,29 +73,9 @@ private func unzip(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
 /// Untars the gzipped archive at the given file URL into a temporary directory, 
 /// then sends the file URL to that directory.
 private func untargz(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
-	return createTemporaryDirectory()
+	return FileManager.default.reactive.createTemporaryDirectoryWithTemplate(ArchiveTemplate)
 		.flatMap(.merge) { directoryURL in
 			return untargz(archive: fileURL, to: directoryURL)
 				.then(SignalProducer<URL, CarthageError>(value: directoryURL))
 		}
-}
-
-private func createTemporaryDirectory() -> SignalProducer<URL, CarthageError> {
-	return SignalProducer.attempt { () -> Result<String, CarthageError> in
-			var temporaryDirectoryTemplate: ContiguousArray<CChar> = (NSTemporaryDirectory() as NSString).appendingPathComponent("carthage-archive.XXXXXX").utf8CString
-			let result: UnsafeMutablePointer<Int8>? = temporaryDirectoryTemplate.withUnsafeMutableBufferPointer { (template: inout UnsafeMutableBufferPointer<CChar>) -> UnsafeMutablePointer<CChar> in
-				return mkdtemp(template.baseAddress)
-			}
-
-			if result == nil {
-				return .failure(.taskError(.posixError(errno)))
-			}
-
-			let temporaryPath = temporaryDirectoryTemplate.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<CChar>) -> String in
-				return String(validatingUTF8: ptr.baseAddress!)!
-			}
-
-			return .success(temporaryPath)
-			}
-			.map { URL(fileURLWithPath: $0, isDirectory: true) }
 }

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -313,6 +313,39 @@ extension Reactive where Base: FileManager {
 			observer.sendCompleted()
 		}
 	}
+
+	/// Creates a temporary directory with the given template name. Sends the
+	/// URL of the temporary directory and completes if successful, else errors.
+	///
+	/// The template name should adhere to the format required by the mkdtemp()
+	/// function.
+	public func createTemporaryDirectoryWithTemplate(_ template: String) -> SignalProducer<URL, CarthageError> {
+		return SignalProducer.attempt { [base = self.base] () -> Result<String, CarthageError> in
+			let temporaryDirectory: NSString
+			if #available(OSXApplicationExtension 10.12, *) {
+				temporaryDirectory = base.temporaryDirectory.path as NSString
+			} else {
+				temporaryDirectory = NSTemporaryDirectory() as NSString
+			}
+
+			var temporaryDirectoryTemplate: ContiguousArray<CChar> = temporaryDirectory.appendingPathComponent(template).utf8CString
+
+			let result: UnsafeMutablePointer<Int8>? = temporaryDirectoryTemplate.withUnsafeMutableBufferPointer { (template: inout UnsafeMutableBufferPointer<CChar>) -> UnsafeMutablePointer<CChar> in
+				return mkdtemp(template.baseAddress)
+			}
+
+			if result == nil {
+				return .failure(.taskError(.posixError(errno)))
+			}
+
+			let temporaryPath = temporaryDirectoryTemplate.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<CChar>) -> String in
+				return String(validatingUTF8: ptr.baseAddress!)!
+			}
+
+			return .success(temporaryPath)
+			}
+			.map { URL(fileURLWithPath: $0, isDirectory: true) }
+	}
 }
 
 private let defaultSessionError = NSError(domain: CarthageKitBundleIdentifier,


### PR DESCRIPTION
Now that `FileManager` has a `temporaryDirectory` property as of macOS 10.12, it makes sense to couple temporary directory creation logic to it.