### PR TITLE
Restrictively match non-semver commitish'es

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -175,9 +175,17 @@ public enum VersionSpecifier: VersionType {
 			if let semanticVersion = SemanticVersion.from(version).value {
 				return predicate(semanticVersion)
 			} else {
-				// Consider non-semantic versions (e.g., branches) to meet every
-				// version range requirement.
-				return true
+				// Restrictively match versions that `SemanticVersion` doesn't understand.
+				switch self {
+				case .any:
+					return true
+					
+				case .gitReference(let currentReference):
+					return version.commitish == currentReference
+					
+				case .atLeast, .compatibleWith, .exactly:
+					return false
+				}
 			}
 		}
 


### PR DESCRIPTION
Changes the matching logic for non-semver versions to be more restrictive so it doesn't match non-semver tags when I specify a semantic versioning tag, fixing issues that I'm seeing when using Carthage with my project.

## More info regarding the issue that I am trying to solve:
By compiling and running Carthage in Xcode, I have found that ReactiveCocoa and a few of my other dependencies have various tags that Carthage 0.24.0 and 0.23.0 (I didn't check older versions) are apparently unable to handle. `carthage update <arguments>` always fails to produce a working set of dependency versions for my project. If I make this change and run Carthage on my project, both `carthage bootstrap <arguments>` and `carthage update <arguments>` work fine.

For ReactiveCocoa, I ran into both issue #469, and a problem where Carthage chooses a non-numeric tag. Carthage appears to use "swift-before-signal-producers" specifically, but I've seen it try various other tags as well. If I clone ReactiveCocoa and just delete the current problem tag, Carthage just chooses another problem tag. I get into a loop where I run Carthage, delete whatever tag it picked, and run Carthage again, only to see it fail on another tag.

(My only experience with Carthage's source is a few hours of time examining its behavior in Xcode's debugger, so I may be missing something important about this behavior. And I just got a few failing tests with this change, which I am checking out.)