### PR TITLE
Fixed local project can not build at second time and add Skip feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ DerivedData
 
 Carthage.pkg
 Carthage/Build
+CarthageApp.pkg
+CarthageKit.framework.zip

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -87,6 +87,8 @@ public enum CarthageError: Error {
 
 	/// An internal error occurred
 	case internalError(description: String)
+	
+	case skipped(Dependency)
 }
 
 extension CarthageError {
@@ -334,6 +336,9 @@ extension CarthageError: CustomStringConvertible {
 
 		case let .internalError(description):
 			return description
+			
+		case let .skipped(dependency):
+			return "⚠️   Skip Building: \(dependency.name) accroding to the config in Cartfile"
 		}
 	}
 }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -50,9 +50,7 @@ public func launchGitTask(
 	// See https://github.com/Carthage/Carthage/issues/219.
 	var updatedEnvironment = environment ?? ProcessInfo.processInfo.environment
 	updatedEnvironment["GIT_TERMINAL_PROMPT"] = "0"
-
 	let taskDescription = Task("/usr/bin/env", arguments: [ "git" ] + arguments, workingDirectoryPath: repositoryFileURL?.path, environment: updatedEnvironment)
-
 	return taskDescription.launch(standardInput: standardInput)
 		.ignoreTaskData()
 		.mapError(CarthageError.taskError)
@@ -99,6 +97,7 @@ public func fetchRepository(_ repositoryFileURL: URL, remoteURL: GitURL? = nil, 
 	precondition(repositoryFileURL.isFileURL)
 
 	var arguments = [ "fetch", "--prune", "--quiet" ]
+	
 	if let remoteURL = remoteURL {
 		arguments.append(remoteURL.urlString)
 	}
@@ -116,6 +115,8 @@ public func fetchRepository(_ repositoryFileURL: URL, remoteURL: GitURL? = nil, 
 			FetchCache.updateLastFetchTime(forURL: remoteURL)
 		})
 }
+
+
 
 /// Sends each tag found in the given Git repository.
 public func listTags(_ repositoryFileURL: URL) -> SignalProducer<String, CarthageError> {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -703,7 +703,11 @@ public func build(
 ) -> SignalProducer<BuildSchemeProducer, CarthageError> {
 	let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 	let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
-
+	
+	if Dependency.skippableDependencies.contains(dependency) {
+		let value = SignalProducer<TaskEvent<(ProjectLocator, Scheme)>, CarthageError>(error: .skipped(dependency))
+		return SignalProducer<BuildSchemeProducer, CarthageError>(value: value)
+	}
 	return symlinkBuildPath(for: dependency, rootDirectoryURL: rootDirectoryURL)
 		.map { _ -> BuildSchemeProducer in
 			return buildInDirectory(dependencyURL, withOptions: options, dependency: (dependency, version), rootDirectoryURL: rootDirectoryURL, sdkFilter: sdkFilter)

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -71,6 +71,7 @@ extension GitURL: ArgumentProtocol {
 /// Logs project events put into the sink.
 internal struct ProjectEventSink {
 	private let colorOptions: ColorOptions
+	private var echoMap: [String : [String]] = [:]
 
 	init(colorOptions: ColorOptions) {
 		self.colorOptions = colorOptions
@@ -81,13 +82,18 @@ internal struct ProjectEventSink {
 
 		switch event {
 		case let .cloning(dependency):
-			carthage.println(formatting.bullets + "Cloning " + formatting.projectName(dependency.name))
+			var clones = echoMap["Cloning"] ?? []
+			let name = dependency.name
+			guard clones.contains(name) == false else { return }
+			clones.append(name)
+			echoMap["Cloning"] = clones
+			carthage.println(formatting.bullets + "Cloning " + formatting.projectName(name) + " " + formatting.path(dependency.description) )
 
 		case let .fetching(dependency):
-			carthage.println(formatting.bullets + "Fetching " + formatting.projectName(dependency.name))
+			carthage.println(formatting.bullets + "Fetching " + formatting.projectName(dependency.name) + " " + formatting.path(dependency.description) )
 
 		case let .checkingOut(dependency, revision):
-			carthage.println(formatting.bullets + "Checking out " + formatting.projectName(dependency.name) + " at " + formatting.quote(revision))
+			carthage.println(formatting.bullets + "Checking out " + formatting.projectName(dependency.name) + " at " + formatting.quote(revision) + " path " + formatting.path(dependency.description))
 
 		case let .downloadingBinaryFrameworkDefinition(dependency, url):
 			carthage.println(formatting.bullets + "Downloading binary-only framework " + formatting.projectName(dependency.name)


### PR DESCRIPTION
Due to not fully knowing the project, may this is a workaround, not really solution. 
Can improve later.

Fixed Bug:
- local project will crash at second time build or update, need remove folder in dependencies, and use clone every time
- when local project and remote project that both referred to same `name`, will using local project first

Add new feature:
- Show path for repo when `Cloning`, `Fetching`,  `Checkout`
- Suppoort skip for cetain repo by append `##skip` at the end of line. eg:
> git "../path/to/local/project" == 2.0.0 ##skip