### PR TITLE
[WIP] Adding Git Output for Verbosity #630

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -47,6 +47,12 @@ public enum ProjectEvent {
 
 	/// Building an uncached project.
 	case buildingUncached(Dependency)
+
+	/// Launching a git task.
+	case launchingGitTask(Task)
+
+	/// Running a git task.
+	case runningGitTask(String)
 }
 
 extension ProjectEvent: Equatable {


### PR DESCRIPTION
This is a WIP because to fix #630 it will require a decent sized design change that I'd like to run by before actually starting any real work.

The main issue is the `launchGitTask` func in Git.swift of CarthageKit. It specifically calls the `ignoreTaskData` and only listens for the final success event fired from the ReactiveTask. In this MR, i was able to grab a hold of that data before we ignored and provided some rudimentary logging :p to just show that those events are the ones we'd want to end up logging.

I propose that we update launchGitTask to be a protocol/class (or a higher order func) so we can decorate the launching capabilities.

Then we'd have one launcher that actually creates the reactive task like the current implementation but we don't ignore the task data. One launcher that sits on top and will fire ProjectEvents from the project event observer, and another launcher on top of that that will ignoreTaskData and map the output to a string.

We'd then need to refactor the codebase to pass in the task launcher instead of just referring to it globally.

And then, once the project events are firing, we can easily just listen and output them if the verbose flag is set in the carthage project.

There other ways we could solve this, so @mdiep let me know what you think :).