### PR TITLE
[gardening] Refactor: extend Result attempting a throwing closure taking a URL, failing with `CarthageError`

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -226,6 +226,22 @@ extension Scanner {
 	}
 }
 
+extension Result where Error == CarthageError {
+	/// Constructs a result from a throwing closure taking a `URL`, failing with `CarthageError` if throw occurs.
+	/// - parameter carthageError: Defaults to `CarthageError.writeFailed`.
+	internal init(
+		at url: URL,
+		carthageError: (URL, NSError) -> CarthageError = CarthageError.writeFailed,
+		attempt closure: (URL) throws -> Value
+	) {
+		do {
+			self = .success(try closure(url))
+		} catch let error as NSError {
+			self = .failure(carthageError(url, error))
+		}
+	}
+}
+
 extension URL {
 	/// The type identifier of the receiver, or an error if it was unable to be
 	/// determined.

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -194,14 +194,11 @@ struct VersionFile {
 	}
 
 	func write(to url: URL) -> Result<(), CarthageError> {
-		do {
+		return Result(at: url, attempt: {
 			let json = toJSONObject()
 			let jsonData = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-			try jsonData.write(to: url, options: .atomic)
-			return .success(())
-		} catch let error as NSError {
-			return .failure(.writeFailed(url, error))
-		}
+			try jsonData.write(to: $0, options: .atomic)
+		})
 	}
 }
 


### PR DESCRIPTION
```swift
extension Result where Error == CarthageError {
	/// Constructs a result from a throwing closure taking a `URL`, failing with `CarthageError` if throw occurs.
	/// - parameter carthageError: Defaults to `CarthageError.writeFailed`.
	internal init(
		at url: URL,
		carthageError: (URL, NSError) -> CarthageError = CarthageError.writeFailed,
		attempt closure: (URL) throws -> Value
	) {
		do {
			self = .success(try closure(url))
		} catch let error as NSError {
			self = .failure(carthageError(url, error))
		}
	}
}
```

[No functional changes (after force push)](https://github.com/Carthage/Carthage/pull/2070#issuecomment-316130854).