### PR TITLE
Don't create Carthage/Build symlink if project doesn't use Carthage

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -965,7 +965,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 		_ options: BuildOptions,
 		dependenciesToBuild: [String]? = nil,
 		sdkFilter: @escaping SDKFilterCallback = { sdks, _, _, _ in .success(sdks) }
-	) -> SignalProducer<BuildSchemeProducer, CarthageError> {
+	) -> BuildSchemeProducer {
 		return loadResolvedCartfile()
 			.flatMap(.concat) { resolvedCartfile -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
 				return self.buildOrderForResolvedCartfile(resolvedCartfile, dependenciesToInclude: dependenciesToBuild)
@@ -1013,7 +1013,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 							return self.installBinaries(for: dependency, pinnedVersion: version, toolchain: options.toolchain)
 								.filterMap { installed -> (Dependency, PinnedVersion)? in
 									return installed ? (dependency, version) : nil
-							}
+								}
 						case let .binary(url):
 							return self.installBinariesForBinaryProject(url: url, pinnedVersion: version, projectName: dependency.name, toolchain: options.toolchain)
 								.then(.init(value: (dependency, version)))
@@ -1029,7 +1029,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 					}
 					.flatten()
 			}
-			.flatMap(.concat) { dependency, version -> SignalProducer<BuildSchemeProducer, CarthageError> in
+			.flatMap(.concat) { dependency, version -> BuildSchemeProducer in
 				let dependencyPath = self.directoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true).path
 				if !FileManager.default.fileExists(atPath: dependencyPath) {
 					return .empty
@@ -1042,21 +1042,68 @@ public final class Project { // swiftlint:disable:this type_body_length
 				let derivedDataVersioned = derivedDataPerDependency.appendingPathComponent(version.commitish, isDirectory: true)
 				options.derivedDataPath = derivedDataVersioned.resolvingSymlinksInPath().path
 
-				return build(dependency: dependency, version: version, self.directoryURL, withOptions: options, sdkFilter: sdkFilter)
-					.map { producer -> BuildSchemeProducer in
-						return producer.flatMapError { error in
-							switch error {
-							case .noSharedFrameworkSchemes:
-								// Log that building the dependency is being skipped,
-								// not to error out with `.noSharedFrameworkSchemes`
-								// to continue building other dependencies.
-								self._projectEventsObserver.send(value: .skippedBuilding(dependency, error.description))
-								return .empty
-
-							default:
-								return SignalProducer(error: error)
-							}
+				return self
+					.dependencySet(for: dependency, version: version)
+					.flatMap(.concat) { dependencies -> SignalProducer<(), CarthageError> in
+						// Don't create symlink the build folder if the dependencies doesn't have
+						// any Carthage dependencies.
+						if dependencies.isEmpty {
+							return .empty
 						}
+						return symlinkBuildPath(for: dependency, rootDirectoryURL: self.directoryURL)
+					}
+					.then(build(dependency: dependency, version: version, self.directoryURL, withOptions: options, sdkFilter: sdkFilter))
+					.flatMapError { error in
+						switch error {
+						case .noSharedFrameworkSchemes:
+							// Log that building the dependency is being skipped,
+							// not to error out with `.noSharedFrameworkSchemes`
+							// to continue building other dependencies.
+							self._projectEventsObserver.send(value: .skippedBuilding(dependency, error.description))
+							return .empty
+
+						default:
+							return SignalProducer(error: error)
+						}
+					}
+			}
+	}
+}
+
+/// Creates symlink between the dependency build folder and the root build folder
+///
+/// Returns a signal indicating success
+private func symlinkBuildPath(for dependency: Dependency, rootDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
+	return SignalProducer { () -> Result<(), CarthageError> in
+		let rootBinariesURL = rootDirectoryURL.appendingPathComponent(Constants.binariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
+		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
+		let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
+		let fileManager = FileManager.default
+
+		// Link this dependency's Carthage/Build folder to that of the root
+		// project, so it can see all products built already, and so we can
+		// automatically drop this dependency's product in the right place.
+		let dependencyBinariesURL = dependencyURL.appendingPathComponent(Constants.binariesFolderPath, isDirectory: true)
+
+		let createDirectory = { try fileManager.createDirectory(at: $0, withIntermediateDirectories: true) }
+		return Result(at: rootBinariesURL, attempt: createDirectory)
+			.flatMap { _ in
+				Result(at: dependencyBinariesURL, attempt: fileManager.removeItem(at:))
+					.recover(with: Result(at: dependencyBinariesURL.deletingLastPathComponent(), attempt: createDirectory))
+			}
+			.flatMap { _ in
+				Result(at: rawDependencyURL, carthageError: CarthageError.readFailed, attempt: {
+						try $0.resourceValues(forKeys: [ .isSymbolicLinkKey ]).isSymbolicLink
+					})
+					.flatMap { isSymlink in
+						Result(at: dependencyBinariesURL, attempt: {
+							if isSymlink == true {
+								return try fileManager.createSymbolicLink(at: $0, withDestinationURL: rootBinariesURL)
+							} else {
+								let linkDestinationPath = relativeLinkDestination(for: dependency, subdirectory: Constants.binariesFolderPath)
+								return try fileManager.createSymbolicLink(atPath: $0.path, withDestinationPath: linkDestinationPath)
+							}
+						})
 					}
 			}
 	}

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -19,7 +19,6 @@ class ProjectSpec: QuickSpec {
 			func buildDependencyTest(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [String] {
 				let project = Project(directoryURL: directoryURL)
 				let result = project.buildCheckedOutDependenciesWithOptions(BuildOptions(configuration: "Debug", platforms: platforms, cacheBuilds: cacheBuilds), dependenciesToBuild: dependenciesToBuild)
-					.flatten(.concat)
 					.ignoreTaskData()
 					.on(value: { project, scheme in
 						NSLog("Building scheme \"\(scheme)\" in \(project)")

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -127,7 +127,6 @@ class XcodeSpec: QuickSpec {
 
 			for dependency in dependencies {
 				let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
-					.flatten(.concat)
 					.ignoreTaskData()
 					.on(value: { project, scheme in // swiftlint:disable:this end_closure
 						NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -137,7 +136,7 @@ class XcodeSpec: QuickSpec {
 				expect(result.error).to(beNil())
 			}
 
-			let result = buildInDirectory(directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this closure_params_parantheses
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -239,7 +238,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.default.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -268,7 +267,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.default.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -291,7 +290,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.default.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [.macOS]))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [.macOS]), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -312,7 +311,7 @@ class XcodeSpec: QuickSpec {
 
 			_ = try? FileManager.default.removeItem(at: _buildFolderURL)
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -335,7 +334,6 @@ class XcodeSpec: QuickSpec {
 			let dependency = Dependency.gitHub(.dotCom, Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
 			let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS ]))
-				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { project, scheme in
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -357,7 +355,6 @@ class XcodeSpec: QuickSpec {
 			let dependency = Dependency.gitHub(.dotCom, Repository(owner: "github", name: "Archimedes"))
 			let version = PinnedVersion("0.1")
 			let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [ .macOS, .iOS ]))
-				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { project, scheme in
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -405,7 +402,6 @@ class XcodeSpec: QuickSpec {
 			let dependencyBuildURL = dependencyURL.appendingPathComponent(Constants.binariesFolderPath)
 
 			let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
-				.flatten(.concat)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")


### PR DESCRIPTION
This prevents us from polluting those dependencies with a `Carthage/` directory. (This can be annoying if you're using submodules and they haven't ignored that directory.)