### PR TITLE
Update resolver signature and update/add tests

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -400,9 +400,6 @@ public final class Project { // swiftlint:disable:this type_body_length
 					dependenciesToUpdate: dependenciesToUpdate
 				)
 			}
-			.reduce(into: [:]) { (result: inout [Dependency: PinnedVersion], dependency) in
-				result[dependency.0] = dependency.1
-			}
 			.map(ResolvedCartfile.init)
 	}
 

--- a/Tests/CarthageKitTests/ResolverSpec.swift
+++ b/Tests/CarthageKitTests/ResolverSpec.swift
@@ -65,11 +65,12 @@ private struct DB {
 	}
 
 	func resolve(
+		_ resolverType: ResolverProtocol.Type,
 		_ dependencies: [Dependency: VersionSpecifier],
 		resolved: [Dependency: PinnedVersion] = [:],
 		updating: Set<Dependency> = []
-	) -> Result<[(Dependency, PinnedVersion)], CarthageError> {
-		let resolver = Resolver(
+	) -> Result<[Dependency: PinnedVersion], CarthageError> {
+		let resolver = resolverType.init(
 			versionsForDependency: self.versions(for:),
 			dependenciesForDependency: self.dependencies(for:version:),
 			resolvedGitReference: self.resolvedGitReference(_:reference:)
@@ -80,7 +81,6 @@ private struct DB {
 				lastResolved: resolved,
 				dependenciesToUpdate: updating.map { $0.name }
 			)
-			.collect()
 			.first()!
 	}
 }
@@ -122,227 +122,318 @@ private func ==<A: Equatable, B: Equatable>(lhs: Expectation<[(A, B)]>, rhs: [(A
 
 class ResolverSpec: QuickSpec {
 	override func spec() {
-		it("should resolve a simple Cartfile") {
-			let db: DB = [
-				github1: [
-					.v0_1_0: [
-						github2: .compatibleWith(.v1_0_0),
-					],
-				],
-				github2: [
-					.v1_0_0: [:],
-				],
-			]
+		sharedExamples("resolver") { (context: @escaping SharedExampleContext) in
+			let resolverType = context()["resolverType"] as! ResolverProtocol.Type
 
-			let resolved = db.resolve([ github1: .exactly(.v0_1_0) ])
-			expect(resolved.value!) == [
-				(github2, .v1_0_0),
-				(github1, .v0_1_0),
-			]
-		}
+			describe("\(resolverType)") {
 
-		it("should resolve to the latest matching versions") {
-			let db: DB = [
-				github1: [
-					.v0_1_0: [
-						github2: .compatibleWith(.v1_0_0),
-					],
-					.v1_0_0: [
-						github2: .compatibleWith(.v2_0_0),
-					],
-					.v1_1_0: [
-						github2: .compatibleWith(.v2_0_0),
-					],
-				],
-				github2: [
-					.v1_0_0: [:],
-					.v2_0_0: [:],
-					.v2_0_1: [:],
-				],
-			]
+				it("should resolve a simple Cartfile") {
+					let db: DB = [
+						github1: [
+							.v0_1_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+						],
+						github2: [
+							.v1_0_0: [:],
+						],
+						]
 
-			let resolved = db.resolve([ github1: .any ])
-			expect(resolved.value!) == [
-				(github2, .v2_0_1),
-				(github1, .v1_1_0),
-			]
-		}
+					let resolved = db.resolve(resolverType, [ github1: .exactly(.v0_1_0) ])
+					expect(resolved.value!) == [
+						github2: .v1_0_0,
+						github1: .v0_1_0,
+					]
+				}
 
-		it("should resolve a subset when given specific dependencies") {
-			let db: DB = [
-				github1: [
-					.v1_0_0: [
-						github2: .compatibleWith(.v1_0_0),
-					],
-					.v1_1_0: [
-						github2: .compatibleWith(.v1_0_0),
-					],
-				],
-				github2: [
-					.v1_0_0: [ github3: .compatibleWith(.v1_0_0) ],
-					.v1_1_0: [ github3: .compatibleWith(.v1_0_0) ],
-				],
-				github3: [
-					.v1_0_0: [:],
-					.v1_1_0: [:],
-					.v1_2_0: [:],
-				],
-				git1: [
-					.v1_0_0: [:],
-				],
-			]
+				it("should resolve to the latest matching versions") {
+					let db: DB = [
+						github1: [
+							.v0_1_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+							.v1_0_0: [
+								github2: .compatibleWith(.v2_0_0),
+							],
+							.v1_1_0: [
+								github2: .compatibleWith(.v2_0_0),
+							],
+						],
+						github2: [
+							.v1_0_0: [:],
+							.v2_0_0: [:],
+							.v2_0_1: [:],
+						],
+						]
 
-			let resolved = db.resolve(
-				[
-					github1: .any,
-					// Newly added dependencies which are not inclued in the
-					// list should not be resolved.
-					git1: .any,
-				],
-				resolved: [ github1: .v1_0_0, github2: .v1_0_0, github3: .v1_0_0 ],
-				updating: [ github2 ]
-			)
-			expect(resolved.value!) == [
-				(github3, .v1_2_0),
-				(github2, .v1_1_0),
-				(github1, .v1_0_0),
-			]
-		}
+					let resolved = db.resolve(resolverType, [ github1: .any ])
+					expect(resolved.value!) == [
+						github2: .v2_0_1,
+						github1: .v1_1_0,
+					]
+				}
 
-		pending("should resolve a subset when given specific dependencies that have constraints") {
-			let db: DB = [
-				github1: [
-					.v1_0_0: [
-						github2: .compatibleWith(.v1_0_0),
-					],
-					.v1_1_0: [
-						github2: .compatibleWith(.v1_0_0),
-					],
-					.v2_0_0: [
-						github2: .compatibleWith(.v2_0_0),
-					],
-				],
-				github2: [
-					.v1_0_0: [ github3: .compatibleWith(.v1_0_0) ],
-					.v1_1_0: [ github3: .compatibleWith(.v1_0_0) ],
-					.v2_0_0: [:],
-				],
-				github3: [
-					.v1_0_0: [:],
-					.v1_1_0: [:],
-					.v1_2_0: [:],
-				],
-			]
+				it("should resolve a subset when given specific dependencies") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+							.v1_1_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+						],
+						github2: [
+							.v1_0_0: [ github3: .compatibleWith(.v1_0_0) ],
+							.v1_1_0: [ github3: .compatibleWith(.v1_0_0) ],
+						],
+						github3: [
+							.v1_0_0: [:],
+							.v1_1_0: [:],
+							.v1_2_0: [:],
+						],
+						git1: [
+							.v1_0_0: [:],
+						],
+						]
 
-			let resolved = db.resolve(
-				[ github1: .any ],
-				resolved: [ github1: .v1_0_0, github2: .v1_0_0, github3: .v1_0_0 ],
-				updating: [ github2 ]
-			)
-			expect(resolved.value!) == [
-				(github3, .v1_2_0),
-				(github2, .v1_1_0),
-				(github1, .v1_0_0),
-			]
-		}
+					let resolved = db.resolve(resolverType,
+					                          [
+												github1: .any,
+												// Newly added dependencies which are not inclued in the
+												// list should not be resolved.
+												git1: .any,
+												],
+					                          resolved: [ github1: .v1_0_0, github2: .v1_0_0, github3: .v1_0_0 ],
+					                          updating: [ github2 ]
+					)
+					expect(resolved.value!) == [
+						github3: .v1_2_0,
+						github2: .v1_1_0,
+						github1: .v1_0_0,
+					]
+				}
 
-		it("should resolve a Cartfile whose dependency is specified by both a branch name and a SHA which is the HEAD of that branch") {
-			let branch = "development"
-			let sha = "8ff4393ede2ca86d5a78edaf62b3a14d90bffab9"
+				it("should fail when given incompatible nested version specifiers") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [
+								git1: .compatibleWith(.v1_0_0),
+								github2: .any,
+							],
+						],
+						github2: [
+							.v1_0_0: [
+								git1: .compatibleWith(.v2_0_0),
+							],
+						],
+						git1: [
+							.v1_0_0: [:],
+							.v1_1_0: [:],
+							.v2_0_0: [:],
+							.v2_0_1: [:],
+						]
+					]
+					let resolved = db.resolve(resolverType, [github1: .any])
+					expect(resolved.value).to(beNil())
+					expect(resolved.error).notTo(beNil())
+				}
 
-			var db: DB = [
-				github1: [
-					.v1_0_0: [
-						github2: .any,
-						github3: .gitReference(sha),
-					],
-				],
-				github2: [
-					.v1_0_0: [
-						github3: .gitReference(branch),
-					],
-				],
-				github3: [
-					.v1_0_0: [:],
-				],
-			]
-			db.references = [
-				github3: [
-					branch: PinnedVersion(sha),
-					sha: PinnedVersion(sha),
-				],
-			]
+				it("should correctly resolve when specifiers intersect") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [
+								github2: .compatibleWith(.v1_0_0)
+							]
+						],
+						github2: [
+							.v1_0_0: [:],
+							.v2_0_0: [:]
+						]
+					]
 
-			let resolved = db.resolve([ github1: .any, github2: .any ])
-			expect(resolved.value!) == [
-				(github3, PinnedVersion(sha)),
-				(github2, .v1_0_0),
-				(github1, .v1_0_0),
-			]
-		}
+					let resolved = db.resolve(resolverType, [ github1: .any, github2: .atLeast(.v1_0_0) ])
+					expect(resolved.value!) == [
+						github1: .v1_0_0,
+						github2: .v1_0_0
+					]
+				}
 
