### PR TITLE
No longer need to send completed

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -120,10 +120,6 @@ public final class Project { // swiftlint:disable:this type_body_length
 		self.directoryURL = directoryURL
 	}
 
-	deinit {
-		_projectEventsObserver.sendCompleted()
-	}
-
 	private typealias CachedVersions = [Dependency: [PinnedVersion]]
 	private typealias CachedBinaryProjects = [URL: BinaryProject]
 


### PR DESCRIPTION
From ReactiveSwift v2 it automatically gets interrupted when observer is deallocated.