### PR TITLE
Implemented toolchain-aware swift version check

### DIFF
--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -280,7 +280,7 @@ public func createVersionFileForCommitish(_ commitish: String, dependencyName: S
 /// Returns an optional bool which is nil if no version file exists,
 /// otherwise true if the version file matches and the build can be
 /// skipped or false if there is a mismatch of some kind.
-public func versionFileMatches(_ dependency: Dependency<PinnedVersion>, platforms: Set<Platform>, rootDirectoryURL: URL) -> SignalProducer<Bool?, CarthageError> {
+public func versionFileMatches(_ dependency: Dependency<PinnedVersion>, platforms: Set<Platform>, rootDirectoryURL: URL, toolchain: String?) -> SignalProducer<Bool?, CarthageError> {
 	let rootBinariesURL = rootDirectoryURL.appendingPathComponent(CarthageBinariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
 	let versionFileURL = rootBinariesURL.appendingPathComponent(".\(dependency.project.name).\(VersionFile.pathExtension)")
 	guard let versionFile = VersionFile(url: versionFileURL) else {
@@ -290,7 +290,7 @@ public func versionFileMatches(_ dependency: Dependency<PinnedVersion>, platform
 
 	let platformsToCheck = platforms.isEmpty ? Set<Platform>(Platform.supportedPlatforms) : platforms
 
-	return swiftVersion
+	return swiftVersion(usingToolchain: toolchain)
 		.mapError { error in CarthageError.internalError(description: error.description) }
 		.flatMap(.concat) { localSwiftVersion in
 			return SignalProducer<Platform, CarthageError>(platformsToCheck)

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -53,7 +53,7 @@ class ProjectSpec: QuickSpec {
 				let frameworkURL = platformURL.appendingPathComponent("\(frameworkName)_\(platformName).framework", isDirectory: false)
 				let swiftHeaderURL = frameworkURL.swiftHeaderURL()!
 
-				let swiftVersionResult = swiftVersion.first()!
+				let swiftVersionResult = swiftVersion().first()!
 				expect(swiftVersionResult.error).to(beNil())
 
 				var header = try! String(contentsOf: swiftHeaderURL)

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -34,7 +34,7 @@ class XcodeSpec: QuickSpec {
 		}
 
 		describe("determineSwiftInformation:") {
-			let currentSwiftVersion = swiftVersion.single()?.value
+			let currentSwiftVersion = swiftVersion().single()?.value
 			let testSwiftFramework = "Quick.framework"
 			let currentDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
 			let testSwiftFrameworkURL = currentDirectory.appendingPathComponent(testSwiftFramework)
@@ -64,14 +64,14 @@ class XcodeSpec: QuickSpec {
 			}
 
 			it("should determine when a Swift framework is compatible") {
-				let result = checkSwiftFrameworkCompatibility(testSwiftFrameworkURL).single()
+				let result = checkSwiftFrameworkCompatibility(testSwiftFrameworkURL, usingToolchain: nil).single()
 
 				expect(result?.value) == testSwiftFrameworkURL
 			}
 
 			it("should determine when a Swift framework is incompatible") {
 				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "FakeOldSwift.framework", withExtension: nil)!
-				let result = checkSwiftFrameworkCompatibility(frameworkURL).single()
+				let result = checkSwiftFrameworkCompatibility(frameworkURL, usingToolchain: nil).single()
 
 				expect(result?.value).to(beNil())
 				expect(result?.error) == .incompatibleFrameworkSwiftVersions(local: currentSwiftVersion ?? "", framework: "0.0.0")

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -24,7 +24,7 @@ public struct BootstrapCommand: CommandProtocol {
 				if !FileManager.default.fileExists(atPath: project.resolvedCartfileURL.path) {
 					let formatting = options.checkoutOptions.colorOptions.formatting
 					carthage.println(formatting.bullets + "No Cartfile.resolved found, updating dependencies")
-					return project.updateDependencies(shouldCheckout: options.checkoutAfterUpdate)
+					return project.updateDependencies(shouldCheckout: options.checkoutAfterUpdate, buildOptions: options.buildOptions)
 				}
 				
 				let checkDependencies: SignalProducer<(), CarthageError>
@@ -46,7 +46,7 @@ public struct BootstrapCommand: CommandProtocol {
 				
 				let checkoutDependencies: SignalProducer<(), CarthageError>
 				if options.checkoutAfterUpdate {
-					checkoutDependencies = project.checkoutResolvedDependencies(options.dependenciesToUpdate)
+					checkoutDependencies = project.checkoutResolvedDependencies(options.dependenciesToUpdate, buildOptions: options.buildOptions)
 				} else {
 					checkoutDependencies = .empty
 				}

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -74,6 +74,6 @@ public struct CheckoutCommand: CommandProtocol {
 	/// Checks out dependencies with the given options.
 	public func checkoutWithOptions(_ options: Options) -> SignalProducer<(), CarthageError> {
 		return options.loadProject()
-			.flatMap(.merge) { $0.checkoutResolvedDependencies(options.dependenciesToCheckout) }
+			.flatMap(.merge) { $0.checkoutResolvedDependencies(options.dependenciesToCheckout, buildOptions: nil) }
 	}
 }

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -96,7 +96,7 @@ public struct UpdateCommand: CommandProtocol {
 				}
 				
 				let updateDependencies = project.updateDependencies(
-					shouldCheckout: options.checkoutAfterUpdate,
+					shouldCheckout: options.checkoutAfterUpdate, buildOptions: options.buildOptions,
 					dependenciesToUpdate: options.dependenciesToUpdate
 				)
 				


### PR DESCRIPTION
Potential fix for #1905.

I was able to manually test and verify that the cache was respected for non-default toolchains by using this cartfile:

```
github "Quick/Quick" == 0.9.1
```

and this command with Xcode 8.2.1 selected (using my locally built carthage with the implemented fix):

```
.../carthage update --toolchain com.apple.dt.toolchain.Swift_2_3 --platform osx --cache-builds
```

where the stock 0.21 version of carthage did not respect the cache.

I'm not 100% certain how this can be unit tested, though. This requires either the unit tests to be run on a machine that has Xcode 8-8.2.1, or perhaps that the machine in question has a custom toolchain installed from swift.org that can be used. Is there a reasonable way to unit test this I'm not thinking of?