### PR TITLE
Rename ProjectIdentifier to Dependency

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 		BEA86FA01C9F91500049360B /* Tentacle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = BEB076651C8A1FD800ABD373 /* Tentacle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BEB076661C8A1FD800ABD373 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB076641C8A1FD800ABD373 /* Curry.framework */; };
 		BEB076671C8A1FD800ABD373 /* Tentacle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEB076651C8A1FD800ABD373 /* Tentacle.framework */; };
-		BF3199C01E32E078007DC0D1 /* ProjectIdentifierSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3199BF1E32E078007DC0D1 /* ProjectIdentifierSpec.swift */; };
+		BF3199C01E32E078007DC0D1 /* DependencySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3199BF1E32E078007DC0D1 /* DependencySpec.swift */; };
 		BF6E5DA91E41860700C63D39 /* successful.json in Resources */ = {isa = PBXBuildFile; fileRef = BF6E5DA81E41860700C63D39 /* successful.json */; };
 		BF6E5DAB1E41863500C63D39 /* invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = BF6E5DAA1E41863500C63D39 /* invalid.json */; };
 		BF7A1A0B1E3A7AE9008CBCC5 /* BinaryProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7A1A091E3A7188008CBCC5 /* BinaryProject.swift */; };
@@ -206,7 +206,7 @@
 		BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DuplicateDependenciesCartfile; sourceTree = "<group>"; };
 		BEB076641C8A1FD800ABD373 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Curry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEB076651C8A1FD800ABD373 /* Tentacle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Tentacle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BF3199BF1E32E078007DC0D1 /* ProjectIdentifierSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectIdentifierSpec.swift; sourceTree = "<group>"; };
+		BF3199BF1E32E078007DC0D1 /* DependencySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencySpec.swift; sourceTree = "<group>"; };
 		BF6E5DA81E41860700C63D39 /* successful.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = successful.json; sourceTree = "<group>"; };
 		BF6E5DAA1E41863500C63D39 /* invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = invalid.json; sourceTree = "<group>"; };
 		BF7A1A091E3A7188008CBCC5 /* BinaryProject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryProject.swift; sourceTree = "<group>"; };
@@ -544,9 +544,9 @@
 				D0C6E5731A57040B00A5E3E7 /* ArchiveSpec.swift */,
 				BFFA7A621E3AAFD200CB95A7 /* BinaryProjectSpec.swift */,
 				D0D121DF19E8999E005E4BAA /* CartfileSpec.swift */,
+				BF3199BF1E32E078007DC0D1 /* DependencySpec.swift */,
 				89A8F1771C24AB3C00C0E75A /* FrameworkExtensionsSpec.swift */,
 				CDA0B6C91C468E67006C499C /* GitSpec.swift */,
-				BF3199BF1E32E078007DC0D1 /* ProjectIdentifierSpec.swift */,
 				549B47AF1A4F17FF002498C7 /* ProjectSpec.swift */,
 				D01D82DC1A10B01D00F0DD94 /* ResolverSpec.swift */,
 				D0DE89411A0F2D450030A3EC /* VersionSpec.swift */,
@@ -842,7 +842,7 @@
 				D0C6E5741A57040B00A5E3E7 /* ArchiveSpec.swift in Sources */,
 				549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */,
 				D01D82DD1A10B01D00F0DD94 /* ResolverSpec.swift in Sources */,
-				BF3199C01E32E078007DC0D1 /* ProjectIdentifierSpec.swift in Sources */,
+				BF3199C01E32E078007DC0D1 /* DependencySpec.swift in Sources */,
 				CDA0B6CA1C468E67006C499C /* GitSpec.swift in Sources */,
 				B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */,
 			);

--- a/Source/CarthageKit/Availability.swift
+++ b/Source/CarthageKit/Availability.swift
@@ -39,7 +39,10 @@ extension ResolvedCartfile {
 }
 
 @available(*, unavailable, renamed: "duplicateProjectsIn(_:_:)")
