### PR TITLE
[BinaryProject] Add `file` scheme support in `Dependency`  #1853

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -286,10 +286,10 @@ extension Dependency: Scannable {
 		} else if scanner.scanString("binary", into: nil) {
 			parser = { urlString in
 				if let url = URL(string: urlString) {
-					if url.scheme == "https" {
+					if url.scheme == "https" || url.scheme == "file" {
 						return .success(self.binary(url))
 					} else {
-						return .failure(ScannableError(message: "non-https URL found for dependency type `binary`", currentLine: scanner.currentLine))
+						return .failure(ScannableError(message: "non-https or non-file URL found for dependency type `binary`", currentLine: scanner.currentLine))
 					}
 				} else {
 					return .failure(ScannableError(message: "invalid URL found for dependency type `binary`", currentLine: scanner.currentLine))

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -289,7 +289,7 @@ extension Dependency: Scannable {
 					if url.scheme == "https" || url.scheme == "file" {
 						return .success(self.binary(url))
 					} else {
-						return .failure(ScannableError(message: "non-https or non-file URL found for dependency type `binary`", currentLine: scanner.currentLine))
+						return .failure(ScannableError(message: "non-https, non-file URL found for dependency type `binary`", currentLine: scanner.currentLine))
 					}
 				} else {
 					return .failure(ScannableError(message: "invalid URL found for dependency type `binary`", currentLine: scanner.currentLine))

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -218,7 +218,7 @@ class DependencySpec: QuickSpec {
 
 					let error = Dependency.from(scanner).error
 
-					expect(error) == ScannableError(message: "non-https or non-file URL found for dependency type `binary`", currentLine: "binary \"nope\"")
+					expect(error) == ScannableError(message: "non-https, non-file URL found for dependency type `binary`", currentLine: "binary \"nope\"")
 				}
 
 				it("should fail with invalid URL") {

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -197,7 +197,7 @@ class DependencySpec: QuickSpec {
 			}
 
 			context("binary") {
-				it("should read a URL") {
+				it("should read a URL with https scheme") {
 					let scanner = Scanner(string: "binary \"https://mysupercoolinternalwebhost.com/\"")
 
 					let dependency = Dependency.from(scanner).value
@@ -205,12 +205,20 @@ class DependencySpec: QuickSpec {
 					expect(dependency) == .binary(URL(string: "https://mysupercoolinternalwebhost.com/")!)
 				}
 
+				it("should read a URL with file scheme") {
+					let scanner = Scanner(string: "binary \"file:///my/domain/com/framework.json\"")
+					
+					let dependency = Dependency.from(scanner).value
+					
+					expect(dependency) == .binary(URL(string: "file:///my/domain/com/framework.json")!)
+				}
+
 				it("should fail with non-https URL") {
 					let scanner = Scanner(string: "binary \"nope\"")
 
 					let error = Dependency.from(scanner).error
 
-					expect(error) == ScannableError(message: "non-https URL found for dependency type `binary`", currentLine: "binary \"nope\"")
+					expect(error) == ScannableError(message: "non-https or non-file URL found for dependency type `binary`", currentLine: "binary \"nope\"")
 				}
 
 				it("should fail with invalid URL") {


### PR DESCRIPTION
Hi,

I look at PR #2140 for #1853 and see that I can help
Like requested in #1853, json file with this PR could be accessed through file URL

I make unit test, and also see that downloading the json file is already tested, because the one used in test (successful.json) is in `Bundle`