### PR TITLE
Outdated Colors

### DIFF
--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -85,12 +85,20 @@ public struct ColorOptions: OptionsProtocol {
 	}
 
 	public static func evaluate(_ mode: CommandMode) -> Result<ColorOptions, CommandantError<CarthageError>> {
+		return self.evaluate(mode, additionalUsage: nil)
+	}
+
+	public static func evaluate(_ mode: CommandMode, additionalUsage: String? = nil) -> Result<ColorOptions, CommandantError<CarthageError>> {
+		var usage = "whether to apply color and terminal formatting (one of 'auto', 'always', or 'never')"
+		if let additionalUsage = additionalUsage {
+			usage += "\n" + additionalUsage
+		}
 		return curry(self.init)
 			<*> mode <| Option(
 				key: "color",
 				defaultValue: ColorArgument.auto,
-				usage: "whether to apply color and terminal formatting (one of 'auto', 'always', or 'never')"
-			)
+				usage: usage
+		)
 	}
 }
 
@@ -113,21 +121,5 @@ extension ColorOptions.Formatting {
 			return { $0 }
 		}
 		return Color.Wrap(foreground: update.color).wrap
-	}
-
-	public var legendForOutdatedCommand: String? {
-		guard self.isColorful else { return nil }
-
-		let header = "Legend — <color> • «what happens when you run `carthage update`»:\n"
-		return [OutdatedCommand.UpdateType.newest, .newer, .ineligible].reduce(into: header) {
-			let (color, explanation) = ($1.color, $1.explanation)
-			let tabs = String(
-				repeating: "\t",
-				count: color == .yellow || color == .magenta ? 1 : 2
-			)
-			let colorDescription = Color.Wrap(foreground: color)
-				.wrap("<" + String(describing: color) + ">")
-			$0.append(colorDescription + tabs + "• " + explanation + "\n")
-		}
 	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -94,35 +94,40 @@ public struct ColorOptions: OptionsProtocol {
 	}
 }
 
