### PR TITLE
Avoid name collision on fetching with appending the hash value of a dependency

### DIFF
--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -7,12 +7,15 @@ import Tentacle
 /// Uniquely identifies a project that can be used as a dependency.
 public enum Dependency {
 	/// A repository hosted on GitHub.com or GitHub Enterprise.
+	/// This is treated as case-insensitive.
 	case gitHub(Server, Repository)
 
 	/// An arbitrary Git repository.
+	/// This is treated as case-sensitive.
 	case git(GitURL)
 
 	/// A binary-only framework
+	/// This is treated as case-sensitive.
 	case binary(URL)
 
 	/// The unique, user-visible name for this project.

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -27,6 +27,11 @@ public enum Dependency {
 		}
 	}
 
+	/// The unique identifier for this project which is useful as a file system path.
+	public var fileSystemIdentifier: String {
+		return name + "-" + String(hashValue)
+	}
+
 	/// The path at which this project will be checked out, relative to the
 	/// working directory of the main project.
 	public var relativePath: String {
@@ -35,7 +40,7 @@ public enum Dependency {
 }
 
 extension Dependency {
-	fileprivate init(gitURL: GitURL) {
+	public init(gitURL: GitURL) {
 		let githubHostIdentifier = "github.com"
 		let urlString = gitURL.urlString
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1255,7 +1255,7 @@ private func BCSymbolMapsForFramework(_ frameworkURL: URL, inDirectoryURL direct
 /// Returns the file URL at which the given project's repository will be
 /// located.
 private func repositoryFileURL(for dependency: Dependency, baseURL: URL = Constants.Dependency.repositoriesURL) -> URL {
-	return baseURL.appendingPathComponent(dependency.name, isDirectory: true)
+	return baseURL.appendingPathComponent(dependency.fileSystemIdentifier, isDirectory: true)
 }
 
 /// Returns the string representing a relative path from a dependency back to the root

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -22,7 +22,7 @@ public struct FetchCommand: CommandProtocol {
 	public let function = "Clones or fetches a Git repository ahead of time"
 
 	public func run(_ options: Options) -> Result<(), CarthageError> {
-		let dependency = Dependency.git(options.repositoryURL)
+		let dependency = Dependency(gitURL: options.repositoryURL)
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
 
 		return cloneOrFetch(dependency: dependency, preferHTTPS: true)

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -61,7 +61,9 @@ class ProjectSpec: QuickSpec {
 				for repo in ["TestFramework3", "TestFramework2", "TestFramework1"] {
 					let urlPath = sourceRepoUrl.appendingPathComponent(repo).path
 					let dep = Dependency.git(GitURL(urlPath))
-					let cacheURL = Constants.Dependency.repositoriesURL.appendingPathComponent(dep.fileSystemIdentifier)
+					let cacheURL = Constants.Dependency
+						.repositoriesURL
+						.appendingPathComponent(dep.fileSystemIdentifier.single()!.value!)
 					do {
 						try FileManager.default.removeItem(at: cacheURL)
 					} catch {

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -56,9 +56,19 @@ class ProjectSpec: QuickSpec {
 
 			it("should determine build order without repo cache") {
 				let macOSexpected = ["TestFramework3_Mac", "TestFramework2_Mac", "TestFramework1_Mac"]
-				for dep in ["TestFramework3", "TestFramework2", "TestFramework1"] {
-					_ = try? FileManager.default.removeItem(at: Constants.Dependency.repositoriesURL.appendingPathComponent(dep))
+
+				let sourceRepoUrl = directoryURL.appendingPathComponent("SourceRepos")
+				for repo in ["TestFramework3", "TestFramework2", "TestFramework1"] {
+					let urlPath = sourceRepoUrl.appendingPathComponent(repo).path
+					let dep = Dependency.git(GitURL(urlPath))
+					let cacheURL = Constants.Dependency.repositoriesURL.appendingPathComponent(dep.fileSystemIdentifier)
+					do {
+						try FileManager.default.removeItem(at: cacheURL)
+					} catch {
+						fail("Failed to remove a repository cache at: \(cacheURL)")
+					}
 				}
+
 				// Without the repo cache, it won't know to build frameworks 2 and 3 unless it reads the Cartfile from the checkout directory
 				let result = buildDependencyTest(platforms: [.macOS], cacheBuilds: false, dependenciesToBuild: ["TestFramework1"])
 				expect(result) == macOSexpected


### PR DESCRIPTION
Should fix #2150. Should fix #2143.

This is inspired by https://github.com/apple/swift-package-manager/blob/98cfe1cb24573341488be985fb28d6fe9ecf8920/Sources/SourceControl/Repository.swift#L23-L33.