### PR TITLE
[BREAKING] Make git tags parsing stricter on `SemanticVersion.from(_:)`

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -44,9 +44,8 @@ public struct SemanticVersion: VersionType {
 	public static func from(_ pinnedVersion: PinnedVersion) -> Result<SemanticVersion, ScannableError> {
 		let scanner = Scanner(string: pinnedVersion.commitish)
 
-		// Skip leading characters, like "v" or "version-" or anything like
-		// that.
-		scanner.scanUpToCharacters(from: versionCharacterSet, into: nil)
+		// Skip only the leading "v" character. This matches the SwiftPM's behavior.
+		scanner.scanString("v", into: nil)
 
 		return self.from(scanner).flatMap { version in
 			if scanner.isAtEnd {

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -29,6 +29,8 @@ class SemanticVersionSpec: QuickSpec {
 		it("should fail on invalid semantic versions") {
 			expect(SemanticVersion.from(PinnedVersion("v1")).value).to(beNil())
 			expect(SemanticVersion.from(PinnedVersion("v2.8-alpha")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("version-3.0.0")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("swift-3.1")).value).to(beNil())
 			expect(SemanticVersion.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
 		}
 	}


### PR DESCRIPTION
The new behavior matches the SwiftPM's one.

This revisits #428, #506 and #508.