### PR TITLE
Fix for segmentation fault when bootstrapping

### DIFF
--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -252,7 +252,7 @@ public func createVersionFileForCommitish(
 				let frameworkName = url.deletingPathExtension().lastPathComponent
 				let platformName = url.deletingLastPathComponent().lastPathComponent
 				let frameworkURL = url.appendingPathComponent(frameworkName, isDirectory: false)
-				let details = SignalProducer<(String, String), CarthageError>(value: (frameworkName, platformName))
+				let details = SignalProducer<(String, String), CarthageError>(value: (platformName, frameworkName))
 				return SignalProducer.zip(hashForFileAtURL(frameworkURL), details)
 			}
 			.reduce(into: platformCaches) { (platformCaches: inout PlatformCaches, values: (String, (String, String))) in

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -237,16 +237,14 @@ public func createVersionFileForCommitish(
 	buildProducts: [URL],
 	rootDirectoryURL: URL
 ) -> SignalProducer<(), CarthageError> {
-	typealias PlatformCaches = [String:[CachedFramework]]
-
-	var platformCaches: PlatformCaches = [:]
-
-	let platformsToCache = platforms.isEmpty ? Set(Platform.supportedPlatforms) : platforms
-	for platform in platformsToCache {
-		platformCaches[platform.rawValue] = []
-	}
-
 	if !buildProducts.isEmpty {
+		var platformCaches: [String:[CachedFramework]] = [:]
+
+		let platformsToCache = platforms.isEmpty ? Set(Platform.supportedPlatforms) : platforms
+		for platform in platformsToCache {
+			platformCaches[platform.rawValue] = []
+		}
+
 		return SignalProducer<URL, CarthageError>(buildProducts)
 			.flatMap(.merge) { url -> SignalProducer<(String, (String, String)), CarthageError> in
 				let frameworkName = url.deletingPathExtension().lastPathComponent
@@ -255,7 +253,7 @@ public func createVersionFileForCommitish(
 				let details = SignalProducer<(String, String), CarthageError>(value: (platformName, frameworkName))
 				return SignalProducer.zip(hashForFileAtURL(frameworkURL), details)
 			}
-			.reduce(into: platformCaches) { (platformCaches: inout PlatformCaches, values: (String, (String, String))) in
+			.reduce(into: platformCaches) { (platformCaches: inout [String:[CachedFramework]], values: (String, (String, String))) in
 				let hash = values.0
 				let platformName = values.1.0
 				let frameworkName = values.1.1
@@ -272,7 +270,7 @@ public func createVersionFileForCommitish(
 	} else {
 		// Write out an empty version file for dependencies with no built frameworks, so cache builds can differentiate between
 		// no cache and a dependency that has no frameworks
-		return createVersionFile(commitish, dependencyName: dependencyName, rootDirectoryURL: rootDirectoryURL, platformCaches: platformCaches)
+		return createVersionFile(commitish, dependencyName: dependencyName, rootDirectoryURL: rootDirectoryURL, platformCaches: [:])
 	}
 }
 

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -253,7 +253,7 @@ public func createVersionFileForCommitish(
 				let frameworkURL = url.appendingPathComponent(frameworkName, isDirectory: false)
 				return SignalProducer.zip(hashForFileAtURL(frameworkURL), SignalProducer<URL, CarthageError>(value: url))
 			}
-			.reduce(into: PlatformCaches()) { (platformCaches, values) in
+			.reduce(into: platformCaches) { (platformCaches: inout PlatformCaches, values: (String, URL)) in
 				let hash = values.0
 				let url = values.1
 				let frameworkName = url.deletingPathExtension().lastPathComponent

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -203,6 +203,27 @@ public func createVersionFile(
 	)
 }
 
+private func createVersionFile(
+	_ commitish: String,
+	dependencyName: String,
+	rootDirectoryURL: URL,
+	platformCaches: [String:[CachedFramework]]
+	) -> SignalProducer<(), CarthageError> {
+	return SignalProducer<(), CarthageError> { () -> Result<(), CarthageError> in
+		let rootBinariesURL = rootDirectoryURL.appendingPathComponent(Constants.binariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
+		let versionFileURL = rootBinariesURL.appendingPathComponent(".\(dependencyName).\(VersionFile.pathExtension)")
+
+		let versionFile = VersionFile(
+			commitish: commitish,
+			macOS: platformCaches[Platform.macOS.rawValue],
+			iOS: platformCaches[Platform.iOS.rawValue],
+			watchOS: platformCaches[Platform.watchOS.rawValue],
+			tvOS: platformCaches[Platform.tvOS.rawValue])
+
+		return versionFile.write(to: versionFileURL)
+	}
+}
+
 /// Creates a version file for the dependency in the given root directory with:
 /// - The given commitish
 /// - The provided project name
@@ -216,47 +237,41 @@ public func createVersionFileForCommitish(
 	buildProducts: [URL],
 	rootDirectoryURL: URL
 ) -> SignalProducer<(), CarthageError> {
-	var platformCaches: [String: [CachedFramework]] = [:]
+	typealias PlatformCaches = [String:[CachedFramework]]
+
+	var platformCaches: PlatformCaches = [:]
 
 	let platformsToCache = platforms.isEmpty ? Set(Platform.supportedPlatforms) : platforms
 	for platform in platformsToCache {
 		platformCaches[platform.rawValue] = []
 	}
 
-	let writeVersionFile = SignalProducer<(), CarthageError> { () -> Result<(), CarthageError> in
-		let rootBinariesURL = rootDirectoryURL.appendingPathComponent(Constants.binariesFolderPath, isDirectory: true).resolvingSymlinksInPath()
-		let versionFileURL = rootBinariesURL.appendingPathComponent(".\(dependencyName).\(VersionFile.pathExtension)")
-
-		let versionFile = VersionFile(
-			commitish: commitish,
-			macOS: platformCaches[Platform.macOS.rawValue],
-			iOS: platformCaches[Platform.iOS.rawValue],
-			watchOS: platformCaches[Platform.watchOS.rawValue],
-			tvOS: platformCaches[Platform.tvOS.rawValue])
-
-		return versionFile.write(to: versionFileURL)
-	}
-
 	if !buildProducts.isEmpty {
 		return SignalProducer<URL, CarthageError>(buildProducts)
-			.flatMap(.merge) { url -> SignalProducer<String, CarthageError> in
-				let platformName = url.deletingLastPathComponent().lastPathComponent
+			.flatMap(.merge) { url -> SignalProducer<(String, URL), CarthageError> in
 				let frameworkName = url.deletingPathExtension().lastPathComponent
 				let frameworkURL = url.appendingPathComponent(frameworkName, isDirectory: false)
-				return hashForFileAtURL(frameworkURL)
-					.on(value: { hash in
-						let cachedFramework = CachedFramework(name: frameworkName, hash: hash)
-						if var frameworks = platformCaches[platformName] {
-							frameworks.append(cachedFramework)
-							platformCaches[platformName] = frameworks
-						}
-					})
+				return SignalProducer.zip(hashForFileAtURL(frameworkURL), SignalProducer<URL, CarthageError>(value: url))
 			}
-			.then(writeVersionFile)
+			.reduce(into: PlatformCaches()) { (platformCaches, values) in
+				let hash = values.0
+				let url = values.1
+				let frameworkName = url.deletingPathExtension().lastPathComponent
+				let platformName = url.deletingLastPathComponent().lastPathComponent
+
+				let cachedFramework = CachedFramework(name: frameworkName, hash: hash)
+				if var frameworks = platformCaches[platformName] {
+					frameworks.append(cachedFramework)
+					platformCaches[platformName] = frameworks
+				}
+			}
+			.flatMap(.merge) { platformCaches -> SignalProducer<(), CarthageError> in
+				createVersionFile(commitish, dependencyName: dependencyName, rootDirectoryURL: rootDirectoryURL, platformCaches: platformCaches)
+			}
 	} else {
 		// Write out an empty version file for dependencies with no built frameworks, so cache builds can differentiate between
 		// no cache and a dependency that has no frameworks
-		return writeVersionFile
+		return createVersionFile(commitish, dependencyName: dependencyName, rootDirectoryURL: rootDirectoryURL, platformCaches: platformCaches)
 	}
 }
 


### PR DESCRIPTION
This is my attempt in fixing the issue discussed in #2375. Thanks @blender for consultations! 

Basically the code was converted from capturing and sharing `platformCaches` dictionary to reducing the results of calculating all hashes to a single dictionary. It is then used to initialize `VersionFile` as before.

This is my first time working with a ReactiveSwift codebase, so I am not sure if I followed all the good practices. Things I think could be improved:

* `createVersionFile` function doesn't do that much but has many parameters...
* Nested tuple in `SignalProducer<(String, (String, String)), CarthageError>`. My first try was passing down `url` instead of `(frameworkName, platformName)`, but then I need to calculate `frameworkName` two times.

Let me know what you think!