### PR TITLE
Only check for buildables schemes once workspace filter has occured

### DIFF
--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -47,18 +47,7 @@ public struct ArchiveCommand: CommandProtocol {
 			})
 		} else {
 			let directoryURL = URL(fileURLWithPath: options.directoryPath, isDirectory: true)
-			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release", forPlatforms: [])
-				.collect()
-				.flatMap(.merge) { projects -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
-					return schemesInProjects(projects)
-						.flatMap(.merge) { (schemes: [(Scheme, ProjectLocator)]) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
-							if !schemes.isEmpty {
-								return .init(schemes)
-							} else {
-								return .init(error: .noSharedFrameworkSchemes(.git(GitURL(directoryURL.path)), []))
-							}
-						}
-				}
+			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release")
 				.flatMap(.merge) { scheme, project -> SignalProducer<BuildSettings, CarthageError> in
 					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: "Release")
 					return BuildSettings.load(with: buildArguments)


### PR DESCRIPTION
When building a large project, like the FB SDK, Carthage would initially check for the buildability of each scheme of each project, then filter to only build what was exposed on on the main workspace.

This change attempt to reduce the number of xcodebuild calls by first collecting all possible shared schemes, then letting the xcworkspace filtering to the magic in order to reduce of work being done.