### PR TITLE
Fix possible build errors from ENABLE_THREAD_SANITIZER=YES

### DIFF
--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -90,6 +90,13 @@ public struct BuildArguments {
 			if sdk != .macOSX {
 				args += [ "-sdk", sdk.rawValue ]
 			}
+
+			// Thread Sanitizer isn't supported on other than macOS devices
+			// If ENABLE_THREAD_SANITIZER=YES passed through env, it will lead
+			// to error.
+			if [ .iPhoneOS, .watchOS, .tvOS ].contains(sdk) {
+				args += [ "ENABLE_THREAD_SANITIZER=NO" ]
+			}
 		}
 
 		if let toolchain = toolchain {


### PR DESCRIPTION
```
<unknown>:0: error: unsupported option '-sanitize=thread' for target 'arm64-apple-ios8.0'
Command /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc failed with exit code 1
```

This can be happened when ENABLE_THREAD_SANITIZER=YES passed from Environment Variable. (e.g `carthage build` triggered in `Thread Sanitizer` enabled projects)

Because `Thread Sanitizer` only support in macOS and other device's simulators. If that parameter passes to iPhoneOS, watchOS, AppleTVOS build, it leads to build error.

This fix will prevent for that.