### PR TITLE
Fix that `.xcarchive` is generated in parent directory of working directory

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -635,7 +635,7 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 							result += [
 								// Prevent generating unnecessary empty `.xcarchive`
 								// directories.
-								"-archivePath", "./",
+								"-archivePath", (NSTemporaryDirectory() as NSString).appendingPathComponent(workingDirectoryURL.lastPathComponent),
 
 								// Disable installing when running `archive` action
 								// to prevent built frameworks from being deleted


### PR DESCRIPTION
If you specify the current directory (`./`) for `-archivePath` option, `[CURRENT_DIR_NAME].xcarchive` is generated in that parent directory. For example, supposing the current directory is `~/Desktop/Carthage/`, `-archivePath ./` would generate `~/Desktop/Carthage.xcarchive`.

This is because `-archivePath` option's argument is always interpreted as a file path even that is an existing directory path. For example, supposing there is a directory `~/Desktop/Carthage/Build/`, `-archivePath ./Build/` would generate `~/Desktop/Carthage/Build.xcarchive` (if current directory is `~/Desktop/Carthage/`).
See `IDEArchivePathOverride` in the console for how `-archivePath` option would be actually interpreted by `xcodebuild`.

This is more problematic when creating a prebuilt framework using `carthage build --no-skip-current`. Because `[CURRENT_DIR_NAME].xcarchive` is generated outside the git repository, it is hard to notice that.

With this PR, Carthage generates `.xcarchive` in the temporary directory.