### PR TITLE
Resolve all swiftlint violations.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,9 +17,11 @@ opt_in_rules:
 - vertical_parameter_alignment_on_call
 
 disabled_rules:
+- closure_end_indentation
+- function_parameter_count
+- identifier_name
 - redundant_string_enum_value
 - superfluous_disable_command
-- identifier_name
 
 included:
 - Source

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Result
 
+/// Represents a binary dependency 
 public struct BinaryProject {
 	private static let jsonDecoder = JSONDecoder()
 

--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -15,8 +15,14 @@ public struct BuildOptions {
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
 
-	public init(configuration: String, platforms: Set<Platform> = [], toolchain: String? = nil,
-				derivedDataPath: String? = nil, cacheBuilds: Bool = true, useBinaries: Bool = true) {
+	public init(
+		configuration: String,
+		platforms: Set<Platform> = [],
+		toolchain: String? = nil,
+		derivedDataPath: String? = nil,
+		cacheBuilds: Bool = true,
+		useBinaries: Bool = true
+	) {
 		self.configuration = configuration
 		self.platforms = platforms
 		self.toolchain = toolchain

--- a/Source/CarthageKit/Errors.swift
+++ b/Source/CarthageKit/Errors.swift
@@ -254,7 +254,7 @@ extension CarthageError: CustomStringConvertible {
 		case let .noSharedFrameworkSchemes(dependency, platforms):
 			var description = "Dependency \"\(dependency.name)\" has no shared framework schemes"
 			if !platforms.isEmpty {
-				let platformsString = platforms.map { $0.description }.joined(separator: ", ")
+				let platformsString = platforms.map { $0.rawValue }.joined(separator: ", ")
 				description += " for any of the platforms: \(platformsString)"
 			}
 

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -159,21 +159,21 @@ public func checkoutRepositoryToDirectory(
 			var environment = ProcessInfo.processInfo.environment
 			environment["GIT_WORK_TREE"] = workingDirectoryURL.path
 			return .success(environment)
-		}
-		.attempt { _ in
-			Result(attempt: { try FileManager.default.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true) })
-				.mapError {
-					CarthageError.repositoryCheckoutFailed(
-						workingDirectoryURL: workingDirectoryURL,
-						reason: "Could not create working directory",
-						underlyingError: $0
-					)
-				}
-		}
-		.flatMap(.concat) { environment in
-			return launchGitTask([ "checkout", "--quiet", "--force", revision ], repositoryFileURL: repositoryFileURL, environment: environment)
-		}
-		.then(SignalProducer<(), CarthageError>.empty)
+	}
+	.attempt { _ in
+		Result(attempt: { try FileManager.default.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true) })
+			.mapError {
+				CarthageError.repositoryCheckoutFailed(
+					workingDirectoryURL: workingDirectoryURL,
+					reason: "Could not create working directory",
+					underlyingError: $0
+				)
+			}
+	}
+	.flatMap(.concat) { environment in
+		return launchGitTask([ "checkout", "--quiet", "--force", revision ], repositoryFileURL: repositoryFileURL, environment: environment)
+	}
+	.then(SignalProducer<(), CarthageError>.empty)
 }
 
 /// Clones the given submodule into the working directory of its parent
@@ -215,13 +215,13 @@ public func cloneSubmoduleInWorkingDirectory(_ submodule: Submodule, _ workingDi
 		}
 
 	return SignalProducer<(), CarthageError> { () -> Result<(), CarthageError> in
-			repositoryCheck("remove submodule checkout") {
-				try FileManager.default.removeItem(at: submoduleDirectoryURL)
-			}
+		repositoryCheck("remove submodule checkout") {
+			try FileManager.default.removeItem(at: submoduleDirectoryURL)
 		}
-		.then(cloneRepository(submodule.url, workingDirectoryURL.appendingPathComponent(submodule.path), isBare: false))
-		.then(checkoutSubmodule(submodule, submoduleDirectoryURL))
-		.then(purgeGitDirectories)
+	}
+	.then(cloneRepository(submodule.url, workingDirectoryURL.appendingPathComponent(submodule.path), isBare: false))
+	.then(checkoutSubmodule(submodule, submoduleDirectoryURL))
+	.then(purgeGitDirectories)
 }
 
 /// Recursively checks out the given submodule's revision, in its working
@@ -315,7 +315,7 @@ public func submoduleSHAForPath(_ repositoryFileURL: URL, _ path: String, revisi
 internal func gitmodulesEntriesInRepository(
 	_ repositoryFileURL: URL,
 	revision: String?
-) -> SignalProducer<(name: String, path: String, url: GitURL), CarthageError> {
+) -> SignalProducer<(name: String, path: String, url: GitURL), CarthageError> { // swiftlint:disable:this large_tuple
 	var baseArguments = [ "config", "-z" ]
 	let modulesFile = ".gitmodules"
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -434,7 +434,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 								specifier = .any
 							}
 							result[dependency] = specifier
-					}
+						}
 				}
 				.flatMap(.merge) { resolver.resolve(dependencies: $0, lastResolved: nil, dependenciesToUpdate: nil) }
 		}
