### PR TITLE
[gardening] Avoid labeled if `break` in `Repository.fromIdentifier`.

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -53,14 +53,13 @@ extension Repository {
 		}
 
 		// GitHub Enterprise
-		breakpoint: if let url = URL(string: identifier), let host = url.host {
-			var pathComponents = url.pathComponents.filter { $0 != "/" }
-			guard pathComponents.count >= 2 else { break breakpoint }
-
-			// Consider that the instance might be in subdirectories.
-			let name = pathComponents.removeLast()
-			let owner = pathComponents.removeLast()
-
+		if
+			let url = URL(string: identifier),
+			let host = url.host,
+			case var pathComponents = url.pathComponents.filter({ $0 != "/" }),
+			pathComponents.count >= 2,
+			case (let name, let owner) = (pathComponents.removeLast(), pathComponents.removeLast())
+		{
 			// If the host name starts with “github.com”, that is not an enterprise
 			// one.
 			if host == "github.com" || host == "www.github.com" {


### PR DESCRIPTION
No functional changes.