### PR TITLE
Limit parallelism in discovery of build settings

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -114,11 +114,9 @@ public func buildableSchemesInDirectory(
 		.flatMap(.concat) { project -> SignalProducer<(ProjectLocator, [Scheme]), CarthageError> in
 			return project
 				.schemes()
-				.flatMap(.merge) { scheme -> SignalProducer<(Scheme, BuildArguments), CarthageError> in
+				.flatMap(.concurrent(limit: 4)) { scheme -> SignalProducer<Scheme, CarthageError> in
 					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
-					return .init(value: (scheme, buildArguments))
-				}
-				.flatMap(.concurrent(limit: 4)) { scheme, buildArguments -> SignalProducer<Scheme, CarthageError> in
+
 					return shouldBuildScheme(buildArguments, platforms)
 						.filter { $0 }
 						.map { _ in scheme }


### PR DESCRIPTION
Currently, on large workspaces, one xcodebuild process is spawned per scheme. This saturates the build host with xcodebuild processes.

This is a proposal to limit the max number of xcodebuild processes to 4 at the buildSettings resolution step. 