### PR TITLE
cli-prog used old dylib from /Library/Frameworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
 	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
-	install_name_tool -add_rpath "@executable_path/../Frameworks/$(OUTPUT_FRAMEWORK)/Versions/Current/Frameworks/"  "$(PREFIX)/bin/carthage"
+	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks/$(OUTPUT_FRAMEWORK)/Versions/Current/Frameworks/"  "$(PREFIX)/bin/carthage"
 
 package: installables
 	pkgbuild \


### PR DESCRIPTION
'add_rpath' doesn't work as it adds new rpath to the end of rpaths list and program will use old dylib from /Library/Frameworks instead of prefix-dir. I have production version of Carthage and developed version in prefix dir.

If I made incompatibility changes in my own Carthage version and install it to prefix dir then

$./carthage build

dyld: lazy symbol binding failed: Symbol not found: __TIFV11CarthageKit12BuildOptionscFT13configurationSS9platformsGVs3SetO6XCDBLD8Platform_9toolchainGSqSS_15derivedDataPathGSqSS_11cacheBuildsSb6activeSb_S0_A4_
  Referenced from: /Users/yangand/Downloads/MyCarthage/bin/./carthage
  Expected in: /Library/Frameworks/CarthageKit.framework/CarthageKit

dyld: Symbol not found: __TIFV11CarthageKit12BuildOptionscFT13configurationSS9platformsGVs3SetO6XCDBLD8Platform_9toolchainGSqSS_15derivedDataPathGSqSS_11cacheBuildsSb6activeSb_S0_A4_
  Referenced from: /Users/yangand/Downloads/MyCarthage/bin/./carthage
  Expected in: /Library/Frameworks/CarthageKit.framework/CarthageKit

Abort trap: 6

Because carthage still uses /Library/Frameworks dylib because -add_rpath addes prefix dir to the end of list