-extension OutdatedCommand.UpdateAvailabilityAndApplicability {
-	fileprivate static let dict: [OutdatedCommand.UpdateAvailabilityAndApplicability: Color.Named.Color] = [
-		.updatesAvailableAllApplicable: .green,
-		.updatesAvailableSomeApplicable: .yellow,
-		.updatesAvailableNoneApplicable: .red,
-	]
+extension OutdatedCommand.UpdateType {
+	var color: Color.Named.Color {
+		switch self {
+		case .newest:
+			return .green
+		case .newer:
+			return .yellow
+		case .ineligible:
+			return .red
+		}
+	}
 }
 
 extension ColorOptions.Formatting {
-	subscript(_ index: OutdatedCommand.UpdateAvailabilityAndApplicability) -> Wrap {
-		guard self.isColorful, let color = OutdatedCommand.UpdateAvailabilityAndApplicability.dict[index] else {
+	subscript(_ index: OutdatedCommand.UpdateType?) -> Wrap {
+		guard self.isColorful, let update = index else {
 			return { $0 }
 		}
-		return Color.Wrap(foreground: color).wrap
+		return Color.Wrap(foreground: update.color).wrap
 	}
 
 	public var legendForOutdatedCommand: String? {
 		guard self.isColorful else { return nil }
 
 		let header = "Legend — <color> • «what happens when you run `carthage update`»:\n"
-		return OutdatedCommand.UpdateAvailabilityAndApplicability.dict.reduce(into: header) {
-			let (situation, color) = $1
+		return [OutdatedCommand.UpdateType.newest, .newer, .ineligible].reduce(into: header) {
+			let (color, explanation) = ($1.color, $1.explanation)
 			let tabs = String(
 				repeating: "\t",
 				count: color == .yellow || color == .magenta ? 1 : 2
 			)
 			let colorDescription = Color.Wrap(foreground: color)
 				.wrap("<" + String(describing: color) + ">")
-			$0.append(colorDescription + tabs + "• " + situation.rawValue + "\n")
+			$0.append(colorDescription + tabs + "• " + explanation + "\n")
 		}
 	}
 }

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -77,6 +77,11 @@ public struct ColorOptions: OptionsProtocol {
 		func quote(_ string: String, quotationMark: String = "\"") -> String {
 			return wrap(isColorful, wrap: Color.Wrap(foreground: .green))(quotationMark + string + quotationMark)
 		}
+
+		/// Wraps a string in a color
+		func colored(_ string: String, color: Color.Named.Color) -> String {
+			return wrap(isColorful, wrap: Color.Wrap(foreground: color))(string)
+		}
 	}
 
 	private init(argument: ColorArgument) {

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -33,6 +33,18 @@ public struct OutdatedCommand: CommandProtocol {
 				return "Will not be updated because of the specified version in Cartfile."
 			}
 		}
+
+		static var legend: String {
+			let header = "Legend — <color> • «what happens when you run `carthage update`»:\n"
+			return header + [UpdateType.newest, .newer, .ineligible].map {
+				let (color, explanation) = ($0.color, $0.explanation)
+				let tabs = String(
+					repeating: "\t",
+					count: color == .yellow || color == .magenta ? 1 : 2
+				)
+				return "<" + String(describing: color) + ">" + tabs + "• " + explanation
+			}.joined(separator: "\n")
+		}
 	}
 
 	public struct Options: OptionsProtocol {
@@ -53,7 +65,7 @@ public struct OutdatedCommand: CommandProtocol {
 				<*> mode <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "include nested dependencies")
 				<*> mode <| Option(key: "xcode-warnings", defaultValue: false, usage: "output Xcode compatible warning messages")
-				<*> ColorOptions.evaluate(mode)
+				<*> ColorOptions.evaluate(mode, additionalUsage: UpdateType.legend)
 				<*> mode <| projectDirectoryOption
 		}
 
@@ -93,7 +105,6 @@ public struct OutdatedCommand: CommandProtocol {
 							carthage.println(formatting.projectName(project.name) + " " + versionSummary)
 						}
 					}
-					formatting.legendForOutdatedCommand.map(carthage.println)
 				} else {
 					carthage.println("All dependencies are up to date.")
 				}

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -4,6 +4,7 @@ import Foundation
 import Result
 import ReactiveSwift
 import Curry
+import PrettyColors
 
 /// Type that encapsulates the configuration and evaluation of the `outdated` subcommand.
 public struct OutdatedCommand: CommandProtocol {
@@ -54,12 +55,39 @@ public struct OutdatedCommand: CommandProtocol {
 
 				if !outdatedDependencies.isEmpty {
 					carthage.println(formatting.path("The following dependencies are outdated:"))
+
 					for (project, current, updated, latest) in outdatedDependencies {
+						let versionColor: Color.Named.Color
+						switch (current, updated, latest) {
+						case (_, updated, latest) where updated == latest:
+							// Update available and applicable
+							versionColor = .green
+						case (current, updated, latest) where current != updated && updated != latest:
+							// Update availabe and applicable, but not to the latest version due to version lock
+							versionColor = .yellow
+						case (current, updated, latest) where current == updated:
+							// Update available, but not applicable due to version lock
+							versionColor = .red
+						default:
+							versionColor = .white
+						}
+
 						if options.outputXcodeWarnings {
 							carthage.println("warning: \(formatting.projectName(project.name)) is out of date (\(current) -> \(updated)) (Latest: \(latest))")
 						} else {
-							carthage.println(formatting.projectName(project.name) + " \(current) -> \(updated) (Latest: \(latest))")
+							let versionSummary = formatting.colored(current.description, color: versionColor)
+								+ " -> " + formatting.colored(updated.description, color: versionColor)
+								+ " (Latest: \(latest))"
+							carthage.println(formatting.projectName(project.name) + " " + versionSummary)
 						}
+					}
+
+					if options.colorOptions.formatting.isColorful {
+						carthage.println(formatting.path("The color indicates what happens when you run `carthage update`"))
+						carthage.println(formatting.colored("<green>", color: .green) + "\t\t- Will be updated to the newest version")
+						carthage.println(formatting.colored("<yellow>", color: .yellow) + "\t- Will be updated, but not to the newest version"
+							+ " because of the specified version in Cartfile")
+						carthage.println(formatting.colored("<red>", color: .red) + "\t\t- Will not be updated because of the specified version in Cartfile")
 					}
 				} else {
 					carthage.println("All dependencies are up to date.")


### PR DESCRIPTION
This builds on top of #2254 and includes color output to the `outdated` command to make it easier to read:

**green** for dependencies that can be updated to the latest version
**yellow** for dependencies that can be updated, where the latest update is not compatible
**red** for outdated dependencies where no compatible update is available.

![screen shot 2017-11-14 at 13 50 33](https://user-images.githubusercontent.com/3407787/32780860-1bf0bff2-c943-11e7-97fb-55ea0d6d8f2c.png)