-		it("should correctly order transitive dependencies") {
-			let db: DB = [
-				github1: [
-					.v1_0_0: [
-						github2: .any,
-						github3: .any,
-					],
-				],
-				github2: [
-					.v1_0_0: [
-						github3: .any,
-						git1: .any,
-					],
-				],
-				github3: [
-					.v1_0_0: [ git2: .any ],
-				],
-				git1: [
-					.v1_0_0: [ github3: .any ],
-				],
-				git2: [
-					.v1_0_0: [:],
-				],
-			]
+				// Only the new resolver passes the following tests. Will change to non-pending when checked in
+				pending("should resolve a subset when given specific dependencies that have constraints") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+							.v1_1_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+							.v2_0_0: [
+								github2: .compatibleWith(.v2_0_0),
+							],
+						],
+						github2: [
+							.v1_0_0: [ github3: .compatibleWith(.v1_0_0) ],
+							.v1_1_0: [ github3: .compatibleWith(.v1_0_0) ],
+							.v2_0_0: [:],
+						],
+						github3: [
+							.v1_0_0: [:],
+							.v1_1_0: [:],
+							.v1_2_0: [:],
+						],
+						]
 
-			let resolved = db.resolve([ github1: .any ])
-			expect(resolved.value!) == [
-				(git2, .v1_0_0),
-				(github3, .v1_0_0),
-				(git1, .v1_0_0),
-				(github2, .v1_0_0),
-				(github1, .v1_0_0),
-			]
-		}
+					let resolved = db.resolve(resolverType,
+					                          [ github1: .any ],
+					                          resolved: [ github1: .v1_0_0, github2: .v1_0_0, github3: .v1_0_0 ],
+					                          updating: [ github2 ]
+					)
+					expect(resolved.value!) == [
+						github3: .v1_2_0,
+						github2: .v1_1_0,
+						github1: .v1_0_0,
+					]
+				}
 
