### PR TITLE
Strip string terminator from result of git command

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -336,6 +336,7 @@ internal func gitmodulesEntriesInRepository(
 		.flatMap(.concat) { value in parseConfigEntries(value, keyPrefix: "submodule.", keySuffix: ".path") }
 		.flatMap(.concat) { name, path -> SignalProducer<(name: String, path: String, url: GitURL), CarthageError> in
 			return launchGitTask(baseArguments + [ "--get", "submodule.\(name).url" ], repositoryFileURL: repositoryFileURL)
+				.map { $0.stripping(suffix: "\0") }
 				.map { urlString in (name: name, path: path, url: GitURL(urlString)) }
 		}
 }


### PR DESCRIPTION
This is a strange bug I've encountered: 

Carthage failed, but the failure message was printed incompletely:

![screen shot 2017-11-13 at 17 26 54](https://user-images.githubusercontent.com/3407787/32739298-af0ea62c-c89f-11e7-8358-bd16f0e7b1c8.png)

Turns out, the reason was, that the task description contained the string terminator `\0`. Thats the reason the rest of the error message is not printed:
![screen shot 2017-11-13 at 17 27 12](https://user-images.githubusercontent.com/3407787/32739318-c5d4fb0e-c89f-11e7-9a38-70d3b0058bdc.png)

After some digging, I found out that the string terminator is introduced when searching for the repository url of submodules, and if I run the command manually in the terminal, it is printed as well:

![screen shot 2017-11-13 at 18 16 06](https://user-images.githubusercontent.com/3407787/32739327-caa1fee8-c89f-11e7-846a-fbc350de7a05.png)

I wanted to catch this as soon as possible and not just when printing the error, so this change string returned by `launchGitTask`. Not sure if this could also happen for other commands and if this should be applied at other places as well....
