### PR TITLE
Preliminary task for ReactiveSwift 2.0 migration

### DIFF
--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -51,7 +51,7 @@ public struct BuildSettings {
 				return String(data: data, encoding: .utf8)!
 			}
 			.flatMap(.merge) { string -> SignalProducer<BuildSettings, CarthageError> in
-				return SignalProducer { observer, disposable in
+				return SignalProducer { observer, lifetime in
 					var currentSettings: [String: String] = [:]
 					var currentTarget: String?
 
@@ -64,6 +64,9 @@ public struct BuildSettings {
 						currentTarget = nil
 						currentSettings = [:]
 					}
+
+					let disposable = AnyDisposable()
+					lifetime += disposable
 
 					string.enumerateLines { line, stop in
 						if disposable.isDisposed {

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -236,7 +236,10 @@ public func fetchRepository(_ repositoryFileURL: URL, remoteURL: GitURL? = nil, 
 public func listTags(_ repositoryFileURL: URL) -> SignalProducer<String, CarthageError> {
 	return launchGitTask([ "tag", "--column=never" ], repositoryFileURL: repositoryFileURL)
 		.flatMap(.concat) { (allTags: String) -> SignalProducer<String, CarthageError> in
-			return SignalProducer { observer, disposable in
+			return SignalProducer { observer, lifetime in
+				let disposable = AnyDisposable()
+				lifetime += disposable
+
 				let range = allTags.characters.startIndex..<allTags.characters.endIndex
 				allTags.enumerateSubstrings(in: range, options: [ .byLines, .reverse ]) { line, _, _, stop in
 					if disposable.isDisposed {
@@ -354,7 +357,10 @@ private func checkoutSubmodule(_ submodule: Submodule, _ submoduleWorkingDirecto
 private func parseConfigEntries(_ contents: String, keyPrefix: String = "", keySuffix: String = "") -> SignalProducer<(String, String), NoError> {
 	let entries = contents.characters.split(omittingEmptySubsequences: true) { $0 == "\0" }
 
-	return SignalProducer { observer, disposable in
+	return SignalProducer { observer, lifetime in
+		let disposable = AnyDisposable()
+		lifetime += disposable
+
 		for entry in entries {
 			if disposable.isDisposed {
 				break


### PR DESCRIPTION
https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/2.0.0

Related to

> `SignalProducer` resource management

and

> `SimpleDisposable` and `ActionDisposable` has been folded into `AnyDisposable`