-public func duplicateProjectsInCartfiles(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [ProjectIdentifier] { fatalError() }
+public func duplicateProjectsInCartfiles(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [Dependency] { fatalError() }
+
+@available(*, unavailable, renamed: "Dependency")
+public enum ProjectIdentifier {}
 
 // MARK: - Git.swift
 

--- a/Source/CarthageKit/DuplicateDependency.swift
+++ b/Source/CarthageKit/DuplicateDependency.swift
@@ -1,7 +1,7 @@
 /// A duplicate dependency, used in CarthageError.duplicateDependencies.
 public struct DuplicateDependency {
 	/// The duplicate dependency as a project.
-	public let project: ProjectIdentifier
+	public let dependency: Dependency
 
 	/// The locations where the dependency was found as duplicate.
 	public let locations: [String]
@@ -10,15 +10,15 @@ public struct DuplicateDependency {
 	// cannot be used in test cases, so we reimplement it as public. We are also
 	// sorting locations, which makes sure that we can match them in a
 	// test case.
-	public init(project: ProjectIdentifier, locations: [String]) {
-		self.project = project
+	public init(dependency: Dependency, locations: [String]) {
+		self.dependency = dependency
 		self.locations = locations.sorted(by: <)
 	}
 }
 
 extension DuplicateDependency: CustomStringConvertible {
 	public var description: String {
-		return "\(project) \(printableLocations)"
+		return "\(dependency) \(printableLocations)"
 	}
 
 	private var printableLocations: String {
@@ -34,7 +34,7 @@ extension DuplicateDependency: CustomStringConvertible {
 
 extension DuplicateDependency: Comparable {
 	public static func == (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {
-		return lhs.project == rhs.project && lhs.locations == rhs.locations
+		return lhs.dependency == rhs.dependency && lhs.locations == rhs.locations
 	}
 
 	public static func < (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -237,14 +237,14 @@ extension CarthageError: CustomStringConvertible {
 		case let .missingEnvironmentVariable(variable):
 			return "Environment variable not set: \(variable)"
 
-		case let .noSharedFrameworkSchemes(Dependency, platforms):
-			var description = "Dependency \"\(Dependency.name)\" has no shared framework schemes"
+		case let .noSharedFrameworkSchemes(dependency, platforms):
+			var description = "Dependency \"\(dependency.name)\" has no shared framework schemes"
 			if !platforms.isEmpty {
 				let platformsString = platforms.map { $0.description }.joined(separator: ", ")
 				description += " for any of the platforms: \(platformsString)"
 			}
 
-			switch Dependency {
+			switch dependency {
 			case let .gitHub(repository):
 				description += "\n\nIf you believe this to be an error, please file an issue with the maintainers at \(repository.newIssueURL.absoluteString)"
 

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -14,7 +14,7 @@ import XCDBLD
 
 /// Possible errors that can originate from Carthage.
 public enum CarthageError: Error {
-	public typealias VersionRequirement = (specifier: VersionSpecifier, fromProject: ProjectIdentifier?)
+	public typealias VersionRequirement = (specifier: VersionSpecifier, fromProject: Dependency?)
 
 	/// One or more arguments was invalid.
 	case invalidArgument(description: String)
@@ -23,14 +23,14 @@ public enum CarthageError: Error {
 	case missingBuildSetting(String)
 
 	/// Incompatible version specifiers were given for a dependency.
-	case incompatibleRequirements(ProjectIdentifier, VersionRequirement, VersionRequirement)
+	case incompatibleRequirements(Dependency, VersionRequirement, VersionRequirement)
 
 	/// No tagged versions could be found for the dependency.
-	case taggedVersionNotFound(ProjectIdentifier)
+	case taggedVersionNotFound(Dependency)
 
 	/// No existent version could be found to satisfy the version specifier for
 	/// a dependency.
-	case requiredVersionNotFound(ProjectIdentifier, VersionSpecifier)
+	case requiredVersionNotFound(Dependency, VersionSpecifier)
 
 	/// No entry could be found in Cartfile for a dependency with this name.
 	case unknownDependencies([String])
@@ -64,7 +64,7 @@ public enum CarthageError: Error {
 
 	/// The project is not sharing any framework schemes, so Carthage cannot
 	/// discover them.
-	case noSharedFrameworkSchemes(ProjectIdentifier, Set<Platform>)
+	case noSharedFrameworkSchemes(Dependency, Set<Platform>)
 
 	/// The project is not sharing any schemes, so Carthage cannot discover
 	/// them.
@@ -78,7 +78,7 @@ public enum CarthageError: Error {
 	case duplicateDependencies([DuplicateDependency])
 
 	// There was a cycle between dependencies in the associated graph.
-	case dependencyCycle([ProjectIdentifier: Set<ProjectIdentifier>])
+	case dependencyCycle([Dependency: Set<Dependency>])
 
 	/// A request to the GitHub API failed.
 	case gitHubAPIRequestFailed(Client.Error)
@@ -237,14 +237,14 @@ extension CarthageError: CustomStringConvertible {
 		case let .missingEnvironmentVariable(variable):
 			return "Environment variable not set: \(variable)"
 
-		case let .noSharedFrameworkSchemes(projectIdentifier, platforms):
-			var description = "Dependency \"\(projectIdentifier.name)\" has no shared framework schemes"
+		case let .noSharedFrameworkSchemes(Dependency, platforms):
+			var description = "Dependency \"\(Dependency.name)\" has no shared framework schemes"
 			if !platforms.isEmpty {
 				let platformsString = platforms.map { $0.description }.joined(separator: ", ")
 				description += " for any of the platforms: \(platformsString)"
 			}
 
-			switch projectIdentifier {
+			switch Dependency {
 			case let .gitHub(repository):
 				description += "\n\nIf you believe this to be an error, please file an issue with the maintainers at \(repository.newIssueURL.absoluteString)"
 

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -217,7 +217,7 @@ extension VersionFile: Decodable {
 /// in order to allow those frameworks to be skipped in future builds.
 ///
 /// Returns a signal that succeeds once the file has been created.
-public func createVersionFile(for dependency: ProjectIdentifier, version: PinnedVersion, platforms: Set<Platform>, buildProducts: [URL], rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+public func createVersionFile(for dependency: Dependency, version: PinnedVersion, platforms: Set<Platform>, buildProducts: [URL], rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 	return createVersionFileForCommitish(version.commitish, dependencyName: dependency.name, platforms: platforms, buildProducts: buildProducts, rootDirectoryURL: rootDirectoryURL)
 }
 
@@ -280,7 +280,7 @@ public func createVersionFileForCommitish(_ commitish: String, dependencyName: S
 /// Returns an optional bool which is nil if no version file exists,
 /// otherwise true if the version file matches and the build can be
 /// skipped or false if there is a mismatch of some kind.
-public func versionFileMatches(_ dependency: ProjectIdentifier, version: PinnedVersion, platforms: Set<Platform>, rootDirectoryURL: URL, toolchain: String?) -> SignalProducer<Bool?, CarthageError> {
+public func versionFileMatches(_ dependency: Dependency, version: PinnedVersion, platforms: Set<Platform>, rootDirectoryURL: URL, toolchain: String?) -> SignalProducer<Bool?, CarthageError> {
 	let rootBinariesURL = rootDirectoryURL.appendingPathComponent(CarthageBinariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
 	let versionFileURL = rootBinariesURL.appendingPathComponent(".\(dependency.name).\(VersionFile.pathExtension)")
 	guard let versionFile = VersionFile(url: versionFileURL) else {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -619,7 +619,7 @@ public typealias BuildSchemeProducer = SignalProducer<TaskEvent<(ProjectLocator,
 /// places its build product into the root directory given.
 ///
 /// Returns producers in the same format as buildInDirectory().
-public func buildDependencyProject(_ dependency: ProjectIdentifier, version: PinnedVersion, _ rootDirectoryURL: URL, withOptions options: BuildOptions, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+public func buildDependencyProject(_ dependency: Dependency, version: PinnedVersion, _ rootDirectoryURL: URL, withOptions options: BuildOptions, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 	let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 	let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
 
@@ -645,7 +645,7 @@ public func buildDependencyProject(_ dependency: ProjectIdentifier, version: Pin
 /// Creates symlink between the dependency build folder and the root build folder
 ///
 /// Returns a signal indicating success
-private func symlinkBuildPathForDependencyProject(_ dependency: ProjectIdentifier, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+private func symlinkBuildPathForDependencyProject(_ dependency: Dependency, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 	return SignalProducer.attempt {
 		let rootBinariesURL = rootDirectoryURL.appendingPathComponent(CarthageBinariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
 		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
@@ -705,7 +705,7 @@ private func symlinkBuildPathForDependencyProject(_ dependency: ProjectIdentifie
 /// Builds the any shared framework schemes found within the given directory.
 ///
 /// Returns a signal of all standard output from `xcodebuild`, and each scheme being built.
-public func buildInDirectory(_ directoryURL: URL, withOptions options: BuildOptions, dependency: (project: ProjectIdentifier, version: PinnedVersion)? = nil, rootDirectoryURL: URL? = nil, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> BuildSchemeProducer {
+public func buildInDirectory(_ directoryURL: URL, withOptions options: BuildOptions, dependency: (project: Dependency, version: PinnedVersion)? = nil, rootDirectoryURL: URL? = nil, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> BuildSchemeProducer {
 	precondition(directoryURL.isFileURL)
 
 	return BuildSchemeProducer { observer, disposable in

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -24,13 +24,13 @@ class CartfileSpec: QuickSpec {
 
 			let cartfile = result.value!
 
-			let reactiveCocoa = ProjectIdentifier.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa"))
-			let mantle = ProjectIdentifier.gitHub(Repository(owner: "Mantle", name: "Mantle"))
-			let libextobjc = ProjectIdentifier.gitHub(Repository(owner: "jspahrsummers", name: "libextobjc"))
-			let xcconfigs = ProjectIdentifier.gitHub(Repository(owner: "jspahrsummers", name: "xcconfigs"))
-			let iosCharts = ProjectIdentifier.gitHub(Repository(owner: "danielgindi", name: "ios-charts"))
-			let errorTranslations = ProjectIdentifier.gitHub(Repository(server: .enterprise(url: URL(string: "https://enterprise.local/ghe")!), owner: "desktop", name: "git-error-translations"))
-			let errorTranslations2 = ProjectIdentifier.git(GitURL("https://enterprise.local/desktop/git-error-translations2.git"))
+			let reactiveCocoa = Dependency.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa"))
+			let mantle = Dependency.gitHub(Repository(owner: "Mantle", name: "Mantle"))
+			let libextobjc = Dependency.gitHub(Repository(owner: "jspahrsummers", name: "libextobjc"))
+			let xcconfigs = Dependency.gitHub(Repository(owner: "jspahrsummers", name: "xcconfigs"))
+			let iosCharts = Dependency.gitHub(Repository(owner: "danielgindi", name: "ios-charts"))
+			let errorTranslations = Dependency.gitHub(Repository(server: .enterprise(url: URL(string: "https://enterprise.local/ghe")!), owner: "desktop", name: "git-error-translations"))
+			let errorTranslations2 = Dependency.git(GitURL("https://enterprise.local/desktop/git-error-translations2.git"))
 			
 			expect(cartfile.dependencies) == [
 				reactiveCocoa: .atLeast(SemanticVersion(major: 2, minor: 3, patch: 1)),
@@ -70,15 +70,15 @@ class CartfileSpec: QuickSpec {
 			}
 			
 			let projects = dupes
-				.map { $0.project }
+				.map { $0.dependency }
 				.sorted { $0.description < $1.description }
 			expect(dupes.count) == 3
 			
 			let self2Dupe = projects[0]
-			expect(self2Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self2", name: "self2"))
+			expect(self2Dupe) == Dependency.gitHub(Repository(owner: "self2", name: "self2"))
 			
 			let self3Dupe = projects[1]
-			expect(self3Dupe) == ProjectIdentifier.gitHub(Repository(owner: "self3", name: "self3"))
+			expect(self3Dupe) == Dependency.gitHub(Repository(owner: "self3", name: "self3"))
 		}
 
 		it("should detect duplicate dependencies across two Cartfiles") {
@@ -104,13 +104,13 @@ class CartfileSpec: QuickSpec {
 			expect(dupes.count) == 3
 
 			let dupe1 = dupes[0]
-			expect(dupe1) == ProjectIdentifier.gitHub(Repository(owner: "1", name: "1"))
+			expect(dupe1) == Dependency.gitHub(Repository(owner: "1", name: "1"))
 
 			let dupe3 = dupes[1]
-			expect(dupe3) == ProjectIdentifier.gitHub(Repository(owner: "3", name: "3"))
+			expect(dupe3) == Dependency.gitHub(Repository(owner: "3", name: "3"))
 
 			let dupe5 = dupes[2]
-			expect(dupe5) == ProjectIdentifier.gitHub(Repository(owner: "5", name: "5"))
+			expect(dupe5) == Dependency.gitHub(Repository(owner: "5", name: "5"))
 		}
 
 		it("should not allow a binary framework with git reference") {

--- a/Source/CarthageKitTests/DependencySpec.swift
+++ b/Source/CarthageKitTests/DependencySpec.swift
@@ -4,7 +4,7 @@ import Nimble
 import Quick
 import Tentacle
 
-class ProjectIdentifierSpec: QuickSpec {
+class DependencySpec: QuickSpec {
 	override func spec() {
 
 		var dependencyType: String!
@@ -23,7 +23,7 @@ class ProjectIdentifierSpec: QuickSpec {
 			it("should fail without dependency") {
 				let scanner = Scanner(string: dependencyType)
 
-				let error = ProjectIdentifier.from(scanner).error
+				let error = Dependency.from(scanner).error
 
 				let expectedError = ScannableError(message: "expected string after dependency type", currentLine: dependencyType)
 				expect(error).to(equal(expectedError))
@@ -32,7 +32,7 @@ class ProjectIdentifierSpec: QuickSpec {
 			it("should fail without closing quote on dependency") {
 				let scanner = Scanner(string: "\(dependencyType!) \"dependency")
 
-				let error = ProjectIdentifier.from(scanner).error
+				let error = Dependency.from(scanner).error
 
 				let expectedError = ScannableError(message: "empty or unterminated string after dependency type", currentLine: "\(dependencyType!) \"dependency")
 				expect(error).to(equal(expectedError))
@@ -41,7 +41,7 @@ class ProjectIdentifierSpec: QuickSpec {
 			it("should fail with empty dependency") {
 				let scanner = Scanner(string: "\(dependencyType!) \" \"")
 
-				let error = ProjectIdentifier.from(scanner).error
+				let error = Dependency.from(scanner).error
 
 				let expectedError = ScannableError(message: "empty or unterminated string after dependency type", currentLine: "\(dependencyType!) \" \"")
 				expect(error).to(equal(expectedError))
@@ -52,9 +52,9 @@ class ProjectIdentifierSpec: QuickSpec {
 			context ("github") {
 
 				it("should equal the name of a github.com repo") {
-					let projectIdentifier = ProjectIdentifier.gitHub(Repository(owner: "owner", name: "name"))
+					let dependency = Dependency.gitHub(Repository(owner: "owner", name: "name"))
 
-					expect(projectIdentifier.name).to(equal("name"))
+					expect(dependency.name).to(equal("name"))
 				}
 
 				it("should equal the name of an enterprise github repo") {
@@ -63,30 +63,30 @@ class ProjectIdentifierSpec: QuickSpec {
 						owner: "owner",
 						name: "name")
 
-					let projectIdentifier = ProjectIdentifier.gitHub(enterpriseRepo)
+					let dependency = Dependency.gitHub(enterpriseRepo)
 
-					expect(projectIdentifier.name).to(equal("name"))
+					expect(dependency.name).to(equal("name"))
 				}
 			}
 
 			context("git") {
 
 				it("should be the last component of the URL") {
-					let projectIdentifier = ProjectIdentifier.git(GitURL("ssh://server.com/myproject"))
+					let dependency = Dependency.git(GitURL("ssh://server.com/myproject"))
 
-					expect(projectIdentifier.name).to(equal("myproject"))
+					expect(dependency.name).to(equal("myproject"))
 				}
 
 				it("should not include the trailing git suffix") {
-					let projectIdentifier = ProjectIdentifier.git(GitURL("ssh://server.com/myproject.git"))
+					let dependency = Dependency.git(GitURL("ssh://server.com/myproject.git"))
 
-					expect(projectIdentifier.name).to(equal("myproject"))
+					expect(dependency.name).to(equal("myproject"))
 				}
 
 				it("should be the entire URL string if there is no last component") {
-					let projectIdentifier = ProjectIdentifier.git(GitURL("whatisthisurleven"))
+					let dependency = Dependency.git(GitURL("whatisthisurleven"))
 
-					expect(projectIdentifier.name).to(equal("whatisthisurleven"))
+					expect(dependency.name).to(equal("whatisthisurleven"))
 				}
 
 			}
@@ -94,15 +94,15 @@ class ProjectIdentifierSpec: QuickSpec {
 			context("binary") {
 
 				it("should be the last component of the URL") {
-					let projectIdentifier = ProjectIdentifier.binary(URL(string: "https://server.com/myproject")!)
+					let dependency = Dependency.binary(URL(string: "https://server.com/myproject")!)
 
-					expect(projectIdentifier.name).to(equal("myproject"))
+					expect(dependency.name).to(equal("myproject"))
 				}
 
 				it("should not include the trailing git suffix") {
-					let projectIdentifier = ProjectIdentifier.binary(URL(string: "https://server.com/myproject.json")!)
+					let dependency = Dependency.binary(URL(string: "https://server.com/myproject.json")!)
 
-					expect(projectIdentifier.name).to(equal("myproject"))
+					expect(dependency.name).to(equal("myproject"))
 				}
 
 			}
@@ -115,37 +115,37 @@ class ProjectIdentifierSpec: QuickSpec {
 				it("should read a github.com dependency") {
 					let scanner = Scanner(string: "github \"ReactiveCocoa/ReactiveCocoa\"")
 
-					let projectIdentifier = ProjectIdentifier.from(scanner).value
+					let dependency = Dependency.from(scanner).value
 
 					let expectedRepo = Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")
-					expect(projectIdentifier).to(equal(ProjectIdentifier.gitHub(expectedRepo)))
+					expect(dependency).to(equal(Dependency.gitHub(expectedRepo)))
 				}
 
 				it("should read a github.com dependency with full url") {
 					let scanner = Scanner(string: "github \"https://github.com/ReactiveCocoa/ReactiveCocoa\"")
 
-					let projectIdentifier = ProjectIdentifier.from(scanner).value
+					let dependency = Dependency.from(scanner).value
 
 					let expectedRepo = Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")
-					expect(projectIdentifier).to(equal(ProjectIdentifier.gitHub(expectedRepo)))
+					expect(dependency).to(equal(Dependency.gitHub(expectedRepo)))
 				}
 
 				it("should read an enterprise github dependency") {
 					let scanner = Scanner(string: "github \"http://mysupercoolinternalwebhost.com/ReactiveCocoa/ReactiveCocoa\"")
 
-					let projectIdentifier = ProjectIdentifier.from(scanner).value
+					let dependency = Dependency.from(scanner).value
 
 					let expectedRepo = Repository(
 						server: .enterprise(url: URL(string: "http://mysupercoolinternalwebhost.com")!),
 						owner: "ReactiveCocoa",
 						name: "ReactiveCocoa")
-					expect(projectIdentifier).to(equal(ProjectIdentifier.gitHub(expectedRepo)))
+					expect(dependency).to(equal(Dependency.gitHub(expectedRepo)))
 				}
 
 				it("should fail with invalid github.com dependency") {
 					let scanner = Scanner(string: "github \"Whatsthis\"")
 
-					let error = ProjectIdentifier.from(scanner).error
+					let error = Dependency.from(scanner).error
 
 					let expectedError = ScannableError(message: "invalid GitHub repository identifier \"Whatsthis\"")
 					expect(error).to(equal(expectedError))
@@ -154,7 +154,7 @@ class ProjectIdentifierSpec: QuickSpec {
 				it("should fail with invalid enterprise github dependency") {
 					let scanner = Scanner(string: "github \"http://mysupercoolinternalwebhost.com/ReactiveCocoa\"")
 
-					let error = ProjectIdentifier.from(scanner).error
+					let error = Dependency.from(scanner).error
 
 					let expectedError = ScannableError(message: "invalid GitHub repository identifier \"http://mysupercoolinternalwebhost.com/ReactiveCocoa\"")
 					expect(error).to(equal(expectedError))
@@ -168,9 +168,9 @@ class ProjectIdentifierSpec: QuickSpec {
 				it("should read a git URL") {
 					let scanner = Scanner(string: "git \"mygiturl\"")
 
-					let projectIdentifier = ProjectIdentifier.from(scanner).value
+					let dependency = Dependency.from(scanner).value
 
-					expect(projectIdentifier).to(equal(ProjectIdentifier.git(GitURL("mygiturl"))))
+					expect(dependency).to(equal(Dependency.git(GitURL("mygiturl"))))
 				}
 
 				itBehavesLike("invalid dependency") { ["dependencyType": "git"] }
@@ -182,15 +182,15 @@ class ProjectIdentifierSpec: QuickSpec {
 				it("should read a URL") {
 					let scanner = Scanner(string: "binary \"https://mysupercoolinternalwebhost.com/\"")
 
-					let projectIdentifier = ProjectIdentifier.from(scanner).value
+					let dependency = Dependency.from(scanner).value
 
-					expect(projectIdentifier).to(equal(ProjectIdentifier.binary(URL(string: "https://mysupercoolinternalwebhost.com/")!)))
+					expect(dependency).to(equal(Dependency.binary(URL(string: "https://mysupercoolinternalwebhost.com/")!)))
 				}
 
 				it("should fail with non-https URL") {
 					let scanner = Scanner(string: "binary \"nope\"")
 
-					let error = ProjectIdentifier.from(scanner).error
+					let error = Dependency.from(scanner).error
 
 					expect(error).to(equal(ScannableError(message: "non-https URL found for dependency type `binary`", currentLine: "binary \"nope\"")))
 				}
@@ -198,7 +198,7 @@ class ProjectIdentifierSpec: QuickSpec {
 				it("should fail with invalid URL") {
 					let scanner = Scanner(string: "binary \"nop@%@#^@e\"")
 
-					let error = ProjectIdentifier.from(scanner).error
+					let error = Dependency.from(scanner).error
 
 					expect(error).to(equal(ScannableError(message: "invalid URL found for dependency type `binary`", currentLine: "binary \"nop@%@#^@e\"")))
 				}

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -187,8 +187,8 @@ class ProjectSpec: QuickSpec {
 				expect(resultError).notTo(beNil())
 
 				let makeDependency: (String, String, [String]) -> DuplicateDependency = { (repoOwner, repoName, locations) in
-					let project = ProjectIdentifier.gitHub(Repository(owner: repoOwner, name: repoName))
-					return DuplicateDependency(project: project, locations: locations)
+					let dependency = Dependency.gitHub(Repository(owner: repoOwner, name: repoName))
+					return DuplicateDependency(dependency: dependency, locations: locations)
 				}
 
 				let locations = ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]
@@ -222,7 +222,7 @@ class ProjectSpec: QuickSpec {
 			let temporaryURL = URL(fileURLWithPath: temporaryPath, isDirectory: true)
 			let repositoryURL = temporaryURL.appendingPathComponent("carthage1191", isDirectory: true)
 			let cacheDirectoryURL = temporaryURL.appendingPathComponent("cache", isDirectory: true)
-			let projectIdentifier = ProjectIdentifier.git(GitURL(repositoryURL.absoluteString))
+			let dependency = Dependency.git(GitURL(repositoryURL.absoluteString))
 
 			func initRepository() {
 				expect { try FileManager.default.createDirectory(atPath: repositoryURL.path, withIntermediateDirectories: true) }.notTo(throwError())
@@ -239,7 +239,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			func cloneOrFetch(commitish: String? = nil) -> SignalProducer<(ProjectEvent?, URL), CarthageError> {
-				return cloneOrFetchProject(projectIdentifier, preferHTTPS: false, destinationURL: cacheDirectoryURL, commitish: commitish)
+				return cloneOrFetchProject(dependency, preferHTTPS: false, destinationURL: cacheDirectoryURL, commitish: commitish)
 			}
 
 			func assertProjectEvent(commitish: String? = nil, clearFetchTime: Bool = true, action: @escaping (ProjectEvent?) -> ()) {
@@ -360,7 +360,7 @@ class ProjectSpec: QuickSpec {
 
 				_ = project.downloadBinaryFrameworkDefinition(url: testDefinitionURL).first()
 
-				expect(events).to(equal([ProjectEvent.downloadingBinaryFrameworkDefinition(ProjectIdentifier.binary(testDefinitionURL), testDefinitionURL)]))
+				expect(events).to(equal([ProjectEvent.downloadingBinaryFrameworkDefinition(Dependency.binary(testDefinitionURL), testDefinitionURL)]))
 			}
 		}
 	}

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -107,8 +107,8 @@ class XcodeSpec: QuickSpec {
 
 		it("should build for all platforms") {
 			let dependencies = [
-				ProjectIdentifier.gitHub(Repository(owner: "github", name: "Archimedes")),
-				ProjectIdentifier.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")),
+				Dependency.gitHub(Repository(owner: "github", name: "Archimedes")),
+				Dependency.gitHub(Repository(owner: "ReactiveCocoa", name: "ReactiveCocoa")),
 			]
 			let version = PinnedVersion("0.1")
 
@@ -301,7 +301,7 @@ class XcodeSpec: QuickSpec {
 		}
 
 		it("should build for one platform") {
-			let project = ProjectIdentifier.gitHub(Repository(owner: "github", name: "Archimedes"))
+			let project = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
 			let result = buildDependencyProject(project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
 				.flatten(.concat)
@@ -323,7 +323,7 @@ class XcodeSpec: QuickSpec {
 		}
 
 		it("should build for multiple platforms") {
-			let project = ProjectIdentifier.gitHub(Repository(owner: "github", name: "Archimedes"))
+			let project = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
 			let result = buildDependencyProject(project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
 				.flatten(.concat)
@@ -365,7 +365,7 @@ class XcodeSpec: QuickSpec {
 		}
 
 		it("should symlink the build directory") {
-			let project = ProjectIdentifier.gitHub(Repository(owner: "github", name: "Archimedes"))
+			let project = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
 
 			let dependencyURL =	directoryURL.appendingPathComponent(project.relativePath)

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -34,7 +34,7 @@ public struct FetchCommand: CommandProtocol {
 	public let function = "Clones or fetches a Git repository ahead of time"
 
 	public func run(_ options: Options) -> Result<(), CarthageError> {
-		let project = ProjectIdentifier.git(options.repositoryURL)
+		let project = Dependency.git(options.repositoryURL)
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
 
 		return cloneOrFetchProject(project, preferHTTPS: true)


### PR DESCRIPTION
We still refer to `Dependency`s as _projects_ in many places, but I think this is a good start.