### PR TITLE
Reduce unnecessary calls of `gitRootDirectoryForRepository` in `submodulesInRepository`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
       language: objective-c
       osx_image: xcode8.2
       script:
-        - brew update
         - brew uninstall carthage
         - brew install bats
         - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       osx_image: xcode8.2
       script:
         - brew uninstall carthage
-        - brew install bats
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install bats
         - make install
         - bats Source/CarthageIntegration
       env:

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -466,7 +466,14 @@ public func gitRootDirectoryForRepository(_ repositoryFileURL: URL) -> SignalPro
 /// Returns each submodule found in the given repository revision, or an empty
 /// signal if none exist.
 public func submodulesInRepository(_ repositoryFileURL: URL, revision: String = "HEAD") -> SignalProducer<Submodule, CarthageError> {
-	return gitRootDirectoryForRepository(repositoryFileURL)
+	return isGitRepository(repositoryFileURL)
+		.flatMap(.concat) { isRepository -> SignalProducer<URL, CarthageError> in
+			guard isRepository else {
+				return .empty
+			}
+
+			return gitRootDirectoryForRepository(repositoryFileURL)
+		}
 		.flatMap(.concat) { actualRepoURL in
 			return gitmodulesEntriesInRepository(repositoryFileURL, revision: revision)
 				.flatMap(.concat) { name, path, url in

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -466,13 +466,13 @@ public func gitRootDirectoryForRepository(_ repositoryFileURL: URL) -> SignalPro
 /// Returns each submodule found in the given repository revision, or an empty
 /// signal if none exist.
 public func submodulesInRepository(_ repositoryFileURL: URL, revision: String = "HEAD") -> SignalProducer<Submodule, CarthageError> {
-	return gitmodulesEntriesInRepository(repositoryFileURL, revision: revision)
-		.flatMap(.concat) { name, path, url in
-			return gitRootDirectoryForRepository(repositoryFileURL)
-				.flatMap(.concat) { actualRepoURL in
+	return gitRootDirectoryForRepository(repositoryFileURL)
+		.flatMap(.concat) { actualRepoURL in
+			return gitmodulesEntriesInRepository(repositoryFileURL, revision: revision)
+				.flatMap(.concat) { name, path, url in
 					return submoduleSHAForPath(actualRepoURL, path, revision: revision)
 						.map { sha in Submodule(name: name, path: path, url: url, sha: sha) }
-			}
+				}
 		}
 }
 


### PR DESCRIPTION
There should be no need to call it for each entry of `.gitmodules`.