### PR TITLE
[Minor Bugfix] Unwrap  currentLine  in ScannableError's description method

### DIFF
--- a/Source/CarthageKit/ScannableError.swift
+++ b/Source/CarthageKit/ScannableError.swift
@@ -12,7 +12,7 @@ public struct ScannableError: Error {
 
 extension ScannableError: CustomStringConvertible {
 	public var description: String {
-		return "\(message) in line: \(currentLine)"
+		return currentLine.flatMap { "\(message) in line: \($0)" } ?? message
 	}
 }
 


### PR DESCRIPTION
`currentLine` is being printed as an optional as is, so when this description function is called 
the contents of `currentLine` are being printed as `Optional("Nirma/Attributed")` instead of just `"Nirma/Attributed"`.

<img width="804" alt="2017-04-14 19 46 46" src="https://cloud.githubusercontent.com/assets/882822/25041474/33be575c-214b-11e7-9ed7-a7c77fdfe15b.png">

I discovered this while making a mistake myself after editing my `Cartfile` so I don't think users see it often but it bugged (knee slap) me enough to send over a PR.

How does it look?

Thanks!