### PR TITLE
Fix fetching a local repository with relative path

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1214,11 +1214,6 @@ public func cloneOrFetch(
 
 							return SignalProducer(value: (.fetching(dependency), repositoryURL))
 								.concat(
-									// Don't need to pass `remoteURL` here since the repository should have 
-									// the `origin` remote.
-									//
-									// See https://github.com/Carthage/Carthage/issues/968
-									// and https://github.com/Carthage/Carthage/pull/2125.
 									fetchRepository(repositoryURL, refspec: "+refs/heads/*:refs/heads/*")
 										.then(SignalProducer<(ProjectEvent?, URL), CarthageError>.empty)
 								)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1216,6 +1216,9 @@ public func cloneOrFetch(
 								.concat(
 									// Don't need to pass `remoteURL` here since the repository should have 
 									// the `origin` remote.
+									//
+									// See https://github.com/Carthage/Carthage/issues/968
+									// and https://github.com/Carthage/Carthage/pull/2125.
 									fetchRepository(repositoryURL, refspec: "+refs/heads/*:refs/heads/*")
 										.then(SignalProducer<(ProjectEvent?, URL), CarthageError>.empty)
 								)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1208,13 +1208,15 @@ public func cloneOrFetch(
 				.flatMap(.merge) { isRepository -> SignalProducer<(ProjectEvent?, URL), CarthageError> in
 					if isRepository {
 						let fetchProducer: () -> SignalProducer<(ProjectEvent?, URL), CarthageError> = {
-							guard FetchCache.needsFetch(forURL: remoteURL) else {
+							guard FetchCache.needsFetch(forURL: repositoryURL) else {
 								return SignalProducer(value: (nil, repositoryURL))
 							}
 
 							return SignalProducer(value: (.fetching(dependency), repositoryURL))
 								.concat(
-									fetchRepository(repositoryURL, remoteURL: remoteURL, refspec: "+refs/heads/*:refs/heads/*")
+									// Don't need to pass `remoteURL` here since the repository should have 
+									// the `origin` remote.
+									fetchRepository(repositoryURL, refspec: "+refs/heads/*:refs/heads/*")
 										.then(SignalProducer<(ProjectEvent?, URL), CarthageError>.empty)
 								)
 						}


### PR DESCRIPTION
Specifically for the case of `../some-repo`. Formerly `cloneOrFetch` fetches a repository itself as its remote in that case because of the given `GitURL` of `../some-repo`.

In short, running the following command within `~/Library/Caches/org.carthage.CarthageKit/dependencies/some-repo` is the problem.

```bash
# ../some-repo is pointing to the repository itself
/usr/bin/env git fetch --prune --quiet ../some-repo refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/*
```

We should be able to use the `origin` remote instead of `../some-repo` here.

Fixes #968.