-		pending("should fail if no versions match the requirements and prerelease versions exist") {
-			let db: DB = [
-				github1: [
-					.v1_0_0: [:],
-					.v2_0_0_beta_1: [:],
-					.v2_0_0: [:],
-					.v3_0_0_beta_1: [:],
-				],
-			]
 
-			do {
-				let resolved = db.resolve([ github1: .atLeast(.v3_0_0) ])
-				expect(resolved.value).to(beNil())
-				expect(resolved.error).notTo(beNil())
+				pending("should fail when the only valid graph is not in the specified dependencies") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+							.v1_1_0: [
+								github2: .compatibleWith(.v1_0_0),
+							],
+							.v2_0_0: [
+								github2: .compatibleWith(.v2_0_0),
+							],
+						],
+						github2: [
+							.v1_0_0: [ github3: .compatibleWith(.v1_0_0) ],
+							.v1_1_0: [ github3: .compatibleWith(.v1_0_0) ],
+							.v2_0_0: [:],
+						],
+						github3: [
+							.v1_0_0: [:],
+							.v1_1_0: [:],
+							.v1_2_0: [:],
+						],
+						]
+					let resolved = db.resolve(resolverType,
+					                          [ github1: .exactly(.v2_0_0) ],
+					                          resolved: [ github1: .v1_0_0, github2: .v1_0_0, github3: .v1_0_0 ],
+					                          updating: [ github2 ]
+					)
+					expect(resolved.value).to(beNil())
+					expect(resolved.error).notTo(beNil())
+				}
+
+				it("should resolve a Cartfile whose dependency is specified by both a branch name and a SHA which is the HEAD of that branch") {
+					let branch = "development"
+					let sha = "8ff4393ede2ca86d5a78edaf62b3a14d90bffab9"
+
+					var db: DB = [
+						github1: [
+							.v1_0_0: [
+								github2: .any,
+								github3: .gitReference(sha),
+							],
+						],
+						github2: [
+							.v1_0_0: [
+								github3: .gitReference(branch),
+							],
+						],
+						github3: [
+							.v1_0_0: [:],
+						],
+						]
+					db.references = [
+						github3: [
+							branch: PinnedVersion(sha),
+							sha: PinnedVersion(sha),
+						],
+					]
+
+					let resolved = db.resolve(resolverType, [ github1: .any, github2: .any ])
+					expect(resolved.value!) == [
+						github3: PinnedVersion(sha),
+						github2: .v1_0_0,
+						github1: .v1_0_0,
+					]
+				}
+
+				it("should correctly order transitive dependencies") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [
+								github2: .any,
+								github3: .any,
+							],
+						],
+						github2: [
+							.v1_0_0: [
+								github3: .any,
+								git1: .any,
+							],
+						],
+						github3: [
+							.v1_0_0: [ git2: .any ],
+						],
+						git1: [
+							.v1_0_0: [ github3: .any ],
+						],
+						git2: [
+							.v1_0_0: [:],
+						],
+						]
+
+					let resolved = db.resolve(resolverType, [ github1: .any ])
+					expect(resolved.value!) == [
+						git2: .v1_0_0,
+						github3: .v1_0_0,
+						git1: .v1_0_0,
+						github2: .v1_0_0,
+						github1: .v1_0_0,
+					]
+				}
+
+				pending("should fail if no versions match the requirements and prerelease versions exist") {
+					let db: DB = [
+						github1: [
+							.v1_0_0: [:],
+							.v2_0_0_beta_1: [:],
+							.v2_0_0: [:],
+							.v3_0_0_beta_1: [:],
+						],
+						]
+
+					do {
+						let resolved = db.resolve(resolverType, [ github1: .atLeast(.v3_0_0) ])
+						expect(resolved.value).to(beNil())
+						expect(resolved.error).notTo(beNil())
+					}
+					
+					do {
+						let resolved = db.resolve(resolverType, [ github1: .compatibleWith(.v3_0_0) ])
+						expect(resolved.value).to(beNil())
+						expect(resolved.error).notTo(beNil())
+					}
+					
+					do {
+						let resolved = db.resolve(resolverType, [ github1: .exactly(.v3_0_0) ])
+						expect(resolved.value).to(beNil())
+						expect(resolved.error).notTo(beNil())
+					}
+				}
 			}
-
-			do {
-				let resolved = db.resolve([ github1: .compatibleWith(.v3_0_0) ])
-				expect(resolved.value).to(beNil())
-				expect(resolved.error).notTo(beNil())
-			}
-
-			do {
-				let resolved = db.resolve([ github1: .exactly(.v3_0_0) ])
-				expect(resolved.value).to(beNil())
-				expect(resolved.error).notTo(beNil())
-			}
 		}
+
+		itBehavesLike("resolver") { ["resolverType": Resolver.self] }
+		// TODO: Will uncomment when the new resolver is checked in
+		// itBehavesLike("resolver") { ["resolverType": NewResolver.self] }
 	}
 }


### PR DESCRIPTION
Precursor to #2122 

I'd recommend viewing the diff with `?w=1`, since an extra level of indentation got added to the tests, but the differences are not actually that large. 