### PR TITLE
Add aliases for SDK rawValue

### DIFF
--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -69,7 +69,7 @@ public enum SDK: String {
 		return ["tvos": .tvOS]
 	}
 
-	public init?(rawValue: RawValue) {
+	public init?(rawValue: String) {
 		let lowerCasedRawValue = rawValue.lowercased()
 		let maybeSDK = SDK
 			.allSDKs

--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -64,6 +64,24 @@ public enum SDK: String {
 			return .macOS
 		}
 	}
+
+	private static var aliases: [String: SDK] {
+		return ["tvos": .tvOS]
+	}
+
+	public init?(rawValue: RawValue) {
+		let lowerCasedRawValue = rawValue.lowercased()
+		let maybeSDK = SDK
+			.allSDKs
+			.map { ($0, $0.rawValue) }
+			.first(where: { (_, stringValue) in stringValue.lowercased() == lowerCasedRawValue })?
+			.0
+
+		guard let sdk = maybeSDK ?? SDK.aliases[lowerCasedRawValue] else {
+			return nil
+		}
+		self = sdk
+	}
 }
 
 // TODO: this won't be necessary anymore in Swift 2.

--- a/Tests/XCDBLDTests/SDKSpec.swift
+++ b/Tests/XCDBLDTests/SDKSpec.swift
@@ -33,13 +33,21 @@ class SDKSpec: QuickSpec {
 					expect(tvOS2).notTo(beNil())
 					expect(tvOS2) == SDK.tvOS
 					
-					let macos = SDK(rawValue: "macosx")
-					expect(macos).notTo(beNil())
-					expect(macos) == SDK.macOSX
+					let tvOSSimulator = SDK(rawValue: "appletvsimulator")
+					expect(tvOSSimulator).notTo(beNil())
+					expect(tvOSSimulator) == SDK.tvSimulator
 					
-					let ios = SDK(rawValue: "iphoneos")
-					expect(ios).notTo(beNil())
-					expect(ios) == SDK.iPhoneOS
+					let macOS = SDK(rawValue: "macosx")
+					expect(macOS).notTo(beNil())
+					expect(macOS) == SDK.macOSX
+					
+					let iOS = SDK(rawValue: "iphoneos")
+					expect(iOS).notTo(beNil())
+					expect(iOS) == SDK.iPhoneOS
+					
+					let iOSimulator = SDK(rawValue: "iphonesimulator")
+					expect(iOSimulator).notTo(beNil())
+					expect(iOSimulator) == SDK.iPhoneSimulator
 				}
 			}
 		}

--- a/Tests/XCDBLDTests/SDKSpec.swift
+++ b/Tests/XCDBLDTests/SDKSpec.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Nimble
+import Quick
+
+@testable import XCDBLD
+
+class SDKSpec: QuickSpec {
+	override func spec() {
+		describe("\(SDK.self)") {
+			describe("initializer") {
+				it("should return nil for empty string") {
+					expect(SDK(rawValue: "")).to(beNil())
+				}
+				
+				it("should return nil for unexpected input") {
+					expect(SDK(rawValue: "speakerOS")).to(beNil())
+				}
+				
+				it("should return a valid value for expected input") {
+					let watchOS = SDK(rawValue: "watchOS")
+					expect(watchOS).notTo(beNil())
+					expect(watchOS) == SDK.watchOS
+					
+					let watchOSSimulator = SDK(rawValue: "wAtchsiMulator")
+					expect(watchOSSimulator).notTo(beNil())
+					expect(watchOSSimulator) == SDK.watchSimulator
+					
+					let tvOS1 = SDK(rawValue: "tvOS")
+					expect(tvOS1).notTo(beNil())
+					expect(tvOS1) == SDK.tvOS
+					
+					let tvOS2 = SDK(rawValue: "appletvos")
+					expect(tvOS2).notTo(beNil())
+					expect(tvOS2) == SDK.tvOS
+					
+					let macos = SDK(rawValue: "macosx")
+					expect(macos).notTo(beNil())
+					expect(macos) == SDK.macOSX
+					
+					let ios = SDK(rawValue: "iphoneos")
+					expect(ios).notTo(beNil())
+					expect(ios) == SDK.iPhoneOS
+				}
+			}
+		}
+	}
+}

