### PR TITLE
Ensure input files to copy-frameworks are unique

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -165,7 +165,8 @@ private func inputFiles() -> SignalProducer<String, CarthageError> {
 				return SignalProducer(result: getEnvironmentVariable("SCRIPT_INPUT_FILE_\(index)"))
 			}
 
-			return SignalProducer<SignalProducer<String, CarthageError>, CarthageError>(variables)
-				.flatten(.concat)
+			return SignalProducer.zip(variables)
+				.map { Set($0) }
+				.flatMap(.concat) { SignalProducer<String, CarthageError>($0) }
 		}
 }

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -159,14 +159,8 @@ private func inputFiles() -> SignalProducer<String, CarthageError> {
 		}
 	}
 
-	return SignalProducer(result: count)
-		.flatMap(.merge) { count -> SignalProducer<String, CarthageError> in
-			let variables = (0..<count).map { index -> SignalProducer<String, CarthageError> in
-				return SignalProducer(result: getEnvironmentVariable("SCRIPT_INPUT_FILE_\(index)"))
-			}
-
-			return SignalProducer.zip(variables)
-				.map { Set($0) }
-				.flatMap(.concat) { SignalProducer<String, CarthageError>($0) }
-		}
+	return SignalProducer<Int, CarthageError>(result: count)
+		.flatMap(.merge) { SignalProducer<Int, CarthageError>(0..<$0) }
+		.attemptMap { getEnvironmentVariable("SCRIPT_INPUT_FILE_\($0)") }
+		.uniqueValues()
 }

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -159,7 +159,7 @@ private func inputFiles() -> SignalProducer<String, CarthageError> {
 		}
 	}
 
-	return SignalProducer<Int, CarthageError>(result: count)
+	return SignalProducer(result: count)
 		.flatMap(.merge) { SignalProducer<Int, CarthageError>(0..<$0) }
 		.attemptMap { getEnvironmentVariable("SCRIPT_INPUT_FILE_\($0)") }
 		.uniqueValues()


### PR DESCRIPTION
Duplicated input files can cause failures. Fixes #1901.