### PR TITLE
[GitURL] Fix relative path handling in `normalizedURLString`

### DIFF
--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -9,13 +9,15 @@ public struct GitURL {
 	/// information. This is mostly useful for comparison, and not for any
 	/// actual Git operations.
 	internal var normalizedURLString: String {
-		let parsedURL: URL? = URL(string: urlString)
-
-		if let parsedURL = parsedURL, let host = parsedURL.host {
+		if let parsedURL = URL(string: urlString), let host = parsedURL.host {
 			// Normal, valid URL.
 			let path = strippingGitSuffix(parsedURL.path)
 			return "\(host)\(path)"
-		} else if urlString.hasPrefix("/") {
+		} else if urlString.hasPrefix("/") // "/path/to/..."
+			|| urlString.hasPrefix(".") // "./path/to/...", "../path/to/..."
+			|| urlString.hasPrefix("~") // "~/path/to/..."
+			|| !urlString.contains(":") // "path/to/..." with avoiding "git@github.com:owner/name"
+		{
 			// Local path.
 			return strippingGitSuffix(urlString)
 		} else {

--- a/Tests/CarthageKitTests/GitURLSpec.swift
+++ b/Tests/CarthageKitTests/GitURLSpec.swift
@@ -20,6 +20,32 @@ class GitURLSpec: QuickSpec {
 					expect(GitURL("/path/to/git/repo").normalizedURLString) == expected
 				}
 
+				it("should parse local relative path") {
+					do {
+						let expected = "path/to/git/repo"
+						expect(GitURL("path/to/git/repo.git").normalizedURLString) == expected
+						expect(GitURL("path/to/git/repo").normalizedURLString) == expected
+					}
+
+					do {
+						let expected = "./path/to/git/repo"
+						expect(GitURL("./path/to/git/repo.git").normalizedURLString) == expected
+						expect(GitURL("./path/to/git/repo").normalizedURLString) == expected
+					}
+
+					do {
+						let expected = "../path/to/git/repo"
+						expect(GitURL("../path/to/git/repo.git").normalizedURLString) == expected
+						expect(GitURL("../path/to/git/repo").normalizedURLString) == expected
+					}
+
+					do {
+						let expected = "~/path/to/git/repo"
+						expect(GitURL("~/path/to/git/repo.git").normalizedURLString) == expected
+						expect(GitURL("~/path/to/git/repo").normalizedURLString) == expected
+					}
+				}
+
 				it("should parse scp syntax") {
 					let expected = "github.com/antitypical/Result"
 					expect(GitURL("git@github.com:antitypical/Result.git").normalizedURLString) == expected


### PR DESCRIPTION
Formerly relative paths are parsed as the scp syntax.