### PR TITLE
Speed up build command

### DIFF
--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -117,10 +117,10 @@ public struct BuildSettings {
 	///
 	/// If an SDK is unrecognized or could not be determined, an error will be
 	/// sent on the returned signal.
-	public static func SDKsForScheme(_ scheme: Scheme, inProject project: ProjectLocator) -> SignalProducer<SDK, CarthageError> {
+	public static func SDKsForScheme(_ scheme: Scheme, inProject project: ProjectLocator) -> SignalProducer<(BuildSettings,SDK), CarthageError> {
 		return load(with: BuildArguments(project: project, scheme: scheme))
 			.take(first: 1)
-			.flatMap(.merge) { $0.buildSDKs }
+			.flatMap(.merge) { settings in settings.buildSDKs.map { (settings, $0) } }
 	}
 
 	/// Returns the value for the given build setting, or an error if it could


### PR DESCRIPTION
Reduce the amount of calls to `xcodebuild` by `min(1, number_of_sdks_in_scheme * n_schemes)` by returning `BuildSettings` and `SDK` at the same time.

