### PR TITLE
Disable the "Strip Linked Product" build setting when using the "arch…

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -650,6 +650,10 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 								// setting for GCC as noted in
 								// https://developer.apple.com/library/content/qa/qa1964/_index.html.
 								"CLANG_ENABLE_CODE_COVERAGE=NO",
+
+								// Disable the "Strip Linked Product" build
+								// setting so we can later generate a dSYM
+								"STRIP_INSTALLED_PRODUCT=NO",
 							]
 						}
 


### PR DESCRIPTION
Fix for #2280 and friends.

Disable the "Strip Linked Product" build setting (STRIP_INSTALLED_PRODUCT), when using the "archive" command to build.

This keeps the debug information around so a valid dSYM can be generated.

This change is necessary since Carthage moved to using the "archive" command to build. Most products have `STRIP_INSTALLED_PRODUCT` set to true, but this does not kick in unless you have `DEPLOYMENT_POSTPROCESSING` set to true as well, and that is false for most products. However, using "archive" instead of "build" magically overrides `DEPLOYMENT_POSTPROCESSING` to true, resulting in the product being stripped of debug symbols. As a result dSYM generation produces effectively no information for builds that are built with "archive" (e.g. OSX and iOS device, but not iOS simulator)

This also restores the 0.25 behavior that built frameworks are not stripped. Prior to fix, stripping was happening with the archive command, which may have caused additional issues that were not reported. With this change, we are back to the old behavior and stripping is done at framework copy time.

Testing done:
1. Build a framework using Carthage
2. Use "grep" to check the produced framework for a known source file name.
3. Use "grep" to check the produced dSYM for a known source file name
4. Run an app that uses this framework in Xcode. Open Debug->Debug Workflow->Shared Libraries and ensure the framework has "Debug Symbols" as "Yes"

Prior to fix, all checks above failed, and post fix, all checks above succeed.