### PR TITLE
Avoid breaking for-loop on Result’s value, only break on error in `symlinkCheckoutPaths`

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -913,9 +913,11 @@ public final class Project { // swiftlint:disable:this type_body_length
 						continue
 					}
 
-					return Result(at: dependencyCheckoutURL, attempt: {
+					if let error = Result(at: dependencyCheckoutURL, attempt: {
 						try fileManager.createSymbolicLink(atPath: $0.path, withDestinationPath: linkDestinationPath)
-					})
+					}).error {
+						return .failure(error)
+					}
 				}
 
 				return .success()


### PR DESCRIPTION
Fixes bug introduced in <https://github.com/Carthage/Carthage/commit/ec4d59a#commitcomment-23208406>.

Message assuring “no functional changes” is incorrect in commit ec4d59a44351ee56d545cb0446115a0c151dc3fa.

```diff
-	do {
-		try FileManager.default.copyItem(at: url, to: destinationURL, avoiding·rdar·32984063: true)
-		return .success(destinationURL)
-	} catch let error as NSError {
-		return .failure(.writeFailed(destinationURL, error))
-	}
+	return Result(at: destinationURL, attempt: {
+		try FileManager.default.copyItem(at: url, to: $0, avoiding·rdar·32984063: true)
+		return $0
+	})
```

Accidentally introduced a functional change (moreover, a bug) by `return`ing the result’s value from a for-loop — breaking the loop and returning from the surrounding closure.

Return to previous behavior where only the result’s error breaks the for-loop.