### PR TITLE
Check swift compiler

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -46,7 +46,7 @@ private func compilerVersionArguments(usingToolchain toolchain: String?) -> [Str
 private func parseSwiftVersionCommand(output: String?) -> String? {
 	guard
 		let output = output,
-		let regex = try? NSRegularExpression(pattern: "Apple Swift version (.+) \\(", options: []),
+		let regex = try? NSRegularExpression(pattern: "Apple Swift version .+ \\((.*)\\)", options: []),
 		let matchRange = regex.firstMatch(in: output, options: [], range: NSRange(location: 0, length: output.characters.count))?.rangeAt(1)
 		else {
 			return nil

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -136,7 +136,7 @@ class ProjectSpec: QuickSpec {
 					let result1 = buildDependencyTest(platforms: [.macOS])
 					expect(result1).to(equal(expected))
 					
-					overwriteSwiftVersion("TestFramework3", forPlatformName: "Mac", inDirectory: buildDirectoryURL, withVersion: "1.0")
+					overwriteSwiftVersion("TestFramework3", forPlatformName: "Mac", inDirectory: buildDirectoryURL, withVersion: "swiftlang-000.0.1 clang-000.0.0.1")
 
 					let result2 = buildDependencyTest(platforms: [.macOS])
 					expect(result2).to(equal(expected))

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -82,7 +82,7 @@ class XcodeSpec: QuickSpec {
 				let result = checkSwiftFrameworkCompatibility(frameworkURL, usingToolchain: nil).single()
 
 				expect(result?.value).to(beNil())
-				expect(result?.error) == .incompatibleFrameworkSwiftVersions(local: currentSwiftVersion ?? "", framework: "0.0.0")
+				expect(result?.error) == .incompatibleFrameworkSwiftVersions(local: currentSwiftVersion ?? "", framework: "swiftlang-800.0.63 clang-800.0.42.1")
 			}
 		}
 


### PR DESCRIPTION
Fixes #1983 

Instead of using the language version from the swift version string, use the compiler version. That way binary compatible but different SWIFT_VERSION builds will still properly cache / be considered compatible. 