### PR TITLE
Log the version warning to stderr

### DIFF
--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -21,8 +21,7 @@ guard ensureGitVersion().first()?.value == true else {
 }
 
 if let remoteVersion = remoteVersion(), localVersion() < remoteVersion {
-	let formatting = ColorOptions.Formatting(true)
-	fputs(formatting.bullets + "Please update to the latest Carthage version: \(remoteVersion). You currently are on \(localVersion())" + "\n", stderr)
+	fputs("Please update to the latest Carthage version: \(remoteVersion). You currently are on \(localVersion())" + "\n", stderr)
 }
 
 if let carthagePath = Bundle.main.executablePath {

--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -22,7 +22,7 @@ guard ensureGitVersion().first()?.value == true else {
 
 if let remoteVersion = remoteVersion(), localVersion() < remoteVersion {
 	let formatting = ColorOptions.Formatting(true)
-	carthage.println(formatting.bullets + "Please update to the latest Carthage version: \(remoteVersion). You currently are on \(localVersion())")
+	fputs(formatting.bullets + "Please update to the latest Carthage version: \(remoteVersion). You currently are on \(localVersion())" + "\n", stderr)
 }
 
 if let carthagePath = Bundle.main.executablePath {


### PR DESCRIPTION
We have some scripts that do different things based on the version of carthage they have. This allows us to roll out carthage updates across our build machines without any downtime when we uptake changes in carthage. 

Recently noticed a reversion in behavior, and it was because our usage of `carthage version` didn't work for parsing the version anymore as the warning about being out of date got in the way. It made sense to me that this sort of warning belongs in stderr, as it's not part of the 'normal' output of the command. 