### PR TITLE
Add option to Outdated to output Xcode-compatible warnings

### DIFF
--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -10,6 +10,7 @@ public struct OutdatedCommand: CommandProtocol {
 	public struct Options: OptionsProtocol {
 		public let useSSH: Bool
 		public let isVerbose: Bool
+		public let outputXcodeWarnings: Bool
 		public let colorOptions: ColorOptions
 		public let directoryPath: String
 
@@ -23,6 +24,7 @@ public struct OutdatedCommand: CommandProtocol {
 			return curry(self.init)
 				<*> mode <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "include nested dependencies")
+				<*> mode <| Option(key: "xcode-warnings", defaultValue: false, usage: "output Xcode compatible warning messages")
 				<*> ColorOptions.evaluate(mode)
 				<*> mode <| projectDirectoryOption
 		}
@@ -53,7 +55,11 @@ public struct OutdatedCommand: CommandProtocol {
 				if !outdatedDependencies.isEmpty {
 					carthage.println(formatting.path("The following dependencies are outdated:"))
 					for (project, current, updated) in outdatedDependencies {
-						carthage.println(formatting.projectName(project.name) + " \(current) -> \(updated)")
+						if options.outputXcodeWarnings {
+							carthage.println("warning: \(formatting.projectName(project.name)) is out of date (\(current) -> \(updated))")
+						} else {
+							carthage.println(formatting.projectName(project.name) + " \(current) -> \(updated)")
+						}
 					}
 				} else {
 					carthage.println("All dependencies are up to date.")


### PR DESCRIPTION
This PR implements #2103

It adds an option `--xcode-warnings` to the `outdated` command to instruct it to output messages that Xcode will treat as warnings:

<img width="267" alt="xcode-warnings-example" src="https://user-images.githubusercontent.com/1205831/31459567-641b53b8-ae78-11e7-8588-70e9cf71e551.png">