### PR TITLE
Exclude specific schemes via Cartfile.ignore

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		A1411ED61EFC1BFD0060461F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1411ED51EFC1BFD0060461F /* Constants.swift */; };
 		A940B2F520C0363F001C4C59 /* CartfileCommentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */; };
 		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
+		A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A199B91B1EF2557300AE5933 /* Ignorefile.swift */; };
 		B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */; };
 		B1F27D401E4541A1002D4754 /* TestVersionFile in Resources */ = {isa = PBXBuildFile; fileRef = B1F27D3F1E4541A1002D4754 /* TestVersionFile */; };
 		BE02925B1E40363B004FB579 /* XCDBLD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE02925A1E40363B004FB579 /* XCDBLD.framework */; };
@@ -210,6 +211,7 @@
 		A14BB69B1EFA36B90077ABF4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = SOURCE_ROOT; };
 		A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartfileCommentsSpec.swift; sourceTree = "<group>"; };
 		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
+		A199B91B1EF2557300AE5933 /* Ignorefile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ignorefile.swift; sourceTree = "<group>"; };
 		B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionFileSpec.swift; sourceTree = "<group>"; };
 		B1F27D3F1E4541A1002D4754 /* TestVersionFile */ = {isa = PBXFileReference; explicitFileType = text.json; fileEncoding = 4; path = TestVersionFile; sourceTree = "<group>"; };
 		BE0292481E403355004FB579 /* XCDBLDExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCDBLDExtensions.swift; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 				88ED56D519ECE34900CBF5C4 /* Git.swift */,
 				D0D1219119E88B8F005E4BAA /* GitHub.swift */,
 				CD43D9DD1F43074000CD60F6 /* GitURL.swift */,
+				A199B91B1EF2557300AE5933 /* Ignorefile.swift */,
 				D0A2025D1B114D1000C71375 /* ProducerQueue.swift */,
 				CD28C99C1E11846200322AF7 /* ProductType.swift */,
 				F603929819EA29F80050A6AF /* Project.swift */,
@@ -846,6 +849,7 @@
 				D0DE89441A0F2D9B0030A3EC /* Scannable.swift in Sources */,
 				F162F3421D63D8A900809D7E /* VersionFile.swift in Sources */,
 				CDD7CF791F75ED88000E0EA5 /* Dependency.swift in Sources */,
+				A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */,
 				BF7A1A0B1E3A7AE9008CBCC5 /* BinaryProject.swift in Sources */,
 				D01D82D71A10160700F0DD94 /* Resolver.swift in Sources */,
 				CDB099241E6DC2D40030B4A8 /* ScannableError.swift in Sources */,

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		90CDE7BE2003252C00D98F37 /* FakeOSSSwift.framework in Resources */ = {isa = PBXBuildFile; fileRef = 90CDE7BC2003249C00D98F37 /* FakeOSSSwift.framework */; };
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
+		A12397B91F2AB3A600A4370F /* TestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = A12397B71F2AB24900A4370F /* TestCartfile.ignore */; };
 		A1411ED61EFC1BFD0060461F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1411ED51EFC1BFD0060461F /* Constants.swift */; };
 		A940B2F520C0363F001C4C59 /* CartfileCommentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */; };
 		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
@@ -207,6 +208,7 @@
 		90CDE7BC2003249C00D98F37 /* FakeOSSSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FakeOSSSwift.framework; sourceTree = "<group>"; };
 		98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-bash-completion"; sourceTree = "<group>"; };
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
+		A12397B71F2AB24900A4370F /* TestCartfile.ignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestCartfile.ignore; sourceTree = "<group>"; };
 		A1411ED51EFC1BFD0060461F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A14BB69B1EFA36B90077ABF4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = SOURCE_ROOT; };
 		A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartfileCommentsSpec.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 				90CDE7BC2003249C00D98F37 /* FakeOSSSwift.framework */,
 				CD09E2881F0E3F1400A0378A /* FakeSwift.framework */,
 				D0AAAB5419FB1062007B24B3 /* TestCartfile */,
+				A12397B71F2AB24900A4370F /* TestCartfile.ignore */,
 				D0F551DB1A0D71AB0093311F /* TestCartfile.resolved */,
 				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
 				B1F27D3F1E4541A1002D4754 /* TestVersionFile */,
@@ -751,6 +754,7 @@
 				CD9A77991EDD7E2000A77B00 /* DuplicateDependencies in Resources */,
 				D0C6E5761A57042100A5E3E7 /* CartfilePrivateOnly.zip in Resources */,
 				CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */,
