### PR TITLE
Check if schemes are buildable with projects, not workspaces

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -132,35 +132,38 @@ public func buildableSchemesInDirectory(
 		.flatMap(.merge) { (projects: [(ProjectLocator, [Scheme])]) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
 			return schemesInProjects(projects).flatten()
 		}
-		.flatMap(.merge) { scheme, project -> SignalProducer<(Scheme, ProjectLocator, ProjectLocator), CarthageError> in
-			return locator
-				// This scheduler hop is required to avoid disallowed recursive signals.
-				// See https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2042.
-				.start(on: QueueScheduler(qos: .default, name: "org.carthage.CarthageKit.Xcode.buildInDirectory"))
-				// Pick up the first workspace which can build the scheme.
-				.filter { project, schemes in
-					switch project {
-					case .workspace where schemes.contains(scheme):
-						return true
-
-					default:
-						return false
-					}
-				}
-				// If there is no appropriate workspace, use the project in
-				// which the scheme is defined instead.
-				.concat(value: (project, []))
-				.take(first: 1)
-				.map { host, _ in (scheme, project, host) }
-		}
-		.flatMap(.concurrent(limit: 4)) { (scheme: Scheme, project: ProjectLocator, host: ProjectLocator) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+		.flatMap(.concurrent(limit: 4)) { scheme, project -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
 			/// Check whether we should the scheme by checking against the project. If we're building
 			/// from a workspace, then it might include additional targets that would trigger our
 			/// check.
 			let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
 			return shouldBuildScheme(buildArguments, platforms)
 				.filter { $0 }
-				.map { _ in (scheme, host) }
+				.map { _ in (scheme, project) }
+		}
+		.flatMap(.concurrent(limit: 4)) { scheme, project -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+			return locator
+				// This scheduler hop is required to avoid disallowed recursive signals.
+				// See https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2042.
+				.start(on: QueueScheduler(qos: .default, name: "org.carthage.CarthageKit.Xcode.buildInDirectory"))
+				// Pick up the first workspace which can build the scheme.
+				.flatMap(.concat) { project, schemes -> SignalProducer<ProjectLocator, CarthageError> in
+					switch project {
+					case .workspace where schemes.contains(scheme):
+						let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
+						return shouldBuildScheme(buildArguments, platforms)
+							.filter { $0 }
+							.map { _ in project }
+
+					default:
+						return .empty
+					}
+				}
+				// If there is no appropriate workspace, use the project in
+				// which the scheme is defined instead.
+				.concat(value: project)
+				.take(first: 1)
+				.map { project in (scheme, project) }
 		}
 		.collect()
 		.flatMap(.merge) { (schemes: [(Scheme, ProjectLocator)]) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -138,7 +138,7 @@ public func buildableSchemesInDirectory(
 						return .init(error: .noSharedFrameworkSchemes(.git(GitURL(directoryURL.path)), platforms))
 					}
 				}
-		}.flatMap(.merge) { scheme, project -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+		}.flatMap(.merge) { scheme, project -> SignalProducer<(Scheme, ProjectLocator, ProjectLocator), CarthageError> in
 			return locator
 				// This scheduler hop is required to avoid disallowed recursive signals.
 				// See https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2042.
@@ -157,13 +157,16 @@ public func buildableSchemesInDirectory(
 				// which the scheme is defined instead.
 				.concat(value: (project, []))
 				.take(first: 1)
-				.map { project, _ in (scheme, project) }
+				.map { host, _ in (scheme, project, host) }
 		}
-		.flatMap(.concurrent(limit: 4)) { (scheme: Scheme, project: ProjectLocator) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+		.flatMap(.concurrent(limit: 4)) { (scheme: Scheme, project: ProjectLocator, host: ProjectLocator) -> SignalProducer<(Scheme, ProjectLocator), CarthageError> in
+			/// Check whether we should the scheme by checking against the project. If we're building
+			/// from a workspace, then it might include additional targets that would trigger our
+			/// check.
 			let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: configuration)
 			return shouldBuildScheme(buildArguments, platforms)
 				.filter { $0 }
-				.map { _ in (scheme, project) }
+				.map { _ in (scheme, host) }
 		}
 }
 


### PR DESCRIPTION
Fixes #2369.

This broke in #2344. The check for whether a scheme should be built needs to occur against the project it's from, not against the workspace that includes it.

cc @jdhealy @allenhumphreys