### PR TITLE
[Cartfile] Remove unnecessary CustomStringConvertible conformance

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -121,12 +121,6 @@ public struct Cartfile {
 	}
 }
 
-extension Cartfile: CustomStringConvertible {
-	public var description: String {
-		return dependencies.description
-	}
-}
-
 /// Returns an array containing dependencies that are listed in both arguments.
 public func duplicateDependenciesIn(_ cartfile1: Cartfile, _ cartfile2: Cartfile) -> [Dependency] {
 	let projects1 = cartfile1.dependencies.keys


### PR DESCRIPTION
If we should preserve this, we should update the implementation to be consistent with `ResolvedCartfile` instead.