### PR TITLE
Use `archive` action when building device SDKs to disable LLVM Instrumentation

### DIFF
--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -190,6 +190,9 @@ public struct BuildSettings {
 		let r2 = self["CONFIGURATION"]
 		guard let configuration = r2.value else { return r2 }
 
+		// A value almost certainly beginning with `-` or (lacking said value) an
+		// empty string to append without effect in the path below because Xcode
+		// expects the path like that.
 		let effectivePlatformName = self["EFFECTIVE_PLATFORM_NAME"].value ?? ""
 
 		// e.g.,

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -631,18 +631,22 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 						var result: [String] = [xcodebuildAction.rawValue]
 
 						if xcodebuildAction == .archive {
-							// Prevent generating unnecessary empty `.xcarchive` directories.
-							result += ["-archivePath", "./"]
-						}
+							result += [
+								// Prevent generating unnecessary empty `.xcarchive`
+								// directories.
+								"-archivePath", "./",
 
-						result += [
-							// Disable GCC (and LLVM) Instrumentation.
-							//
-							// See https://github.com/Carthage/Carthage/issues/2056
-							// and https://developer.apple.com/library/content/qa/qa1964/_index.html.
-							"GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO",
-							"CLANG_ENABLE_CODE_COVERAGE=NO",
-						]
+								// Disable the “Instrument Program Flow” build
+								// setting for both GCC and LLVM as noted in
+								// https://developer.apple.com/library/content/qa/qa1964/_index.html.
+								"GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO",
+
+								// Disable the “Generate Test Coverage Files” build
+								// setting for GCC as noted in
+								// https://developer.apple.com/library/content/qa/qa1964/_index.html.
+								"CLANG_ENABLE_CODE_COVERAGE=NO",
+							]
+						}
 
 						return result
 					}()

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -2,6 +2,19 @@ import Foundation
 
 /// Configures a build with Xcode.
 public struct BuildArguments {
+	/// Available actions for xcodebuild listed in `man xcodebuild`
+	public enum Action: String {
+		case build = "build"
+		case buildForTesting = "build-for-testing"
+		case analyze = "analyze"
+		case archive = "archive"
+		case test = "test"
+		case testWithoutBuilding = "test-without-building"
+		case installSrc = "install-src"
+		case install = "install"
+		case clean = "clean"
+	}
+
 	/// Represents a build setting whether full bitcode should be embedded in the
 	/// binary.
 	public enum BitcodeGenerationMode: String {

--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -26,13 +26,24 @@ public enum SDK: String {
 
 	public static let allSDKs: Set<SDK> = [.macOSX, .iPhoneOS, .iPhoneSimulator, .watchOS, .watchSimulator, .tvOS, .tvSimulator]
 
+	/// Returns whether this is a device SDK.
+	public var isDevice: Bool {
+		switch self {
+		case .macOSX, .iPhoneOS, .watchOS, .tvOS:
+			return true
+
+		case .iPhoneSimulator, .watchSimulator, .tvSimulator:
+			return false
+		}
+	}
+
 	/// Returns whether this is a simulator SDK.
 	public var isSimulator: Bool {
 		switch self {
 		case .iPhoneSimulator, .watchSimulator, .tvSimulator:
 			return true
 
-		case _:
+		case .macOSX, .iPhoneOS, .watchOS, .tvOS:
 			return false
 		}
 	}


### PR DESCRIPTION
Should fix #2056.

See also https://developer.apple.com/library/content/qa/qa1964/_index.html.