### PR TITLE
Rename `project` to `dependency` for `Dependency` type

### DIFF
--- a/Source/CarthageKit/Availability.swift
+++ b/Source/CarthageKit/Availability.swift
@@ -38,7 +38,7 @@ extension ResolvedCartfile {
 	public mutating func appendCartfile(_ cartfile: Cartfile) { fatalError() }
 }
 
-@available(*, unavailable, renamed: "duplicateProjectsIn(_:_:)")
+@available(*, unavailable, renamed: "duplicateDependenciesIn(_:_:)")
 public func duplicateProjectsInCartfiles(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [Dependency] { fatalError() }
 
 @available(*, unavailable, renamed: "Dependency")

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -320,7 +320,7 @@ extension Dependency: CustomStringConvertible {
 
 extension Dependency {
 
-	/// Returns the URL that the project's remote repository exists at.
+	/// Returns the URL that the dependency's remote repository exists at.
 	func gitURL(preferHTTPS: Bool) -> GitURL? {
 		switch self {
 		case let .gitHub(repository):

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -127,9 +127,8 @@ extension Cartfile: CustomStringConvertible {
 	}
 }
 
-/// Returns an array containing projects that are listed as dependencies
-/// in both arguments.
-public func duplicateProjectsIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [Dependency] {
+/// Returns an array containing dependencies that are listed in both arguments.
+public func duplicateDependenciesIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [Dependency] {
 	let projects1 = cartfile1.dependencies.keys
 	let projects2 = cartfile2.dependencies.keys
 	return Array(Set(projects1).intersection(Set(projects2)))

--- a/Source/CarthageKit/DuplicateDependency.swift
+++ b/Source/CarthageKit/DuplicateDependency.swift
@@ -1,6 +1,6 @@
 /// A duplicate dependency, used in CarthageError.duplicateDependencies.
 public struct DuplicateDependency {
-	/// The duplicate dependency as a project.
+	/// The duplicate dependency
 	public let dependency: Dependency
 
 	/// The locations where the dependency was found as duplicate.

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -14,7 +14,7 @@ import XCDBLD
 
 /// Possible errors that can originate from Carthage.
 public enum CarthageError: Error {
-	public typealias VersionRequirement = (specifier: VersionSpecifier, fromProject: Dependency?)
+	public typealias VersionRequirement = (specifier: VersionSpecifier, fromDependency: Dependency?)
 
 	/// One or more arguments was invalid.
 	case invalidArgument(description: String)
@@ -101,7 +101,7 @@ public extension CarthageError {
 }
 
 private func == (_ lhs: CarthageError.VersionRequirement, _ rhs: CarthageError.VersionRequirement) -> Bool {
-	return lhs.specifier == rhs.specifier && lhs.fromProject == rhs.fromProject
+	return lhs.specifier == rhs.specifier && lhs.fromDependency == rhs.fromDependency
 }
 
 extension CarthageError: Equatable {

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -202,8 +202,8 @@ extension CarthageError: CustomStringConvertible {
 			return description
 
 		case let .incompatibleRequirements(dependency, first, second):
-			let requirement: (VersionRequirement) -> String = { specifier, fromProject in
-				return "\(specifier)" + (fromProject.map { " (\($0))" } ?? "")
+			let requirement: (VersionRequirement) -> String = { specifier, fromDependency in
+				return "\(specifier)" + (fromDependency.map { " (\($0))" } ?? "")
 			}
 			return "Could not pick a version for \(dependency), due to mutually incompatible requirements:\n\t\(requirement(first))\n\t\(requirement(second))"
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -382,8 +382,8 @@ public final class Project {
 		return SignalProducer.attempt {
 				return .success(self.cachedVersions)
 			}
-			.flatMap(.merge) { versionsByProject -> SignalProducer<PinnedVersion, CarthageError> in
-				if let versions = versionsByProject[dependency] {
+			.flatMap(.merge) { versionsByDependency -> SignalProducer<PinnedVersion, CarthageError> in
+				if let versions = versionsByDependency[dependency] {
 					return SignalProducer(versions)
 				} else {
 					return fetchVersions

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -929,7 +929,7 @@ public final class Project {
 				for name in names {
 					let dependencyCheckoutURL = dependencyCheckoutsURL.appendingPathComponent(name)
 					let subdirectoryPath = (CarthageProjectCheckoutsPath as NSString).appendingPathComponent(name)
-					let linkDestinationPath = relativeLinkDestinationForDependencyProject(dependency, subdirectory: subdirectoryPath)
+					let linkDestinationPath = relativeLinkDestination(for: dependency, subdirectory: subdirectoryPath)
 
 					let dependencyCheckoutURLResource = try? dependencyCheckoutURL.resourceValues(forKeys: [
 						.isSymbolicLinkKey,
@@ -1216,8 +1216,8 @@ private func repositoryFileURL(for dependency: Dependency, baseURL: URL = Cartha
 	return baseURL.appendingPathComponent(dependency.name, isDirectory: true)
 }
 
-/// Returns the string representing a relative path from a dependency project back to the root
-internal func relativeLinkDestinationForDependencyProject(_ dependency: Dependency, subdirectory: String) -> String {
+/// Returns the string representing a relative path from a dependency back to the root
+internal func relativeLinkDestination(for dependency: Dependency, subdirectory: String) -> String {
 	let dependencySubdirectoryPath = (dependency.relativePath as NSString).appendingPathComponent(subdirectory)
 	let componentsForGettingTheHellOutOfThisRelativePath = Array(repeating: "..", count: (dependencySubdirectoryPath as NSString).pathComponents.count - 1)
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -872,7 +872,7 @@ public final class Project {
 	/// less temporary location.
 	private func downloadBinary(dependency: Dependency, version: SemanticVersion, url: URL) -> SignalProducer<URL, CarthageError> {
 		let fileName = url.lastPathComponent
-		let fileURL = fileURLToCachedBinaryProject(dependency, version, fileName)
+		let fileURL = fileURLToCachedBinaryDependency(dependency, version, fileName)
 
 		if FileManager.default.fileExists(atPath: fileURL.path) {
 			return SignalProducer(value: fileURL)
@@ -1046,9 +1046,9 @@ private func fileURLToCachedBinary(_ dependency: Dependency, _ release: Release,
 }
 
 /// Constructs a file URL to where the binary only framework download should be cached
-private func fileURLToCachedBinaryProject(_ project: Dependency, _ semanticVersion: SemanticVersion, _ fileName: String) -> URL{
+private func fileURLToCachedBinaryDependency(_ dependency: Dependency, _ semanticVersion: SemanticVersion, _ fileName: String) -> URL{
 	// ~/Library/Caches/org.carthage.CarthageKit/binaries/MyBinaryProjectFramework/2.3.1/MyBinaryProject.framework.zip
-	return CarthageDependencyAssetsURL.appendingPathComponent("\(project.name)/\(semanticVersion)/\(fileName)")
+	return CarthageDependencyAssetsURL.appendingPathComponent("\(dependency.name)/\(semanticVersion)/\(fileName)")
 }
 
 /// Caches the downloaded binary at the given URL, moving it to the other URL

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -268,7 +268,7 @@ public final class Project {
 			.attemptMap { cartfile, privateCartfile -> Result<Cartfile, CarthageError> in
 				var cartfile = cartfile
 
-				let duplicateDeps = duplicateProjectsIn(cartfile, privateCartfile).map { DuplicateDependency(dependency: $0, locations: ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]) }
+				let duplicateDeps = duplicateDependenciesIn(cartfile, privateCartfile).map { DuplicateDependency(dependency: $0, locations: ["\(CarthageProjectCartfilePath)", "\(CarthageProjectPrivateCartfilePath)"]) }
 
 				if duplicateDeps.isEmpty {
 					cartfile.append(privateCartfile)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -774,20 +774,20 @@ public final class Project {
 				return result
 			}
 			.flatMap(.latest) { (graph: DependencyGraph) -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
-				let projectsToInclude = Set(graph
-					.map { project, _ in project }
-					.filter { project in dependenciesToInclude?.contains(project.name) ?? false })
+				let dependenciesToInclude = Set(graph
+					.map { dependency, _ in dependency }
+					.filter { dependency in dependenciesToInclude?.contains(dependency.name) ?? false })
 
-				guard let sortedProjects = topologicalSort(graph, nodes: projectsToInclude) else {
+				guard let sortedDependencies = topologicalSort(graph, nodes: dependenciesToInclude) else {
 					return SignalProducer(error: .dependencyCycle(graph))
 				}
 
-				let sortedDependencies = cartfile.dependencies.keys
-					.filter { dependency in sortedProjects.contains(dependency) }
-					.sorted { left, right in sortedProjects.index(of: left)! < sortedProjects.index(of: right)! }
+				let sortedPinnedDependencies = cartfile.dependencies.keys
+					.filter { dependency in sortedDependencies.contains(dependency) }
+					.sorted { left, right in sortedDependencies.index(of: left)! < sortedDependencies.index(of: right)! }
 					.map { ($0, cartfile.dependencies[$0]!) }
 
-				return SignalProducer(sortedDependencies)
+				return SignalProducer(sortedPinnedDependencies)
 			}
 	}
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1018,7 +1018,7 @@ public final class Project {
 				let derivedDataVersioned = derivedDataPerDependency.appendingPathComponent(version.commitish, isDirectory: true)
 				options.derivedDataPath = derivedDataVersioned.resolvingSymlinksInPath().path
 
-				return buildDependencyProject(dependency, version: version, self.directoryURL, withOptions: options, sdkFilter: sdkFilter)
+				return build(dependency: dependency, version: version, self.directoryURL, withOptions: options, sdkFilter: sdkFilter)
 					.map { producer in
 						return producer.flatMapError { error in
 							switch error {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -429,7 +429,7 @@ public final class Project {
 
 	/// Attempts to resolve a Git reference to a version.
 	private func resolvedGitReference(_ dependency: Dependency, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {
-		let repositoryURL = repositoryFileURLForProject(dependency)
+		let repositoryURL = repositoryFileURL(for: dependency)
 		return cloneOrFetchDependency(dependency, commitish: reference)
 			.flatMap(.concat) { _ in
 				return resolveTagInRepository(repositoryURL, reference)
@@ -1212,8 +1212,8 @@ private func BCSymbolMapsForFramework(_ frameworkURL: URL, inDirectoryURL direct
 
 /// Returns the file URL at which the given project's repository will be
 /// located.
-private func repositoryFileURLForProject(_ project: Dependency, baseURL: URL = CarthageDependencyRepositoriesURL) -> URL {
-	return baseURL.appendingPathComponent(project.name, isDirectory: true)
+private func repositoryFileURL(for dependency: Dependency, baseURL: URL = CarthageDependencyRepositoriesURL) -> URL {
+	return baseURL.appendingPathComponent(dependency.name, isDirectory: true)
 }
 
 /// Returns the string representing a relative path from a dependency project back to the root
@@ -1238,7 +1238,7 @@ internal func relativeLinkDestinationForDependencyProject(_ dependency: Dependen
 /// when the operation completes.
 public func cloneOrFetchProject(_ project: Dependency, preferHTTPS: Bool, destinationURL: URL = CarthageDependencyRepositoriesURL, commitish: String? = nil) -> SignalProducer<(ProjectEvent?, URL), CarthageError> {
 	let fileManager = FileManager.default
-	let repositoryURL = repositoryFileURLForProject(project, baseURL: destinationURL)
+	let repositoryURL = repositoryFileURL(for: project, baseURL: destinationURL)
 
 	return SignalProducer.attempt { () -> Result<GitURL, CarthageError> in
 			do {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -623,7 +623,7 @@ public func build(dependency: Dependency, version: PinnedVersion, _ rootDirector
 	let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 	let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
 
-	return symlinkBuildPathForDependencyProject(dependency, rootDirectoryURL: rootDirectoryURL)
+	return symlinkBuildPath(for: dependency, rootDirectoryURL: rootDirectoryURL)
 		.map { _ -> BuildSchemeProducer in
 			return buildInDirectory(dependencyURL, withOptions: options, dependency: (dependency, version), rootDirectoryURL: rootDirectoryURL, sdkFilter: sdkFilter)
 				.mapError { error in
@@ -645,7 +645,7 @@ public func build(dependency: Dependency, version: PinnedVersion, _ rootDirector
 /// Creates symlink between the dependency build folder and the root build folder
 ///
 /// Returns a signal indicating success
-private func symlinkBuildPathForDependencyProject(_ dependency: Dependency, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+private func symlinkBuildPath(for dependency: Dependency, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 	return SignalProducer.attempt {
 		let rootBinariesURL = rootDirectoryURL.appendingPathComponent(CarthageBinariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
 		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -615,11 +615,11 @@ public func createDebugInformation(_ builtProductURL: URL) -> SignalProducer<Tas
 /// begins, then complete or error when building terminates.
 public typealias BuildSchemeProducer = SignalProducer<TaskEvent<(ProjectLocator, String)>, CarthageError>
 
-/// Attempts to build the dependency identified by the given project, then
-/// places its build product into the root directory given.
+/// Attempts to build the dependency, then places its build product into the
+/// root directory given.
 ///
 /// Returns producers in the same format as buildInDirectory().
-public func buildDependencyProject(_ dependency: Dependency, version: PinnedVersion, _ rootDirectoryURL: URL, withOptions options: BuildOptions, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+public func build(dependency: Dependency, version: PinnedVersion, _ rootDirectoryURL: URL, withOptions options: BuildOptions, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 	let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 	let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -691,7 +691,7 @@ private func symlinkBuildPathForDependencyProject(_ dependency: Dependency, root
 				return .failure(.writeFailed(dependencyBinariesURL, error))
 			}
 		} else {
-			let linkDestinationPath = relativeLinkDestinationForDependencyProject(dependency, subdirectory: CarthageBinariesFolderPath)
+			let linkDestinationPath = relativeLinkDestination(for: dependency, subdirectory: CarthageBinariesFolderPath)
 			do {
 				try fileManager.createSymbolicLink(atPath: dependencyBinariesURL.path, withDestinationPath: linkDestinationPath)
 			} catch let error as NSError {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -705,7 +705,7 @@ private func symlinkBuildPathForDependencyProject(_ dependency: Dependency, root
 /// Builds the any shared framework schemes found within the given directory.
 ///
 /// Returns a signal of all standard output from `xcodebuild`, and each scheme being built.
-public func buildInDirectory(_ directoryURL: URL, withOptions options: BuildOptions, dependency: (project: Dependency, version: PinnedVersion)? = nil, rootDirectoryURL: URL? = nil, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> BuildSchemeProducer {
+public func buildInDirectory(_ directoryURL: URL, withOptions options: BuildOptions, dependency: (dependency: Dependency, version: PinnedVersion)? = nil, rootDirectoryURL: URL? = nil, sdkFilter: @escaping SDKFilterCallback = { .success($0.0) }) -> BuildSchemeProducer {
 	precondition(directoryURL.isFileURL)
 
 	return BuildSchemeProducer { observer, disposable in
@@ -780,7 +780,7 @@ public func buildInDirectory(_ directoryURL: URL, withOptions options: BuildOpti
 				guard let dependency = dependency, let rootDirectoryURL = rootDirectoryURL else {
 					return .empty
 				}
-				return createVersionFile(for: dependency.project, version: dependency.version, platforms: options.platforms, buildProducts: urls, rootDirectoryURL: rootDirectoryURL)
+				return createVersionFile(for: dependency.dependency, version: dependency.version, platforms: options.platforms, buildProducts: urls, rootDirectoryURL: rootDirectoryURL)
 					.flatMapError { _ in .empty }
 			}
 			// Discard any Success values, since we want to

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -69,15 +69,15 @@ class CartfileSpec: QuickSpec {
 				return
 			}
 			
-			let projects = dupes
+			let dependencies = dupes
 				.map { $0.dependency }
 				.sorted { $0.description < $1.description }
 			expect(dupes.count) == 3
 			
-			let self2Dupe = projects[0]
+			let self2Dupe = dependencies[0]
 			expect(self2Dupe) == Dependency.gitHub(Repository(owner: "self2", name: "self2"))
 			
-			let self3Dupe = projects[1]
+			let self3Dupe = dependencies[1]
 			expect(self3Dupe) == Dependency.gitHub(Repository(owner: "self3", name: "self3"))
 		}
 

--- a/Source/CarthageKitTests/CartfileSpec.swift
+++ b/Source/CarthageKitTests/CartfileSpec.swift
@@ -100,7 +100,7 @@ class CartfileSpec: QuickSpec {
 			let cartfile2 = result2.value!
 			expect(cartfile2.dependencies.count) == 3
 
-			let dupes = duplicateProjectsIn(cartfile, cartfile2).sorted { $0.description < $1.description }
+			let dupes = duplicateDependenciesIn(cartfile, cartfile2).sorted { $0.description < $1.description }
 			expect(dupes.count) == 3
 
 			let dupe1 = dupes[0]

--- a/Source/CarthageKitTests/ProjectSpec.swift
+++ b/Source/CarthageKitTests/ProjectSpec.swift
@@ -71,7 +71,7 @@ class ProjectSpec: QuickSpec {
 				let sourceRepoUrl = directoryURL.appendingPathComponent("SourceRepos")
 				["TestFramework1", "TestFramework2", "TestFramework3"].forEach { repo in
 					let urlPath = sourceRepoUrl.appendingPathComponent(repo).path
-					let _ = cloneOrFetchProject(.git(GitURL(urlPath)), preferHTTPS: false)
+					let _ = cloneOrFetch(dependency: .git(GitURL(urlPath)), preferHTTPS: false)
 						.wait()
 				}
 			}
@@ -239,7 +239,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			func cloneOrFetch(commitish: String? = nil) -> SignalProducer<(ProjectEvent?, URL), CarthageError> {
-				return cloneOrFetchProject(dependency, preferHTTPS: false, destinationURL: cacheDirectoryURL, commitish: commitish)
+				return CarthageKit.cloneOrFetch(dependency: dependency, preferHTTPS: false, destinationURL: cacheDirectoryURL, commitish: commitish)
 			}
 
 			func assertProjectEvent(commitish: String? = nil, clearFetchTime: Bool = true, action: @escaping (ProjectEvent?) -> ()) {

--- a/Source/CarthageKitTests/ResolverSpec.swift
+++ b/Source/CarthageKitTests/ResolverSpec.swift
@@ -61,8 +61,8 @@ private struct DB {
 		}
 	}
 	
-	func resolvedGitReference(_ project: Dependency, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {
-		if let version = references[project]?[reference] {
+	func resolvedGitReference(_ dependency: Dependency, reference: String) -> SignalProducer<PinnedVersion, CarthageError> {
+		if let version = references[dependency]?[reference] {
 			return .init(value: version)
 		} else {
 			return .empty

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -113,7 +113,7 @@ class XcodeSpec: QuickSpec {
 			let version = PinnedVersion("0.1")
 
 			for project in dependencies {
-				let result = buildDependencyProject(project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+				let result = build(dependency: project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
 					.flatten(.concat)
 					.ignoreTaskData()
 					.on(value: { (project, scheme) in
@@ -303,7 +303,7 @@ class XcodeSpec: QuickSpec {
 		it("should build for one platform") {
 			let dependency = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
-			let result = buildDependencyProject(dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
+			let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { (project, scheme) in
@@ -325,7 +325,7 @@ class XcodeSpec: QuickSpec {
 		it("should build for multiple platforms") {
 			let dependency = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
-			let result = buildDependencyProject(dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
+			let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { (project, scheme) in
@@ -373,7 +373,7 @@ class XcodeSpec: QuickSpec {
 			let buildURL = directoryURL.appendingPathComponent(CarthageBinariesFolderPath)
 			let dependencyBuildURL = dependencyURL.appendingPathComponent(CarthageBinariesFolderPath)
 
-			let result = buildDependencyProject(dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { (project, scheme) in

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -112,8 +112,8 @@ class XcodeSpec: QuickSpec {
 			]
 			let version = PinnedVersion("0.1")
 
-			for project in dependencies {
-				let result = build(dependency: project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			for dependency in dependencies {
+				let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
 					.flatten(.concat)
 					.ignoreTaskData()
 					.on(value: { (project, scheme) in
@@ -134,10 +134,10 @@ class XcodeSpec: QuickSpec {
 			expect(result.error).to(beNil())
 
 			// Verify that the build products exist at the top level.
-			var projectNames = dependencies.map { project in project.name }
-			projectNames.append("ReactiveCocoaLayout")
+			var dependencyNames = dependencies.map { dependency in dependency.name }
+			dependencyNames.append("ReactiveCocoaLayout")
 
-			for dependency in projectNames {
+			for dependency in dependencyNames {
 				let macPath = buildFolderURL.appendingPathComponent("Mac/\(dependency).framework").path
 				let macdSYMPath = (macPath as NSString).appendingPathExtension("dSYM")!
 				let iOSPath = buildFolderURL.appendingPathComponent("iOS/\(dependency).framework").path

--- a/Source/CarthageKitTests/XcodeSpec.swift
+++ b/Source/CarthageKitTests/XcodeSpec.swift
@@ -301,9 +301,9 @@ class XcodeSpec: QuickSpec {
 		}
 
 		it("should build for one platform") {
-			let project = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
+			let dependency = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
-			let result = buildDependencyProject(project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
+			let result = buildDependencyProject(dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { (project, scheme) in
@@ -314,18 +314,18 @@ class XcodeSpec: QuickSpec {
 			expect(result.error).to(beNil())
 
 			// Verify that the build product exists at the top level.
-			let path = buildFolderURL.appendingPathComponent("Mac/\(project.name).framework").path
+			let path = buildFolderURL.appendingPathComponent("Mac/\(dependency.name).framework").path
 			expect(path).to(beExistingDirectory())
 
 			// Verify that the other platform wasn't built.
-			let incorrectPath = buildFolderURL.appendingPathComponent("iOS/\(project.name).framework").path
+			let incorrectPath = buildFolderURL.appendingPathComponent("iOS/\(dependency.name).framework").path
 			expect(FileManager.default.fileExists(atPath: incorrectPath, isDirectory: nil)) == false
 		}
 
 		it("should build for multiple platforms") {
-			let project = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
+			let dependency = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
-			let result = buildDependencyProject(project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
+			let result = buildDependencyProject(dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { (project, scheme) in
@@ -337,8 +337,8 @@ class XcodeSpec: QuickSpec {
 
 			// Verify that the build products of all specified platforms exist 
 			// at the top level.
-			let macPath = buildFolderURL.appendingPathComponent("Mac/\(project.name).framework").path
-			let iosPath = buildFolderURL.appendingPathComponent("iOS/\(project.name).framework").path
+			let macPath = buildFolderURL.appendingPathComponent("Mac/\(dependency.name).framework").path
+			let iosPath = buildFolderURL.appendingPathComponent("iOS/\(dependency.name).framework").path
 
 			for path in [ macPath, iosPath ] {
 				expect(path).to(beExistingDirectory())
@@ -365,15 +365,15 @@ class XcodeSpec: QuickSpec {
 		}
 
 		it("should symlink the build directory") {
-			let project = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
+			let dependency = Dependency.gitHub(Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
 
-			let dependencyURL =	directoryURL.appendingPathComponent(project.relativePath)
+			let dependencyURL =	directoryURL.appendingPathComponent(dependency.relativePath)
 			// Build
 			let buildURL = directoryURL.appendingPathComponent(CarthageBinariesFolderPath)
 			let dependencyBuildURL = dependencyURL.appendingPathComponent(CarthageBinariesFolderPath)
 
-			let result = buildDependencyProject(project, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildDependencyProject(dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
 				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { (project, scheme) in

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -102,38 +102,38 @@ internal struct ProjectEventSink {
 		let formatting = colorOptions.formatting
 		
 		switch event {
-		case let .cloning(project):
-			carthage.println(formatting.bullets + "Cloning " + formatting.projectName(project.name))
+		case let .cloning(dependency):
+			carthage.println(formatting.bullets + "Cloning " + formatting.projectName(dependency.name))
 
-		case let .fetching(project):
-			carthage.println(formatting.bullets + "Fetching " + formatting.projectName(project.name))
+		case let .fetching(dependency):
+			carthage.println(formatting.bullets + "Fetching " + formatting.projectName(dependency.name))
 
-		case let .checkingOut(project, revision):
-			carthage.println(formatting.bullets + "Checking out " + formatting.projectName(project.name) + " at " + formatting.quote(revision))
+		case let .checkingOut(dependency, revision):
+			carthage.println(formatting.bullets + "Checking out " + formatting.projectName(dependency.name) + " at " + formatting.quote(revision))
 
-		case let .downloadingBinaryFrameworkDefinition(project, url):
-			carthage.println(formatting.bullets + "Downloading binary-only framework " + formatting.projectName(project.name) + " at " + formatting.quote(url.absoluteString))
+		case let .downloadingBinaryFrameworkDefinition(dependency, url):
+			carthage.println(formatting.bullets + "Downloading binary-only framework " + formatting.projectName(dependency.name) + " at " + formatting.quote(url.absoluteString))
 
-		case let .downloadingBinaries(project, release):
-			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(project.name) + ".framework binary at " + formatting.quote(release))
+		case let .downloadingBinaries(dependency, release):
+			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(dependency.name) + ".framework binary at " + formatting.quote(release))
 
-		case let .skippedDownloadingBinaries(project, message):
-			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(project.name) + ".framework binary due to the error:\n\t" + formatting.quote(message))
+		case let .skippedDownloadingBinaries(dependency, message):
+			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(dependency.name) + ".framework binary due to the error:\n\t" + formatting.quote(message))
 
-		case let .skippedInstallingBinaries(project, error):
-			carthage.println(formatting.bullets + "Skipped installing " + formatting.projectName(project.name) + ".framework binary due to the error:\n\t" + formatting.quote(String(describing: error)))
+		case let .skippedInstallingBinaries(dependency, error):
+			carthage.println(formatting.bullets + "Skipped installing " + formatting.projectName(dependency.name) + ".framework binary due to the error:\n\t" + formatting.quote(String(describing: error)))
 
-		case let .skippedBuilding(project, message):
-			carthage.println(formatting.bullets + "Skipped building " + formatting.projectName(project.name) + " due to the error:\n" + message)
+		case let .skippedBuilding(dependency, message):
+			carthage.println(formatting.bullets + "Skipped building " + formatting.projectName(dependency.name) + " due to the error:\n" + message)
 
-		case let .skippedBuildingCached(project):
-			carthage.println(formatting.bullets + "Valid cache found for " + formatting.projectName(project.name) + ", skipping build")
+		case let .skippedBuildingCached(dependency):
+			carthage.println(formatting.bullets + "Valid cache found for " + formatting.projectName(dependency.name) + ", skipping build")
 
-		case let .rebuildingCached(project):
-			carthage.println(formatting.bullets + "Invalid cache found for " + formatting.projectName(project.name) + ", rebuilding with all downstream dependencies")
+		case let .rebuildingCached(dependency):
+			carthage.println(formatting.bullets + "Invalid cache found for " + formatting.projectName(dependency.name) + ", rebuilding with all downstream dependencies")
 
-		case let .buildingUncached(project):
-			carthage.println(formatting.bullets + "No cache found for " + formatting.projectName(project.name) + ", building with all downstream dependencies")
+		case let .buildingUncached(dependency):
+			carthage.println(formatting.bullets + "No cache found for " + formatting.projectName(dependency.name) + ", building with all downstream dependencies")
 		}
 	}
 }

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -37,7 +37,7 @@ public struct FetchCommand: CommandProtocol {
 		let dependency = Dependency.git(options.repositoryURL)
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
 
-		return cloneOrFetchProject(dependency, preferHTTPS: true)
+		return cloneOrFetch(dependency: dependency, preferHTTPS: true)
 			.on(value: { event, _ in
 				if let event = event {
 					eventSink.put(event)

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -34,10 +34,10 @@ public struct FetchCommand: CommandProtocol {
 	public let function = "Clones or fetches a Git repository ahead of time"
 
 	public func run(_ options: Options) -> Result<(), CarthageError> {
-		let project = Dependency.git(options.repositoryURL)
+		let dependency = Dependency.git(options.repositoryURL)
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
 
-		return cloneOrFetchProject(project, preferHTTPS: true)
+		return cloneOrFetchProject(dependency, preferHTTPS: true)
 			.on(value: { event, _ in
 				if let event = event {
 					eventSink.put(event)


### PR DESCRIPTION
A follow-up for #1915.