### PR TITLE
Cached lastest remote version to avoid blocked fetching in poor network environment

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -8,7 +8,7 @@ import ReactiveSwift
 public protocol VersionType: Hashable {}
 
 /// A semantic version.
-public struct SemanticVersion: VersionType {
+public struct SemanticVersion: VersionType, Codable {
 	/// The major version.
 	///
 	/// Increments to this component represent incompatible API changes.

--- a/Source/carthage/BuildVersion.swift
+++ b/Source/carthage/BuildVersion.swift
@@ -5,8 +5,43 @@ import ReactiveTask
 import Result
 import Tentacle
 
+struct ExpirableVersion: Codable {
+	let version: SemanticVersion?
+	let expiredDate: Date
+
+	init(version: SemanticVersion?, shelfLife: TimeInterval) {
+		self.version = version
+		self.expiredDate = Date(timeIntervalSinceNow: shelfLife)
+	}
+
+	init?(fromJSONData data: Data?) {
+		guard let wrappedData = data, let wrapped = try? JSONDecoder().decode(ExpirableVersion.self, from: wrappedData) else {
+			return nil
+		}
+		self = wrapped
+	}
+
+	func encodedJSONData() -> Data? {
+		return try? JSONEncoder().encode(self)
+	}
+
+	var isExpired: Bool {
+		return Date().compare(expiredDate) == ComparisonResult.orderedDescending
+	}
+}
+
 /// The latest online version as a SemanticVersion object.
 public func remoteVersion() -> SemanticVersion? {
+	let userDefaults = UserDefaults.standard
+	let cachedKey = "latestCarthageRemoteVersion"
+
+	let expirableVersionData = userDefaults.data(forKey: cachedKey)
+	let expirableVersion = ExpirableVersion(fromJSONData: expirableVersionData)
+
+	guard expirableVersion == nil || expirableVersion!.isExpired else {
+		return expirableVersion!.version
+	}
+
 	let latestRemoteVersion = Client(.dotCom)
 		.execute(Repository(owner: "Carthage", name: "Carthage").releases, perPage: 2)
 		.map { _, releases in
@@ -19,5 +54,11 @@ public func remoteVersion() -> SemanticVersion? {
 		.timeout(after: 0.5, raising: CarthageError.gitHubAPITimeout, on: QueueScheduler.main)
 		.first()
 
-	return latestRemoteVersion?.value
+	// Expired after one day
+	let latestExpirableVersion = ExpirableVersion(version: latestRemoteVersion?.value,
+	                                              shelfLife: 24 * 60 * 60)
+	if let encodedData = latestExpirableVersion.encodedJSONData() {
+		userDefaults.set(encodedData, forKey: cachedKey)
+	}
+	return latestExpirableVersion.version
 }


### PR DESCRIPTION
Since `carthage copy-frameworks` will run in each xcodebuild, blocked fetching remote version will make it slow in poor network environment.
A better way is to cache it and run periodically for such a non-critical thing.
  