### PR TITLE
`NSTextCheckingResult.range(at:)` is only available in Swift 4 (not in Swift 3.2)

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -448,7 +448,7 @@ extension Reactive where Base: URLSession {
 	}
 }
 
-#if !swift(>=3.2)
+#if !swift(>=4)
 	extension NSTextCheckingResult {
 		internal func range(at idx: Int) -> NSRange {
 			return rangeAt(idx)


### PR DESCRIPTION
Ref: #2063 