@@ -595,8 +595,6 @@ public final class Project { // swiftlint:disable:this type_body_length
 	///
 	/// Sends a boolean indicating whether binaries were installed.
 	private func installBinaries(for dependency: Dependency, pinnedVersion: PinnedVersion, toolchain: String?) -> SignalProducer<Bool, CarthageError> {
-		let checkoutDirectoryURL = self.directoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
-
 		switch dependency {
 		case let .gitHub(server, repository):
 			let client = Client(server: server)
@@ -919,10 +917,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 		let fileManager = FileManager.default
 
 		return self.dependencySet(for: dependency, version: version)
-			.zip(with: // file system objects which might conflict with symlinks
-				list(treeish: version.commitish, atPath: carthageProjectCheckoutsPath, inRepository: repositoryURL)
-					.map { (path: String) in (path as NSString).lastPathComponent }
-					.collect()
+			// file system objects which might conflict with symlinks
+			.zip(with: list(treeish: version.commitish, atPath: carthageProjectCheckoutsPath, inRepository: repositoryURL)
+									.map { (path: String) in (path as NSString).lastPathComponent }
+									.collect()
 			)
 			.attemptMap { (dependencies: Set<Dependency>, components: [String]) -> Result<(), CarthageError> in
 				let names = dependencies
@@ -967,6 +965,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 						// user wrote this directory, unaware of the precedent not to circumvent carthage’s management?
 						// directory exists as the result of rogue process or gamma ray?
 
+						// swiftlint:disable:next todo
 						// TODO: explore possibility of messaging user, informing that deleting said directory will result
 						// in symlink creation with carthage versions greater than 0.20.0, maybe with more broad advice on
 						// “from scratch” reproducability.
@@ -990,7 +989,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 	/// be rebuilt unless otherwise specified via build options.
 	///
 	/// Returns a producer-of-producers representing each scheme being built.
-	public func buildCheckedOutDependenciesWithOptions(
+	public func buildCheckedOutDependenciesWithOptions( // swiftlint:disable:this function_body_length
 		_ options: BuildOptions,
 		dependenciesToBuild: [String]? = nil,
 		sdkFilter: @escaping SDKFilterCallback = { sdks, _, _, _ in .success(sdks) }

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -2,6 +2,7 @@ import Foundation
 import Result
 import ReactiveSwift
 
+/// Protocol for resolving acyclic dependency graphs.
 public protocol ResolverProtocol {
 	init(
 		versionsForDependency: @escaping (Dependency) -> SignalProducer<PinnedVersion, CarthageError>,

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -102,7 +102,7 @@ public func xcodebuildTask(_ task: String, _ buildArguments: BuildArguments) -> 
 
 /// Finds schemes of projects or workspaces, which Carthage should build, found
 /// within the given directory.
-public func buildableSchemesInDirectory(
+public func buildableSchemesInDirectory( // swiftlint:disable:this function_body_length
 	_ directoryURL: URL,
 	withConfiguration configuration: String,
 	forPlatforms platforms: Set<Platform> = []
@@ -435,7 +435,7 @@ public typealias SDKFilterCallback = (_ sdks: [SDK], _ scheme: Scheme, _ configu
 ///
 /// Returns a signal of all standard output from `xcodebuild`, and a signal
 /// which will send the URL to each product successfully built.
-public func buildScheme( // swiftlint:disable:this function_body_length function_parameter_count cyclomatic_complexity
+public func buildScheme( // swiftlint:disable:this function_body_length cyclomatic_complexity
 	_ scheme: Scheme,
 	withOptions options: BuildOptions,
 	inProject project: ProjectLocator,
@@ -496,7 +496,6 @@ public func buildScheme( // swiftlint:disable:this function_body_length function
 		.flatMap(.concat) { platform, sdks -> SignalProducer<TaskEvent<URL>, CarthageError> in
 			let folderURL = rootDirectoryURL.appendingPathComponent(platform.relativePath, isDirectory: true).resolvingSymlinksInPath()
 
-			// TODO: Generalize this further?
 			switch sdks.count {
 			case 1:
 				return build(sdk: sdks[0], with: buildArgs, in: workingDirectoryURL)
@@ -582,6 +581,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length function
 }
 
 /// Runs the build for a given sdk and build arguments, optionally performing a clean first
+// swiftlint:disable:next function_body_length
 private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectoryURL: URL) -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> {
 	var argsForLoading = buildArgs
 	argsForLoading.sdk = sdk
@@ -761,7 +761,7 @@ public func build(
 /// Builds the any shared framework schemes found within the given directory.
 ///
 /// Returns a signal of all standard output from `xcodebuild`, and each scheme being built.
-public func buildInDirectory(
+public func buildInDirectory( // swiftlint:disable:this function_body_length
 	_ directoryURL: URL,
 	withOptions options: BuildOptions,
 	dependency: (dependency: Dependency, version: PinnedVersion)? = nil,
@@ -787,7 +787,14 @@ public func buildInDirectory(
 					return sdkFilter(filteredSDKs, scheme, configuration, project)
 				}
 
-				return buildScheme(scheme, withOptions: options, inProject: project, rootDirectoryURL: rootDirectoryURL, workingDirectoryURL: directoryURL, sdkFilter: wrappedSDKFilter)
+				return buildScheme(
+						scheme,
+						withOptions: options,
+						inProject: project,
+						rootDirectoryURL: rootDirectoryURL,
+						workingDirectoryURL: directoryURL,
+						sdkFilter: wrappedSDKFilter
+					)
 					.mapError { error -> CarthageError in
 						if case let .taskError(taskError) = error {
 							return .buildFailed(taskError, log: nil)
@@ -1041,7 +1048,7 @@ public func architecturesInPackage(_ packageURL: URL) -> SignalProducer<String, 
 public func stripDebugSymbols(_ frameworkURL: URL) -> SignalProducer<(), CarthageError> {
 	return SignalProducer<URL, CarthageError> { () -> Result<URL, CarthageError> in binaryURL(frameworkURL) }
 		.flatMap(.merge) { binaryURL -> SignalProducer<TaskEvent<Data>, CarthageError> in
-			let stripTask = Task("/usr/bin/xcrun", arguments: [ "strip", "-S","-o", binaryURL.path, binaryURL.path])
+			let stripTask = Task("/usr/bin/xcrun", arguments: [ "strip", "-S", "-o", binaryURL.path, binaryURL.path])
 			return stripTask.launch()
 				.mapError(CarthageError.taskError)
 		}

--- a/Source/XCDBLD/Platform.swift
+++ b/Source/XCDBLD/Platform.swift
@@ -34,10 +34,3 @@ public enum Platform: String {
 		}
 	}
 }
-
-// TODO: this won't be necessary anymore with Swift 2.
-extension Platform: CustomStringConvertible {
-	public var description: String {
-		return rawValue
-	}
-}

--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -74,7 +74,7 @@ public enum SDK: String {
 		let maybeSDK = SDK
 			.allSDKs
 			.map { ($0, $0.rawValue) }
-			.first(where: { (_, stringValue) in stringValue.lowercased() == lowerCasedRawValue })?
+			.first { _, stringValue in stringValue.lowercased() == lowerCasedRawValue }?
 			.0
 
 		guard let sdk = maybeSDK ?? SDK.aliases[lowerCasedRawValue] else {
@@ -84,7 +84,6 @@ public enum SDK: String {
 	}
 }
 
-// TODO: this won't be necessary anymore in Swift 2.
 extension SDK: CustomStringConvertible {
 	public var description: String {
 		switch self {

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -37,6 +37,7 @@ public struct ArchiveCommand: CommandProtocol {
 	public let verb = "archive"
 	public let function = "Archives built frameworks into a zip that Carthage can use"
 
+	// swiftlint:disable:next function_body_length
 	public func run(_ options: Options) -> Result<(), CarthageError> {
 		let formatting = options.colorOptions.formatting
 

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -48,7 +48,12 @@ public struct CopyFrameworksCommand: CommandProtocol {
 private func copyFramework(_ source: URL, target: URL, validArchitectures: [String]) -> SignalProducer<(), CarthageError> {
 	return SignalProducer.combineLatest(copyProduct(source, target), codeSigningIdentity())
 		.flatMap(.merge) { url, codesigningIdentity -> SignalProducer<(), CarthageError> in
-			let strip = stripFramework(url, keepingArchitectures: validArchitectures, strippingDebugSymbols: shouldStripDebugSymbols(), codesigningIdentity: codesigningIdentity)
+			let strip = stripFramework(
+				url,
+				keepingArchitectures: validArchitectures,
+				strippingDebugSymbols: shouldStripDebugSymbols(),
+				codesigningIdentity: codesigningIdentity
+			)
 			if buildActionIsArchiveOrInstall() {
 				return strip
 					.then(copyBCSymbolMapsForFramework(url, fromDirectory: source.deletingLastPathComponent()))

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -299,7 +299,7 @@ class XcodeSpec: QuickSpec {
 		it("should error out with .noSharedFrameworkSchemes if there is no shared framework schemes") {
 			let _directoryURL = Bundle(for: type(of: self)).url(forResource: "Swell-0.5.0", withExtension: nil)!
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug", platforms: [.macOS]), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -316,6 +316,7 @@ class XcodeSpec: QuickSpec {
 			}
 
 			expect(isExpectedError) == true
+			expect(result.error?.description) == "Dependency \"Swell-0.5.0\" has no shared framework schemes for any of the platforms: Mac"
 		}
 
 		it("should build for one platform") {


### PR DESCRIPTION
Some clean up of the compilation warnings. Most of this is either adding `swiftlint:disable` hints or resolving the issue.

In collaboration with @mdiep, I disabled 2 rules in `.swiftlint.yml` definition.
I also removed conformance to `CustomStringConvertible` for `Platform` as it only returned the `rawValue` and the call site was accessing `description` directly, which defeats the purpose of the protocol. I updated the call site to use `rawValue` directly. I added a test around this to make sure nothing changed.