--- a/XCDBLD.xcodeproj/project.pbxproj
+++ b/XCDBLD.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		8A5C8CFC202BB81E002242EB /* SDKSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKSpec.swift; sourceTree = "<group>"; };
+		8A5C8CFC202BB81E002242EB /* SDKSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKSpec.swift; sourceTree = "<group>"; };
 		BE0292401E403278004FB579 /* BuildArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArguments.swift; sourceTree = "<group>"; };
 		BE0292421E403298004FB579 /* BuildArgumentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArgumentsSpec.swift; sourceTree = "<group>"; };
 		BE0292441E40330D004FB579 /* ProjectLocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectLocator.swift; sourceTree = "<group>"; };

--- a/XCDBLD.xcodeproj/project.pbxproj
+++ b/XCDBLD.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A5C8CFE202BBBA4002242EB /* SDKSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5C8CFC202BB81E002242EB /* SDKSpec.swift */; };
 		BE0292411E403278004FB579 /* BuildArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0292401E403278004FB579 /* BuildArguments.swift */; };
 		BE0292431E403298004FB579 /* BuildArgumentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0292421E403298004FB579 /* BuildArgumentsSpec.swift */; };
 		BE0292451E40330D004FB579 /* ProjectLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0292441E40330D004FB579 /* ProjectLocator.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8A5C8CFC202BB81E002242EB /* SDKSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKSpec.swift; sourceTree = "<group>"; };
 		BE0292401E403278004FB579 /* BuildArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArguments.swift; sourceTree = "<group>"; };
 		BE0292421E403298004FB579 /* BuildArgumentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildArgumentsSpec.swift; sourceTree = "<group>"; };
 		BE0292441E40330D004FB579 /* ProjectLocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectLocator.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				BE0292421E403298004FB579 /* BuildArgumentsSpec.swift */,
 				BE02924A1E40337A004FB579 /* ProjectLocatorSpec.swift */,
 				CD54FC591F39EA6700DCE10F /* XcodeVersionSpec.swift */,
+				8A5C8CFC202BB81E002242EB /* SDKSpec.swift */,
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 			);
 			name = XCDBLDTests;
@@ -372,6 +375,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE0292431E403298004FB579 /* BuildArgumentsSpec.swift in Sources */,
+				8A5C8CFE202BBBA4002242EB /* SDKSpec.swift in Sources */,
 				CD54FC5A1F39EA6700DCE10F /* XcodeVersionSpec.swift in Sources */,
 				BE02924B1E40337A004FB579 /* ProjectLocatorSpec.swift in Sources */,
 			);


### PR DESCRIPTION
Fixes #2345 where the actual problem is that `otool` produces a mix of valid `Platform` and `SDK` string raw values.

Eg. 
```
otool -lv Carthage/Build/Mac/VSCCrypto.framework/VSCCrypto  | grep LC_VERSION
      cmd LC_VERSION_MIN_MACOSX

otool -lv Carthage/Build/iOS/VSCCrypto.framework/VSCCrypto  | grep LC_VERSION
      cmd LC_VERSION_MIN_IPHONEOS

otool -lv Carthage/Build/watchOS/VSCCrypto.framework/VSCCrypto  | grep LC_VERSION
      cmd LC_VERSION_MIN_WATCHOS
      cmd LC_VERSION_MIN_WATCHOS
```
But for tvOS...

```
otool -lv Carthage/Build/tvOS/VSCCrypto.framework/VSCCrypto  | grep LC_VERSION
      cmd LC_VERSION_MIN_TVOS
```

which is awkward since following convention this should be `LC_VERSION_MIN_APPLETVOS`
or the other ones should be MACOS, IOS, WATCHOS