### PR TITLE
[Proposal] Skip binary download & checkout if valid cache exists

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -819,16 +819,15 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.flatMap(.merge) { dependencies, submodulesByPath -> SignalProducer<(), CarthageError> in
 				return SignalProducer<(Dependency, PinnedVersion), CarthageError>(dependencies)
 					.flatMap(.merge) { dependency, version -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
-						guard buildOptions?.cacheBuilds == true else {
+						guard let buildOptions = buildOptions, buildOptions.cacheBuilds else {
 							return .init(value: (dependency, version))
 						}
-						let platforms = buildOptions?.platforms ?? []
 						return versionFileMatches(
 							dependency,
 							version: version,
-							platforms: platforms,
+							platforms: buildOptions.platforms,
 							rootDirectoryURL: self.directoryURL,
-							toolchain: buildOptions?.toolchain).flatMap(.merge) { matched -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
+							toolchain: buildOptions.toolchain).flatMap(.merge) { matched -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
 								matched == true ? .empty : .init(value: (dependency, version))
 						}
 					}


### PR DESCRIPTION
Currently `carthage bootstrap --cache-builds` overwrites existing frameworks with binaries downloaded without checking version files which causes an issue that it overwrites existing valid binaries with ones downloaded even if they were built with incompatible Swift version..

ex) Using Swift 4.0.2 on the machine and the remote binary is built with Swift 4.0.1. Even if this case, Carthage overwrites the valid binary on the machine with the incompatible one and try to build again so far..

Also I was thinking that `carthage bootstrap` should perform the checkout only if needed since it takes long.

To solve these, this PR changes to check version files for each first and then skip downloading & checking out if `--cache-builds` option is provided and the valid cache is found.

P.S. I’m happy to add tests for this but wanna make sure this gets through before.