### PR TITLE
[PoC] Split derived data directory by Xcode version

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -136,6 +136,9 @@ public final class Project { // swiftlint:disable:this type_body_length
 	private var cachedBinaryProjects: CachedBinaryProjects = [:]
 	private let cachedBinaryProjectsQueue = SerialProducerQueue(name: "org.carthage.Constants.Project.cachedBinaryProjectsQueue")
 
+	private lazy var xcodeVersionDirectory: String = XcodeVersion.make()
+		.map { "\($0.version)_\($0.buildVersion)" } ?? "Unknown"
+
 	/// Attempts to load Cartfile or Cartfile.private from the given directory,
 	/// merging their dependencies.
 	public func loadCombinedCartfile() -> SignalProducer<Cartfile, CarthageError> {
@@ -968,7 +971,8 @@ public final class Project { // swiftlint:disable:this type_body_length
 
 				var options = options
 				let baseURL = options.derivedDataPath.flatMap(URL.init(string:)) ?? Constants.Dependency.derivedDataURL
-				let derivedDataPerDependency = baseURL.appendingPathComponent(dependency.name, isDirectory: true)
+				let derivedDataPerXcode = baseURL.appendingPathComponent(self.xcodeVersionDirectory, isDirectory: true)
+				let derivedDataPerDependency = derivedDataPerXcode.appendingPathComponent(dependency.name, isDirectory: true)
 				let derivedDataVersioned = derivedDataPerDependency.appendingPathComponent(version.commitish, isDirectory: true)
 				options.derivedDataPath = derivedDataVersioned.resolvingSymlinksInPath().path
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -488,7 +488,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 							return SignalProducer(value: .standardError(data))
 
 						case let .success(deviceSettingsByTarget):
-							return settingsByTarget(build(sdk: simulatorSDK, with: buildArgs, in: workingDirectoryURL, performClean: false))
+							return settingsByTarget(build(sdk: simulatorSDK, with: buildArgs, in: workingDirectoryURL))
 								.flatMapTaskEvents(.concat) { (simulatorSettingsByTarget: [String: BuildSettings]) -> SignalProducer<(BuildSettings, BuildSettings), CarthageError> in
 									assert(
 										deviceSettingsByTarget.count == simulatorSettingsByTarget.count,
@@ -540,7 +540,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 }
 
 /// Runs the build for a given sdk and build arguments, optionally performing a clean first
-private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectoryURL: URL, performClean: Bool = true) -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> {
+private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectoryURL: URL) -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> {
 	var argsForLoading = buildArgs
 	argsForLoading.sdk = sdk
 
@@ -615,7 +615,7 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 						argsForBuilding.bitcodeGenerationMode = .bitcode
 					}
 
-					let actions = performClean ? ["clean", "build"] : ["build"]
+					let actions = ["build"]
 
 					var buildScheme = xcodebuildTask(actions, argsForBuilding)
 					buildScheme.workingDirectoryPath = workingDirectoryURL.path

--- a/Source/XCDBLD/XcodeVersion.swift
+++ b/Source/XCDBLD/XcodeVersion.swift
@@ -11,6 +11,7 @@ import ReactiveTask
 	}
 #endif
 
+/// Represents version and build version of an Xcode.
 public struct XcodeVersion {
 	public let version: String
 	public let buildVersion: String
@@ -20,24 +21,33 @@ public struct XcodeVersion {
 		self.buildVersion = buildVersion
 	}
 
+	internal init?(xcodebuildOutput: String) {
+		let range = NSRange(location: 0, length: xcodebuildOutput.utf16.count)
+		guard let match = XcodeVersion.regex.firstMatch(in: xcodebuildOutput, range: range) else {
+			return nil
+		}
+
+		let nsString = xcodebuildOutput as NSString
+		let version = nsString.substring(with: match.range(at: 1))
+		let buildVersion = nsString.substring(with: match.range(at: 2))
+
+		self.init(version: version, buildVersion: buildVersion)
+	}
+
+	// swiftlint:disable next force_try
+	private static let regex = try! NSRegularExpression(pattern: "Xcode ([0-9.]+)\\nBuild version (.+)")
+
 	public static func make() -> XcodeVersion? {
 		let task = Task("/usr/bin/xcrun", arguments: ["xcodebuild", "-version"])
 		return task.launch()
 			.ignoreTaskData()
 			.map { String(data: $0, encoding: .utf8)! }
-			.flatMap(.concat) { input -> SignalProducer<XcodeVersion, TaskError> in
-				// swiftlint:disable next force_try
-				let regex = try! NSRegularExpression(pattern: "Xcode ([0-9.]+)\\nBuild version (.+)")
-				guard let match = regex.firstMatch(in: input, range: NSRange(location: 0, length: input.utf16.count)) else {
+			.flatMap(.concat) { output -> SignalProducer<XcodeVersion, TaskError> in
+				if let xcodeVersion = XcodeVersion(xcodebuildOutput: output) {
+					return .init(value: xcodeVersion)
+				} else {
 					return .empty
 				}
-
-				let nsString = input as NSString
-				let version = nsString.substring(with: match.range(at: 1))
-				let buildVersion = nsString.substring(with: match.range(at: 2))
-
-				let xcodeVersion = XcodeVersion(version: version, buildVersion: buildVersion)
-				return SignalProducer(value: xcodeVersion)
 			}
 			.single()?.value
 	}

--- a/Source/XCDBLD/XcodeVersion.swift
+++ b/Source/XCDBLD/XcodeVersion.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Result
+import ReactiveSwift
+import ReactiveTask
+
+#if !swift(>=4)
+	extension NSTextCheckingResult {
+		fileprivate func range(at idx: Int) -> NSRange {
+			return rangeAt(idx)
+		}
+	}
+#endif
+
+public struct XcodeVersion {
+	public let version: String
+	public let buildVersion: String
+
+	private init(version: String, buildVersion: String) {
+		self.version = version
+		self.buildVersion = buildVersion
+	}
+
+	public static func make() -> XcodeVersion? {
+		let task = Task("/usr/bin/xcrun", arguments: ["xcodebuild", "-version"])
+		return task.launch()
+			.ignoreTaskData()
+			.map { String(data: $0, encoding: .utf8)! }
+			.flatMap(.concat) { input -> SignalProducer<XcodeVersion, TaskError> in
+				// swiftlint:disable next force_try
+				let regex = try! NSRegularExpression(pattern: "Xcode ([0-9.]+)\\nBuild version (.+)")
+				guard let match = regex.firstMatch(in: input, range: NSRange(location: 0, length: input.utf16.count)) else {
+					return .empty
+				}
+
+				let nsString = input as NSString
+				let version = nsString.substring(with: match.range(at: 1))
+				let buildVersion = nsString.substring(with: match.range(at: 2))
+
+				let xcodeVersion = XcodeVersion(version: version, buildVersion: buildVersion)
+				return SignalProducer(value: xcodeVersion)
+			}
+			.single()?.value
+	}
+}

--- a/XCDBLD.xcodeproj/project.pbxproj
+++ b/XCDBLD.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		BE0292521E4033FE004FB579 /* ReactiveTask.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE0292511E4033FE004FB579 /* ReactiveTask.framework */; };
 		BE0292541E403407004FB579 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE0292531E403407004FB579 /* ReactiveSwift.framework */; };
 		BE0292561E4034B5004FB579 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0292551E4034B5004FB579 /* Platform.swift */; };
+		CD4323C41F32DEBF0083C968 /* XcodeVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4323C31F32DEBF0083C968 /* XcodeVersion.swift */; };
 		D01F8A4A19EA28FE00643E7C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01F8A4719EA28F600643E7C /* Quick.framework */; };
 		D01F8A4C19EA28FE00643E7C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01F8A4B19EA28FE00643E7C /* Nimble.framework */; };
 		D0D1217219E87B05005E4BAA /* XCDBLD.h in Headers */ = {isa = PBXBuildFile; fileRef = D0D1217119E87B05005E4BAA /* XCDBLD.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -44,6 +45,7 @@
 		BE0292511E4033FE004FB579 /* ReactiveTask.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveTask.framework; path = Carthage/Checkouts/ReactiveTask/build/Debug/ReactiveTask.framework; sourceTree = "<group>"; };
 		BE0292531E403407004FB579 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Checkouts/ReactiveSwift/build/Debug/ReactiveSwift.framework; sourceTree = "<group>"; };
 		BE0292551E4034B5004FB579 /* Platform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
+		CD4323C31F32DEBF0083C968 /* XcodeVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeVersion.swift; sourceTree = "<group>"; };
 		D01F8A4719EA28F600643E7C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D01F8A4B19EA28FE00643E7C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				BE0292551E4034B5004FB579 /* Platform.swift */,
 				BE0292441E40330D004FB579 /* ProjectLocator.swift */,
 				BE02924C1E4033AE004FB579 /* SDK.swift */,
+				CD4323C31F32DEBF0083C968 /* XcodeVersion.swift */,
 				D0D1216F19E87B05005E4BAA /* Supporting Files */,
 			);
 			name = XCDBLD;
@@ -350,6 +353,7 @@
 			files = (
 				BE0292561E4034B5004FB579 /* Platform.swift in Sources */,
 				BE0292471E403318004FB579 /* MachOType.swift in Sources */,
+				CD4323C41F32DEBF0083C968 /* XcodeVersion.swift in Sources */,
 				BE0292451E40330D004FB579 /* ProjectLocator.swift in Sources */,
 				BE02924D1E4033AE004FB579 /* SDK.swift in Sources */,
 				BE0292411E403278004FB579 /* BuildArguments.swift in Sources */,


### PR DESCRIPTION
This would make it enable to remove `clean` action from `xcodebuild clean build`.

This would also address #1469 and #2062. See also #1419.