### PR TITLE
[gardening] Refactor with `Result(attempt:)`

### DIFF
--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -27,9 +27,9 @@ public struct Constants {
 	private static let userCachesURL: URL = {
 		let fileManager = FileManager.default
 
-		let urlResult: Result<URL, NSError> = `try` { _ -> URL? in
-			return try? fileManager.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-		}.flatMap { cachesURL in
+		let urlResult: Result<URL, NSError> = Result(attempt: {
+			try fileManager.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+		}).flatMap { cachesURL in
 			let dependenciesURL = cachesURL.appendingPathComponent(Constants.bundleIdentifier, isDirectory: true)
 			let dependenciesPath = dependenciesURL.absoluteString
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -197,12 +197,9 @@ public final class Project { // swiftlint:disable:this type_body_length
 	/// Reads the project's Cartfile.resolved.
 	public func loadResolvedCartfile() -> SignalProducer<ResolvedCartfile, CarthageError> {
 		return SignalProducer.attempt {
-			do {
-				let resolvedCartfileContents = try String(contentsOf: self.resolvedCartfileURL, encoding: .utf8)
-				return ResolvedCartfile.from(string: resolvedCartfileContents)
-			} catch let error as NSError {
-				return .failure(.readFailed(self.resolvedCartfileURL, error))
-			}
+			Result(attempt: { try String(contentsOf: self.resolvedCartfileURL, encoding: .utf8) })
+				.mapError { .readFailed(self.resolvedCartfileURL, $0) }
+				.flatMap(ResolvedCartfile.from)
 		}
 	}
 


### PR DESCRIPTION
No changes to API. [One (small improvement) functional change](https://github.com/jdhealy/Carthage/commit/59060edba9de865fb4e2b52cd7b007f0f251a057).