+				A12397B91F2AB3A600A4370F /* TestCartfile.ignore in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06F5F0AD208C493200D528CD /* DependencyTestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = 06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */; };
+		06F5F0AE208C494A00D528CD /* DependencyTestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = 06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */; };
 		0FDFEA7E2055D638008862E3 /* ProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFEA7D2055D638008862E3 /* ProxyTests.swift */; };
 		0FDFEA802055FACE008862E3 /* Proxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFEA7F2055FACE008862E3 /* Proxy.swift */; };
 		2190FA981FD5B2F0008D8A79 /* OutdatedDependencies in Resources */ = {isa = PBXBuildFile; fileRef = 2190FA961FD5B05F008D8A79 /* OutdatedDependencies */; };
@@ -40,6 +42,7 @@
 		A940B2F520C0363F001C4C59 /* CartfileCommentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */; };
 		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
 		A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A199B91B1EF2557300AE5933 /* Ignorefile.swift */; };
+		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
 		B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */; };
 		B1F27D401E4541A1002D4754 /* TestVersionFile in Resources */ = {isa = PBXBuildFile; fileRef = B1F27D3F1E4541A1002D4754 /* TestVersionFile */; };
 		BE02925B1E40363B004FB579 /* XCDBLD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE02925A1E40363B004FB579 /* XCDBLD.framework */; };
@@ -179,6 +182,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = DependencyTestCartfile.ignore; sourceTree = "<group>"; };
 		0FDFEA7D2055D638008862E3 /* ProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyTests.swift; sourceTree = "<group>"; };
 		0FDFEA7F2055FACE008862E3 /* Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proxy.swift; sourceTree = "<group>"; };
 		2190FA961FD5B05F008D8A79 /* OutdatedDependencies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = OutdatedDependencies; sourceTree = "<group>"; };
@@ -214,6 +218,7 @@
 		A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartfileCommentsSpec.swift; sourceTree = "<group>"; };
 		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
 		A199B91B1EF2557300AE5933 /* Ignorefile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ignorefile.swift; sourceTree = "<group>"; };
+		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
 		B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionFileSpec.swift; sourceTree = "<group>"; };
 		B1F27D3F1E4541A1002D4754 /* TestVersionFile */ = {isa = PBXFileReference; explicitFileType = text.json; fileEncoding = 4; path = TestVersionFile; sourceTree = "<group>"; };
 		BE0292481E403355004FB579 /* XCDBLDExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCDBLDExtensions.swift; sourceTree = "<group>"; };
@@ -388,6 +393,7 @@
 				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
 				B1F27D3F1E4541A1002D4754 /* TestVersionFile */,
 				BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */,
+				06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -740,6 +746,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06F5F0AE208C494A00D528CD /* DependencyTestCartfile.ignore in Resources */,
 				8AC381451FC3AAE4007CF7E8 /* Alamofire.framework in Resources */,
 				CD9A779B1EDD7FEB00A77B00 /* BinaryOnly in Resources */,
 				3B19041E1E4CFE4A00A866AD /* FakeOldObjc.framework in Resources */,
