### PR TITLE
Fix checkout removal

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -586,9 +586,9 @@ public final class Project {
 						}
 						.flatMap(.concat) {
 							return self.unarchiveAndCopyBinaryFrameworks(zipFile: $0, projectName: dependency.name, commitish: revision, toolchain: toolchain)
-								.on(terminated: {
-									// We can receive the 'interrupted' event due to the 'take(first: 1)' below, so listen to 'terminated' to ensure we catch it
-									_ = try? FileManager.default.removeItem(at: checkoutDirectoryURL)
+								.on(value: { _ in
+									// Trash the checkouts folder when we've successfully copied binaries, to avoid building unnecessarily
+									_ = try? FileManager.default.trashItem(at: checkoutDirectoryURL, resultingItemURL: nil)
 								})
 						}
 						.flatMap(.concat) { self.removeItem(at: $0) }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -588,7 +588,7 @@ public final class Project {
 							return self.unarchiveAndCopyBinaryFrameworks(zipFile: $0, projectName: dependency.name, commitish: revision, toolchain: toolchain)
 								.on(terminated: {
 									// We can receive the 'interrupted' event due to the 'take(first: 1)' below, so listen to 'terminated' to ensure we catch it
-									_ = try? FileManager.default.trashItem(at: checkoutDirectoryURL, resultingItemURL: nil)
+									_ = try? FileManager.default.removeItem(at: checkoutDirectoryURL)
 								})
 						}
 						.flatMap(.concat) { self.removeItem(at: $0) }


### PR DESCRIPTION
Fixes #1969

Does a couple things
  *  Move the event listener for removing the checkout folder to within the binary unarchive flatMap. This ensures it only occurs after something is actually unarchived, and not for every checkout, regardless of binary status
  *  Listen for 'terminated' instead of 'completed', since the signal at this point in the operator chain will be interrupted by the later 'take' call. 
  *  Use `removeItem` instead of `trashItem`. This can easily be reverted, but I saw no reason for using the trash like this. It's generally expected that command line tools will be a little less forgiving on removal of things anyway, and this appeared to be the only place we used trash
