### PR TITLE
[Makefile] Improve `prefix_install` rpath handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
 	rsync -a --delete "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
+	install_name_tool -delete_rpath "@executable_path/../Frameworks" "$(PREFIX)/bin/carthage" # Avoid duplication of "@executable_path/../Frameworks"
 	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks" "$(PREFIX)/bin/carthage"
 	install_name_tool -rpath "/Library/Frameworks/CarthageKit.framework/Versions/Current/Frameworks" "@executable_path/../Frameworks/CarthageKit.framework/Versions/Current/Frameworks" "$(PREFIX)/bin/carthage"
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ prefix_install: installables
 	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
 	rsync -a --delete "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
-	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks/$(OUTPUT_FRAMEWORK)/Versions/Current/Frameworks/"  "$(PREFIX)/bin/carthage"
+	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks" "$(PREFIX)/bin/carthage"
+	install_name_tool -rpath "/Library/Frameworks/CarthageKit.framework/Versions/Current/Frameworks" "@executable_path/../Frameworks/CarthageKit.framework/Versions/Current/Frameworks" "$(PREFIX)/bin/carthage"
 
 package: installables
 	pkgbuild \


### PR DESCRIPTION
Replaces both `/Library/Frameworks` and `/Library/Frameworks/CarthageKit.framework/Versions/Current/Frameworks`.

---

This is inspired by SwiftLint: https://github.com/realm/SwiftLint/blob/0.20.1/Makefile#L75-L76.

This complements #2055 and will fix #495.

/cc @norio-nomura 