@@ -762,6 +769,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06F5F0AD208C493200D528CD /* DependencyTestCartfile.ignore in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -228,6 +228,25 @@ By default Carthage will rebuild a dependency regardless of whether it's the sam
 
 Note: At this time `--cache-builds` is incompatible with `--use-submodules`. Using both will result in working copy and committed changes to your submodule dependency not being correctly rebuilt. See [#1785](https://github.com/Carthage/Carthage/issues/1785) for details.
 
+### Skip building schemes
+
+By default Carthage will build all shared schemes of a dependency. In some cases, framework authors might opt for using one repository for multiple different frameworks to be able to share code between them without much effort. In order to enhance build time, you can skip all schemes you don't need by creating a `Cartfile.ignore` in the same folder as your `Cartfile` with entries following this structure:
+
+```
+# Ignore unnecessary schemes in framework X
+scheme "NameOfSchemeToSkip-iOS"
+scheme "NameOfSchemeToSkip-macOS"
+```
+
+Carthage will then ignore the scheme when building your dependencies, it will still continue to check them out though. Note that comments can be added to structure the `Cartfile.ignore` by preceding a line with `#` just like in the `Cartfile`.
+
+In the rare case a dependency contains multiple projects with the same schemes names, you can also specify the exact project name like so:
+
+```
+scheme "ProjectName/NameOfSchemeToSkip-iOS"
+scheme "ProjectName/NameOfSchemeToSkip-macOS"
+```
+
 ### Bash/Zsh/Fish completion
 
 Auto completion of Carthage commands and options are available as documented in [Bash/Zsh/Fish Completion][Bash/Zsh/Fish Completion].

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -92,6 +92,9 @@ public struct Constants {
 		/// The relative path to a project's Cartfile.resolved.
 		public static let resolvedCartfilePath = "Cartfile.resolved"
 
+		/// The relative path to a project's Cartfile.ignore.
+		public static let ignoreCartfilePath = "Cartfile.ignore"
+
 		/// The text that needs to exist in a GitHub Release asset's name, for it to be
 		/// tried as a binary framework.
 		public static let binaryAssetPattern = ".framework"

--- a/Source/CarthageKit/Ignorefile.swift
+++ b/Source/CarthageKit/Ignorefile.swift
@@ -74,6 +74,11 @@ public struct Ignorefile {
 public struct IgnoreEntry {
 	public let project: String?
 	public let scheme: String
+
+	public init(project: String?, scheme: String) {
+		self.project = project
+		self.scheme = scheme
+	}
 }
 
 extension IgnoreEntry: Comparable {

--- a/Source/CarthageKit/Ignorefile.swift
+++ b/Source/CarthageKit/Ignorefile.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Result
+
+/// Represents a Cartfile.ignore, which is a specification of what projects
+/// and schemes should be ignored and therefore excluded from update/boostrap.
+public struct Ignorefile {
+	/// The project names listed in the Cartfile.ignore.
+	public var projects: [IgnoreEntry]
+
+	/// The scheme names listed in the Cartfile.ignore.
+	public var schemes: [IgnoreEntry]
+
+	/// Returns the location where Cartfile.ignore should exist within the
+	/// given directory.
+	public static func url(in directoryURL: URL) -> URL {
+		return directoryURL.appendingPathComponent("Cartfile.ignore")
+	}
+
+	/// Attempts to parse Cartfile.ignore information from a string.
+	public static func from(string: String) -> Result<Ignorefile, CarthageError> {
+		var projects: [IgnoreEntry] = []
+		var schemes: [IgnoreEntry] = []
+		var result: Result<(), CarthageError> = .success(())
+
+		let commentIndicator = "#"
+		string.enumerateLines { line, stop in
+			let scanner = Scanner(string: line)
+
+			if scanner.scanString(commentIndicator, into: nil) {
+				// Skip the rest of the line.
+				return
+			}
+
+			if scanner.isAtEnd {
+				// The line was all whitespace.
+				return
+			}
+
+			switch IgnoreEntry.from(scanner) {
+			case let .success(ignoreEntry):
+				switch ignoreEntry {
+				case .project:
+					projects.append(ignoreEntry)
+
+				case .scheme:
+					schemes.append(ignoreEntry)
+				}
+
+			case let .failure(error):
+				result = .failure(CarthageError(scannableError: error))
+				stop = true
+				return
+			}
+
+			if scanner.scanString(commentIndicator, into: nil) {
+				// Skip the rest of the line.
+				return
+			}
+
+			if !scanner.isAtEnd {
+				result = .failure(CarthageError.parseError(description: "unexpected trailing characters in line: \(line)"))
+				stop = true
+			}
+		}
+
+		return result.flatMap { _ in
+			return .success(Ignorefile(projects: projects, schemes: schemes))
+		}
+	}
+
+	/// Attempts to parse a Ignorefile from a file at a given URL.
+	public static func from(file ignorefileURL: URL) -> Result<Ignorefile, CarthageError> {
+		do {
+			let ignorefileContents = try String(contentsOf: ignorefileURL, encoding: .utf8)
+			return Ignorefile
+				.from(string: ignorefileContents)
+		} catch let error as NSError {
+			return .failure(CarthageError.readFailed(ignorefileURL, error))
+		}
+	}
+}
+
+/// Uniquely identifies an ignore entry that can be used for ignores.
+public enum IgnoreEntry {
+	/// A project to be ignored.
+	case project(String)
+
+	/// A scheme to be ignored.
+	case scheme(String)
+}
+
+extension IgnoreEntry: Comparable {
+	public static func == (_ lhs: IgnoreEntry, _ rhs: IgnoreEntry) -> Bool {
+		switch (lhs, rhs) {
+		case let (.project(left), .project(right)), let (.scheme(left), .scheme(right)),
+		     let (.project(left), .scheme(right)), let (.scheme(left), .project(right)):
+			return left.caseInsensitiveCompare(right) == .orderedSame
+		}
+	}
+
+	public static func < (_ lhs: IgnoreEntry, _ rhs: IgnoreEntry) -> Bool {
+		switch (lhs, rhs) {
+		case let (.project(left), .project(right)), let (.scheme(left), .scheme(right)),
+		     let (.project(left), .scheme(right)), let (.scheme(left), .project(right)):
+			return left.caseInsensitiveCompare(right) == .orderedAscending
+		}
+	}
+}
+
+extension IgnoreEntry: Hashable {
+	public var hashValue: Int {
+		switch self {
+		case let .project(name), let .scheme(name):
+			return name.hashValue
+		}
+	}
+}
+
+extension IgnoreEntry: Scannable {
+	/// Attempts to parse an IgnoreEntry.
+	public static func from(_ scanner: Scanner) -> Result<IgnoreEntry, ScannableError> {
+		let parser: (String) -> Result<IgnoreEntry, ScannableError>
+
+		if scanner.scanString("project", into: nil) {
+			parser = { name in
+				return .success(IgnoreEntry.project(name))
+			}
+		} else if scanner.scanString("scheme", into: nil) {
+			parser = { name in
+				return .success(IgnoreEntry.scheme(name))
+			}
+		} else {
+			return .failure(ScannableError(message: "unexpected ignore entry type", currentLine: scanner.currentLine))
+		}
+
+		if !scanner.scanString("\"", into: nil) {
+			return .failure(ScannableError(message: "expected string after ignore entry type", currentLine: scanner.currentLine))
+		}
+
+		var name: NSString?
+		if !scanner.scanUpTo("\"", into: &name) || !scanner.scanString("\"", into: nil) {
+			return .failure(ScannableError(message: "empty or unterminated string after ignore entry type", currentLine: scanner.currentLine))
+		}
+
+		if let name = name {
+			return parser(name as String)
+		} else {
+			return .failure(ScannableError(message: "empty string after dependency type", currentLine: scanner.currentLine))
+		}
+	}
+}
+
+extension IgnoreEntry: CustomStringConvertible {
+	public var description: String {
+		switch self {
+		case let .project(name):
+			return "project \"\(name)\""
+
+		case let .scheme(name):
+			return "scheme \"\(name)\""
+		}
+	}
+}

--- a/Source/CarthageKit/Ignorefile.swift
+++ b/Source/CarthageKit/Ignorefile.swift
@@ -112,15 +112,21 @@ extension IgnoreEntry: Scannable {
 
 		if scanner.scanString("scheme", into: nil) {
 			parser = { name in
-				let ignoreEntry: IgnoreEntry = {
+				let ignoreEntryOptional: IgnoreEntry? = {
 					let nameComponents = name.components(separatedBy: "/")
-					if nameComponents.count == 1 {
+					switch nameComponents.count {
+					case 1:
 						return IgnoreEntry(project: nil, scheme: nameComponents[0])
-					} else {
+					case 2:
 						return IgnoreEntry(project: nameComponents.first!, scheme: nameComponents.last!)
+					default:
+						return nil
 					}
 				}()
 
+				guard let ignoreEntry = ignoreEntryOptional else {
+					return .failure(ScannableError(message: "invalid scheme declaration – allowed format: '(<project>/)?<scheme>", currentLine: scanner.currentLine))
+				}
 				return .success(ignoreEntry)
 			}
 		} else {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -94,6 +94,11 @@ public final class Project { // swiftlint:disable:this type_body_length
 		return directoryURL.appendingPathComponent(Constants.Project.resolvedCartfilePath, isDirectory: false)
 	}
 
+	/// The file URL to the project's Cartfile.ignore.
+	public var ignorefileURL: URL {
+		return directoryURL.appendingPathComponent(Constants.Project.ignoreCartfilePath, isDirectory: false)
+	}
+
 	/// Whether to prefer HTTPS for cloning (vs. SSH).
 	public var preferHTTPS = true
 
@@ -195,6 +200,18 @@ public final class Project { // swiftlint:disable:this type_body_length
 			Result(attempt: { try String(contentsOf: self.resolvedCartfileURL, encoding: .utf8) })
 				.mapError { .readFailed(self.resolvedCartfileURL, $0) }
 				.flatMap(ResolvedCartfile.from)
+		}
+	}
+
+	/// Reads the project's Cartfile.ignore.
+	public func loadIgnorefile() -> SignalProducer<Ignorefile, CarthageError> {
+		return SignalProducer.attempt {
+			do {
+				let ignorefileContents = try String(contentsOf: self.ignorefileURL, encoding: .utf8)
+				return Ignorefile.from(string: ignorefileContents)
+			} catch let error as NSError {
+				return .failure(.readFailed(self.ignorefileURL, error))
+			}
 		}
 	}
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -205,13 +205,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 
 	/// Reads the project's Cartfile.ignore.
 	public func loadIgnorefile() -> SignalProducer<Ignorefile, CarthageError> {
-		return SignalProducer.attempt {
-			do {
-				let ignorefileContents = try String(contentsOf: self.ignorefileURL, encoding: .utf8)
-				return Ignorefile.from(string: ignorefileContents)
-			} catch let error as NSError {
-				return .failure(.readFailed(self.ignorefileURL, error))
-			}
+		return SignalProducer {
+			Result(attempt: { try String(contentsOf: self.ignorefileURL, encoding: .utf8) })
+				.mapError { .readFailed(self.ignorefileURL, $0) }
+				.flatMap(Ignorefile.from)
 		}
 	}
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -105,8 +105,9 @@ public func xcodebuildTask(_ task: String, _ buildArguments: BuildArguments) -> 
 public func buildableSchemesInDirectory( // swiftlint:disable:this function_body_length
 	_ directoryURL: URL,
 	withConfiguration configuration: String,
-	forPlatforms platforms: Set<Platform> = []
-) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> {
+	forPlatforms platforms: Set<Platform> = [],
+	ignoreEntries: [IgnoreEntry] = []
+) -> SignalProducer<(Scheme, ProjectLocator, Bool), CarthageError> {
 	precondition(directoryURL.isFileURL)
 	let locator = ProjectLocator
 			.locate(in: directoryURL)
@@ -129,19 +130,19 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 		// Allow dependencies which have no projects, not to error out with
 		// `.noSharedFrameworkSchemes`.
 		.filter { projects in !projects.isEmpty }
-		.flatMap(.merge) { (projects: [(ProjectLocator, [Scheme])]) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
-			return schemesInProjects(projects).flatten()
+		.flatMap(.merge) { (projects: [(ProjectLocator, [Scheme])]) -> SignalProducer<(Scheme, ProjectLocator, Bool), CarthageError> in
+			return schemesInProjects(projects, ignoreEntries: ignoreEntries).flatten()
 		}
-		.flatMap(.concurrent(limit: 4)) { scheme, project -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+		.flatMap(.concurrent(limit: 4)) { scheme, project, skip -> SignalProducer<(Scheme, ProjectLocator, Bool), CarthageError> in
 			/// Check whether we should the scheme by checking against the project. If we're building
 			/// from a workspace, then it might include additional targets that would trigger our
 			/// check.
 			let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
 			return shouldBuildScheme(buildArguments, platforms)
 				.filter { $0 }
-				.map { _ in (scheme, project) }
+				.map { _ in (scheme, project, skip) }
 		}
-		.flatMap(.concurrent(limit: 4)) { scheme, project -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+		.flatMap(.concurrent(limit: 4)) { scheme, project, skip -> SignalProducer<(Scheme, ProjectLocator, Bool), CarthageError> in
 			return locator
 				// This scheduler hop is required to avoid disallowed recursive signals.
 				// See https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2042.
@@ -163,10 +164,10 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 				// which the scheme is defined instead.
 				.concat(value: project)
 				.take(first: 1)
-				.map { project in (scheme, project) }
+				.map { project in (scheme, project, skip) }
 		}
 		.collect()
-		.flatMap(.merge) { (schemes: [(Scheme, ProjectLocator)]) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+		.flatMap(.merge) { (schemes: [(Scheme, ProjectLocator, Bool)]) -> SignalProducer<(Scheme, ProjectLocator, Bool), CarthageError> in
 			if !schemes.isEmpty {
 				return .init(schemes)
 			} else {
@@ -177,7 +178,7 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 
 /// Sends pairs of a scheme and a project, the scheme actually resides in
 /// the project.
-public func schemesInProjects(_ projects: [(ProjectLocator, [Scheme])]) -> SignalProducer<[(Scheme, ProjectLocator)], CarthageError> {
+public func schemesInProjects(_ projects: [(ProjectLocator, [Scheme])], ignoreEntries: [IgnoreEntry] = []) -> SignalProducer<[(Scheme, ProjectLocator, Bool)], CarthageError> {
 	return SignalProducer<(ProjectLocator, [Scheme]), CarthageError>(projects)
 		.map { (project: ProjectLocator, schemes: [Scheme]) in
 			// Only look for schemes that actually reside in the project
@@ -197,7 +198,15 @@ public func schemesInProjects(_ projects: [(ProjectLocator, [Scheme])]) -> Signa
 			}
 		}
 		.flatMap(.concat) { project, schemes in
-			return SignalProducer<(Scheme, ProjectLocator), CarthageError>(schemes.map { ($0, project) })
+			return SignalProducer<(Scheme, ProjectLocator, Bool), CarthageError>(schemes.map { scheme in
+				let skip = ignoreEntries.contains(where: { ignoreEntry -> Bool in
+					guard let projectName = ignoreEntry.project else {
+						return scheme.name == ignoreEntry.scheme
+					}
+					return project.name == projectName && scheme.name == ignoreEntry.scheme
+				})
+				return (scheme, project, skip)
+			})
 		}
 		.collect()
 }
@@ -752,7 +761,7 @@ public func createDebugInformation(_ builtProductURL: URL) -> SignalProducer<Tas
 ///
 /// A producer of this type will send the project and scheme name when building
 /// begins, then complete or error when building terminates.
-public typealias BuildSchemeProducer = SignalProducer<TaskEvent<(ProjectLocator, Scheme)>, CarthageError>
+public typealias BuildSchemeProducer = SignalProducer<TaskEvent<(ProjectLocator, Scheme, Bool)>, CarthageError>
 
 /// Attempts to build the dependency, then places its build product into the
 /// root directory given.
@@ -761,6 +770,7 @@ public typealias BuildSchemeProducer = SignalProducer<TaskEvent<(ProjectLocator,
 public func build(
 	dependency: Dependency,
 	version: PinnedVersion,
+	ignoreEntries: [IgnoreEntry],
 	_ rootDirectoryURL: URL,
 	withOptions options: BuildOptions,
 	sdkFilter: @escaping SDKFilterCallback = { sdks, _, _, _ in .success(sdks) }
@@ -768,7 +778,7 @@ public func build(
 	let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 	let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
 
-	return buildInDirectory(dependencyURL, withOptions: options, dependency: (dependency, version), rootDirectoryURL: rootDirectoryURL, sdkFilter: sdkFilter)
+	return buildInDirectory(dependencyURL, withOptions: options, dependency: (dependency, version, ignoreEntries), rootDirectoryURL: rootDirectoryURL, sdkFilter: sdkFilter)
 		.mapError { error in
 			switch (dependency, error) {
 			case let (_, .noSharedFrameworkSchemes(_, platforms)):
@@ -789,7 +799,7 @@ public func build(
 public func buildInDirectory( // swiftlint:disable:this function_body_length
 	_ directoryURL: URL,
 	withOptions options: BuildOptions,
-	dependency: (dependency: Dependency, version: PinnedVersion)? = nil,
+	dependency: (dependency: Dependency, version: PinnedVersion, ignoreEntries: [IgnoreEntry])? = nil,
 	rootDirectoryURL: URL,
 	sdkFilter: @escaping SDKFilterCallback = { sdks, _, _, _ in .success(sdks) }
 ) -> BuildSchemeProducer {
@@ -798,9 +808,16 @@ public func buildInDirectory( // swiftlint:disable:this function_body_length
 	return BuildSchemeProducer { observer, lifetime in
 		// Use SignalProducer.replayLazily to avoid enumerating the given directory
 		// multiple times.
-		buildableSchemesInDirectory(directoryURL, withConfiguration: options.configuration, forPlatforms: options.platforms)
-			.flatMap(.concat) { (scheme: Scheme, project: ProjectLocator) -> SignalProducer<TaskEvent<URL>, CarthageError> in
-				let initialValue = (project, scheme)
+		buildableSchemesInDirectory(directoryURL, withConfiguration: options.configuration, forPlatforms: options.platforms, ignoreEntries: dependency?.ignoreEntries ?? [])
+			.flatMap(.concat) { (scheme: Scheme, project: ProjectLocator, skip: Bool) -> SignalProducer<TaskEvent<URL>, CarthageError> in
+				let initialValue = (project, scheme, skip)
+
+				if skip {
+					return SignalProducer(value: TaskEvent.success(URL(string: ".")!))
+						.on(started: {
+						observer.send(value: .success(initialValue))
+					})
+				}
 
 				let wrappedSDKFilter: SDKFilterCallback = { sdks, scheme, configuration, project in
 					let filteredSDKs: [SDK]
@@ -846,8 +863,8 @@ public func buildInDirectory( // swiftlint:disable:this function_body_length
 			// Discard any Success values, since we want to
 			// use our initial value instead of waiting for
 			// completion.
-			.map { taskEvent -> TaskEvent<(ProjectLocator, Scheme)> in
-				let ignoredValue = (ProjectLocator.workspace(URL(string: ".")!), Scheme(""))
+			.map { taskEvent -> TaskEvent<(ProjectLocator, Scheme, Bool)> in
+				let ignoredValue = (ProjectLocator.workspace(URL(string: ".")!), Scheme(""), false)
 				return taskEvent.map { _ in ignoredValue }
 			}
 			.filter { taskEvent in

--- a/Source/XCDBLD/ProjectLocator.swift
+++ b/Source/XCDBLD/ProjectLocator.swift
@@ -29,6 +29,11 @@ public enum ProjectLocator {
 	public var level: Int {
 		return fileURL.pathComponents.count - 1
 	}
+
+	/// The name of the project or workspace.
+	public var name: String {
+		return fileURL.deletingPathExtension().lastPathComponent
+	}
 }
 
 extension ProjectLocator: Comparable {

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -55,7 +55,7 @@ public struct ArchiveCommand: CommandProtocol {
 		} else {
 			let directoryURL = URL(fileURLWithPath: options.directoryPath, isDirectory: true)
 			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release")
-				.flatMap(.merge) { scheme, project -> SignalProducer<BuildSettings, CarthageError> in
+				.flatMap(.merge) { scheme, project, _ -> SignalProducer<BuildSettings, CarthageError> in
 					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: "Release")
 					return BuildSettings.load(with: buildArguments)
 				}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -110,8 +110,12 @@ public struct BuildCommand: CommandProtocol {
 							case let .standardError(data):
 								stderrHandle.write(data)
 
-							case let .success(project, scheme):
-								carthage.println(formatting.bullets + "Building scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
+							case let .success(project, scheme, skip):
+								if skip {
+									carthage.println(formatting.bullets + "Ignoring scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
+								} else {
+									carthage.println(formatting.bullets + "Building scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
+								}
 							}
 						}
 					)

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -61,6 +61,21 @@ class CartfileSpec: QuickSpec {
 			]
 		}
 
+		it("should parse a Cartfile.ignore") {
+			let testCartfileURL = Bundle(for: type(of: self)).url(forResource: "TestCartfile", withExtension: "ignore")!
+			let testCartfile = try! String(contentsOf: testCartfileURL, encoding: .utf8)
+
+			let result = Ignorefile.from(string: testCartfile)
+			expect(result.error).to(beNil())
+
+			let ignorefile = result.value!
+			expect(ignorefile.ignoreEntries) == [
+				IgnoreEntry(project: nil, scheme: "RxMoya"), IgnoreEntry(project: nil, scheme: "RxSwift"),
+				IgnoreEntry(project: nil, scheme: "ReactiveMoya"), IgnoreEntry(project: nil, scheme: "ReactiveSwift"),
+				IgnoreEntry(project: "project", scheme: "scheme")
+			]
+		}
+
 		it("should detect duplicate dependencies in a single Cartfile") {
 			let testCartfileURL = Bundle(for: type(of: self)).url(forResource: "DuplicateDependenciesCartfile", withExtension: "")!
 			let testCartfile = try! String(contentsOf: testCartfileURL, encoding: .utf8)

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -23,10 +23,13 @@ class ProjectSpec: QuickSpec {
 				let project = Project(directoryURL: url)
 				let result = project.buildCheckedOutDependenciesWithOptions(BuildOptions(configuration: "Debug", platforms: platforms, cacheBuilds: cacheBuilds), dependenciesToBuild: dependenciesToBuild)
 					.ignoreTaskData()
-					.on(value: { project, scheme in
-						NSLog("Building scheme \"\(scheme)\" in \(project)")
-					})
-					.map { _, scheme in scheme }
+					.on(value: { project, scheme, skip in
+						if skip {
+							NSLog("Ignoring scheme \"\(scheme)\" in \(project)")
+						} else {
+							NSLog("Building scheme \"\(scheme)\" in \(project)")
+						}					})
+					.map { _, scheme, _ in scheme }
 					.collect()
 					.single()!
 				expect(result.error).to(beNil())

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -46,7 +46,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			func buildDependencyTestWithIgnored(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [(String, Bool)] {
-				return buildDependencies(platforms: platforms, cacheBuilds: cacheBuilds, dependenciesToBuild: dependenciesToBuild)
+				return build(directoryURL: directoryURL, platforms: platforms, cacheBuilds: cacheBuilds, dependenciesToBuild: dependenciesToBuild)
 			}
 
 			beforeEach {

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -46,7 +46,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			func buildDependencyTestWithIgnored(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [(String, Bool)] {
-				return buildDependencyies(platforms: platforms, cacheBuilds: cacheBuilds, dependenciesToBuild: dependenciesToBuild)
+				return buildDependencies(platforms: platforms, cacheBuilds: cacheBuilds, dependenciesToBuild: dependenciesToBuild)
 			}
 
 			beforeEach {

--- a/Tests/CarthageKitTests/Resources/DependencyTestCartfile.ignore
+++ b/Tests/CarthageKitTests/Resources/DependencyTestCartfile.ignore
@@ -1,0 +1,1 @@
+scheme "TestFramework1_iOS"

--- a/Tests/CarthageKitTests/Resources/TestCartfile.ignore
+++ b/Tests/CarthageKitTests/Resources/TestCartfile.ignore
@@ -1,0 +1,10 @@
+# Ignore RxSwift variant of Moya
+scheme "RxMoya"
+scheme "RxSwift"
+
+# Ignore ReactiveSwift variant of Moya
+scheme "ReactiveMoya"
+scheme "ReactiveSwift"
+
+# Ignore scheme within specific project
+scheme "project/scheme"

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -473,7 +473,7 @@ class XcodeSpec: QuickSpec {
 																				   platforms: [.iOS],
 																				   derivedDataPath: Constants.Dependency.derivedDataURL.appendingPathComponent("TestFramework-o2nfjkdsajhwenrjle").path), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
-				.on(value: { project, scheme in // swiftlint:disable:this end_closure
+				.on(value: { project, scheme, _ in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
 				})
 				.wait()
@@ -494,7 +494,7 @@ class XcodeSpec: QuickSpec {
 																					platforms: [.iOS],
 																					derivedDataPath: Constants.Dependency.derivedDataURL.appendingPathComponent("TestFramework-o2nfjkdsajhwenrjle").path), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
-				.on(value: { project, scheme in // swiftlint:disable:this end_closure
+				.on(value: { project, scheme, _ in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
 				})
 				.wait()


### PR DESCRIPTION
Closes #1227, #437 and maybe more.

### Goal

My **goal** ist to ensure that with a **Cartfile** that looks like this:

```
github "Moya/Moya"
```

Which would normally build `Moya`, `RxMoya`, `ReactiveMoya`, `Alamofire`, `Result`, `RxSwift` and `ReactiveSwift`. To introduce **a new file named `Cartfile.ignore`** with something like this content:

```
# Ignore RxSwift variant of Moya
scheme "RxMoya"
scheme "RxSwift"

# Ignore ReactiveSwift variant of Moya
scheme "ReactiveMoya"
scheme "ReactiveSwift"
```

Which leads to Carthage only building `Moya`, `Alamofire` and `Result`.

In detail the structure of the `Cartfile.ignore` is highly inspired by the structure of the current existing `Cartfile`. Instead keys like `github` and `git` the `.ignore` file should only support `scheme`.

### `scheme`

This is the first step I want to reach – to ensure all schemes with the name specified after a `scheme` entry within the `Cartfile.ignore` are not built when running Carthage tasks. Note that the user is being notified about this with something like `*** Ignoring scheme "RxMoya" in Moya.xcworkspace`.

> **UPDATE NOTE:** Originally I also had the suggestion to introduce a `project` keyword which would then even prevent from downloading the dependency. See the section "Where to go from here" below where I consider an alternative for that which can be added later on, in a subsequent PR.

---
Please also note, that since this change is purely additive, there should be no side effects whatsoever to any Carthage users who don't specifically create a `Cartfile.ignore` to use this feature.

## Use the Cartfile.ignore right now via Carthage-Pro

I created a fork of Carthage until this gets merged (which might take years) which includes this feature already. Please read [this comment](https://github.com/Carthage/Carthage/pull/1990#issuecomment-386763916) further below for additional details.

# Where to go from here
Here are a few "Next Steps" possible after this PR is merged to go further into this direction:
- [ ] Add the possibility to ignore a dependency even during dependency graph resolution by adding support for entries like `github "ReactiveCocoa/ReactiveSwift"`
- [ ] Consider the `Cartfile.ignore` in dependencies during dependency graph resolution so framework authors can improve the build time for their Carthage users without extra-work for them