### PR TITLE
[Makefile] Add safety to `rm -rf` with `zsh` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+#!/usr/bin/xcrun make -f
+
 CARTHAGE_TEMPORARY_FOLDER?=/tmp/Carthage.dst
 PREFIX?=/usr/local
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-TEMPORARY_FOLDER?=/tmp/Carthage.dst
+CARTHAGE_TEMPORARY_FOLDER?=/tmp/Carthage.dst
 PREFIX?=/usr/local
 
-XCODEFLAGS=-workspace 'Carthage.xcworkspace' -scheme 'carthage' DSTROOT=$(TEMPORARY_FOLDER)
+XCODEFLAGS=-workspace 'Carthage.xcworkspace' -scheme 'carthage' DSTROOT=$(CARTHAGE_TEMPORARY_FOLDER)
 
 INTERNAL_PACKAGE=CarthageApp.pkg
 OUTPUT_PACKAGE=Carthage.pkg
 OUTPUT_FRAMEWORK=CarthageKit.framework
 OUTPUT_FRAMEWORK_ZIP=CarthageKit.framework.zip
 
-BUILT_BUNDLE=$(TEMPORARY_FOLDER)/Applications/carthage.app
+BUILT_BUNDLE=$(CARTHAGE_TEMPORARY_FOLDER)/Applications/carthage.app
 CARTHAGEKIT_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/$(OUTPUT_FRAMEWORK)
 CARTHAGE_EXECUTABLE=$(BUILT_BUNDLE)/Contents/MacOS/carthage
 
@@ -47,7 +47,7 @@ clean:
 	$(RM) "$(INTERNAL_PACKAGE)"
 	$(RM) "$(OUTPUT_PACKAGE)"
 	$(RM) "$(OUTPUT_FRAMEWORK_ZIP)"
-	$(RM_SAFELY) "$(TEMPORARY_FOLDER)"
+	$(RM_SAFELY) "$(CARTHAGE_TEMPORARY_FOLDER)"
 	xcodebuild $(XCODEFLAGS) clean
 
 install: package
@@ -60,15 +60,15 @@ uninstall:
 installables: clean bootstrap
 	xcodebuild $(XCODEFLAGS) install
 
-	$(MKDIR) "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)"
-	$(MV) "$(CARTHAGEKIT_BUNDLE)" "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)"
-	$(MV) "$(CARTHAGE_EXECUTABLE)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage"
+	$(MKDIR) "$(CARTHAGE_TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" "$(CARTHAGE_TEMPORARY_FOLDER)$(BINARIES_FOLDER)"
+	$(MV) "$(CARTHAGEKIT_BUNDLE)" "$(CARTHAGE_TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)"
+	$(MV) "$(CARTHAGE_EXECUTABLE)" "$(CARTHAGE_TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage"
 	$(RM_SAFELY) "$(BUILT_BUNDLE)"
 
 prefix_install: installables
 	$(MKDIR) "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
-	$(RSYNC) "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
-	$(CP) -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
+	$(RSYNC) "$(CARTHAGE_TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/$(OUTPUT_FRAMEWORK)" "$(PREFIX)/Frameworks/"
+	$(CP) -f "$(CARTHAGE_TEMPORARY_FOLDER)$(BINARIES_FOLDER)/carthage" "$(PREFIX)/bin/"
 	install_name_tool -delete_rpath "@executable_path/../Frameworks" "$(PREFIX)/bin/carthage" # Avoid duplication of "@executable_path/../Frameworks"
 	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks" "$(PREFIX)/bin/carthage"
 	install_name_tool -rpath "/Library/Frameworks/CarthageKit.framework/Versions/Current/Frameworks" "@executable_path/../Frameworks/CarthageKit.framework/Versions/Current/Frameworks" "$(PREFIX)/bin/carthage"
@@ -78,7 +78,7 @@ package: installables
 		--component-plist "$(COMPONENTS_PLIST)" \
 		--identifier "org.carthage.carthage" \
 		--install-location "/" \
