### PR TITLE
copy-frameworks Output Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,24 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
     ```sh
-/usr/local/bin/carthage copy-frameworks
-```
+    /usr/local/bin/carthage copy-frameworks
+    ```
 
 1. Add the paths to the frameworks you want to use under “Input Files”, e.g.:
 
     ```
-$(SRCROOT)/Carthage/Build/iOS/Result.framework
-$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework
-$(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
-```
+    $(SRCROOT)/Carthage/Build/iOS/Result.framework
+    $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework
+    $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
+    ```
 
 1. Add the paths to the copied frameworks to the “Output Files”, e.g.:
 
     ```
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveCocoa.framework
-```
+    $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework
+    $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework
+    $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveCocoa.framework
+    ```
 
     With output files specified alongside the input files, Xcode only needs to run the script when the input files have changed or the output files are missing. This means dirty builds will be faster when you haven't rebuilt frameworks with Carthage.
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,20 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 1. Add the paths to the frameworks you want to use under “Input Files”, e.g.:
 
     ```
-$(SRCROOT)/Carthage/Build/iOS/Box.framework
 $(SRCROOT)/Carthage/Build/iOS/Result.framework
+$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
 ```
+
+1. Add the paths to the copied frameworks to the “Output Files”, e.g.:
+
+    ```
+$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework
+$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework
+$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveCocoa.framework
+```
+
+    With output files specified alongside the input files, Xcode only needs to run the script when the input files have changed or the output files are missing. This means dirty builds will be faster when you haven't rebuilt frameworks with Carthage.
 
 This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
 

--- a/README.md
+++ b/README.md
@@ -63,18 +63,19 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 1. On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop each framework you want to use from the [Carthage/Build][] folder on disk.
 1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
-  ```sh
-  /usr/local/bin/carthage copy-frameworks
-  ```
+    ```sh
+/usr/local/bin/carthage copy-frameworks
+```
 
-  and add the paths to the frameworks you want to use under “Input Files”, e.g.:
+    and add the paths to the frameworks you want to use under “Input Files”, e.g.:
 
-  ```
-  $(SRCROOT)/Carthage/Build/iOS/Box.framework
-  $(SRCROOT)/Carthage/Build/iOS/Result.framework
-  $(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
-  ```
-  This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
+    ```
+$(SRCROOT)/Carthage/Build/iOS/Box.framework
+$(SRCROOT)/Carthage/Build/iOS/Result.framework
+$(SRCROOT)/Carthage/Build/iOS/ReactiveCocoa.framework
+```
+
+This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
 
 With the debug information copied into the built products directory, Xcode will be able to symbolicate the stack trace whenever you stop at a breakpoint. This will also enable you to step through third-party code in the debugger.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 /usr/local/bin/carthage copy-frameworks
 ```
 
-    and add the paths to the frameworks you want to use under “Input Files”, e.g.:
+1. Add the paths to the frameworks you want to use under “Input Files”, e.g.:
 
     ```
 $(SRCROOT)/Carthage/Build/iOS/Box.framework


### PR DESCRIPTION
One of the things I learned at WWDC this year is that Xcode is smart about _Run Script_ build phases if you specify both input and output files. If the input files haven't changed and the output files exist, then Xcode doesn't need to run the script again—saving you time on dirty builds.

Projects using `carthage copy-frameworks` can use this to prevent unnecessary copying of frameworks during dirty builds. This should be a nice speed boost for some projects.

A couple caveats apply:

1. Although we copy `.framework`s, `.dsym`s, and `.bcsymbolmap`s, I've only specified the `.framework`s here. I think that should be enough—it's unlikely that the other files would be removed while the `.framework` still existed.

2. This path isn't the correct path for Archive builds—they're copied to a different directory. But I think that's acceptable—archive builds are rare and no worse off than before (because I think it should copy every time).