-		--root "$(TEMPORARY_FOLDER)" \
+		--root "$(CARTHAGE_TEMPORARY_FOLDER)" \
 		--version "$(VERSION_STRING)" \
 		"$(INTERNAL_PACKAGE)"
 
@@ -87,7 +87,7 @@ package: installables
   	--package-path "$(INTERNAL_PACKAGE)" \
    	"$(OUTPUT_PACKAGE)"
 
-	(cd "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" && zip -q -r --symlinks - "$(OUTPUT_FRAMEWORK)") > "$(OUTPUT_FRAMEWORK_ZIP)"
+	(cd "$(CARTHAGE_TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" && zip -q -r --symlinks - "$(OUTPUT_FRAMEWORK)") > "$(OUTPUT_FRAMEWORK_ZIP)"
 
 swiftpm:
 	swift build -c release -Xswiftc -static-stdlib


### PR DESCRIPTION
- Ensure first and only parameter is non-null, contains more than whitespace, non-root if resolving absolutely.
- Ignore potential `zsh` files (except for `/etc/zshenv` — as of 5.3.1 cannot be overridden/ignored), see <http://zsh.sourceforge.net/Doc/Release/Files.html>.
- Rename possibly user-set temporary folder, which gets removed recursively.
	- With prefix, less likely to have a variable by this name leftover, still-set from some previous script from whatever source.

Credit to and thanks to @zhongwuzw

See https://github.com/Carthage/Carthage/pull/2098 for discussion and potential future work.

Once again, massive, massive apologies to anyone affected.

#### Some Smoke Tests and Output

```make
TEMPORARY_FOLDER?=/tmp/MyProject.dst

# ZSH_COMMAND · run single command in `zsh` shell, ignoring most `zsh` startup files. 
ZSH_COMMAND := ZDOTDIR='/var/empty' zsh -o NO_GLOBAL_RCS -c
# RM_SAFELY · `rm -rf` ensuring first and only parameter is non-null, contains more than whitespace, non-root if resolving absolutely
RM_SAFELY := $(ZSH_COMMAND) '[[ ! $${1:?} =~ "^[[:space:]]+\$$" ]] && [[ $${1:A} != "/" ]] && [[ $${\#} == "1" ]] && noglob print -rn $${1:A}' --

.PHONY: default

default:
	$(RM_SAFELY) "$(TEMPORARY_FOLDER)"
```

```shell
$ make
ZDOTDIR='/var/empty' zsh -o NO_GLOBAL_RCS -c '[[ ! ${1:?} =~ "^[[:space:]]+\$" ]] && [[ ${1:A} != "/" ]] && [[ ${#} == "1" ]] && noglob print -rn ${1:A}' -- "/tmp/MyProject.dst"
/private/tmp/MyProject.dst%

$ TEMPORARY_FOLDER="./../../../../.." make
ZDOTDIR='/var/empty' zsh -o NO_GLOBAL_RCS -c '[[ ! ${1:?} =~ "^[[:space:]]+\$" ]] && [[ ${1:A} != "/" ]] && [[ ${#} == "1" ]] && noglob print -rn ${1:A}' -- "./../../../../.."
make: *** [default] Error 1

$ TEMPORARY_FOLDER="      " make
ZDOTDIR='/var/empty' zsh -o NO_GLOBAL_RCS -c '[[ ! ${1:?} =~ "^[[:space:]]+\$" ]] && [[ ${1:A} != "/" ]] && [[ ${#} == "1" ]] && noglob print -rn ${1:A}' -- "      "
make: *** [default] Error 1

$ TEMPORARY_FOLDER="/tmp/some directory" make
ZDOTDIR='/var/empty' zsh -o NO_GLOBAL_RCS -c '[[ ! ${1:?} =~ "^[[:space:]]+\$" ]] && [[ ${1:A} != "/" ]] && [[ ${#} == "1" ]] && noglob print -rn ${1:A}' -- "/tmp/some directory"
/private/tmp/some directory%
```
