### PR TITLE
[BinaryProject] Relative Path Cartfile.resolved Support

### DIFF
--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -115,14 +115,10 @@ extension Dependency: Hashable {
 	}
 }
 
-extension Dependency.Binary: Comparable {
+extension Dependency.Binary: Equatable {
 	public static func == (_ lhs: Dependency.Binary, _ rhs: Dependency.Binary) -> Bool {
 		return lhs.absoluteURL == rhs.absoluteURL &&
 				lhs.representation == rhs.representation
-	}
-
-	public static func < (_ lhs: Dependency.Binary, _ rhs: Dependency.Binary) -> Bool {
-		return lhs.representation.caseInsensitiveCompare(rhs.representation) == .orderedAscending
 	}
 }
 

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -7,16 +7,16 @@ public struct BinaryURL: CustomStringConvertible {
 	/// A Resolved URL
 	public let url: URL
 
-	/// An Optional custom description
-	public let overloadedDescription: String?
+	/// A custom description
+	public let resolvedDescription: String
 
 	public var description: String {
-		return overloadedDescription ?? url.description
+		return resolvedDescription
 	}
 
-	init(url: URL, overloadedDescription: String? = nil) {
+	init(url: URL, resolvedDescription: String) {
 		self.url = url
-		self.overloadedDescription = overloadedDescription
+		self.resolvedDescription = resolvedDescription
 	}
 }
 
@@ -146,10 +146,10 @@ extension Dependency: Scannable {
 			parser = { urlString in
 				if let url = URL(string: urlString) {
 					if url.scheme == "https" || url.scheme == "file" {
-						return .success(self.binary(BinaryURL(url: url)))
+						return .success(self.binary(BinaryURL(url: url, resolvedDescription: url.description)))
 					} else if url.scheme == nil {
 						let absoluteURL = URL(fileURLWithPath: url.relativePath, isDirectory: false, relativeTo: base).standardizedFileURL
-						return .success(self.binary(BinaryURL(url: absoluteURL, overloadedDescription: url.absoluteString)))
+						return .success(self.binary(BinaryURL(url: absoluteURL, resolvedDescription: url.absoluteString)))
 					} else {
 						return .failure(ScannableError(message: "non-https, non-file URL found for dependency type `binary`", currentLine: scanner.currentLine))
 					}

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -2,15 +2,10 @@ import Foundation
 import Result
 import Tentacle
 
-/// Protocol which supports URL + potential custom description
-public protocol URLConvertible: CustomStringConvertible {
-	var url: URL { get }
-}
-
 /// Uniquely identifies a project that can be used as a dependency.
 public enum Dependency {
 	/// Uniquely identifies a Binary Spec's resolved URL and its description
-	public struct BinaryURL: URLConvertible {
+	public struct BinaryURL: CustomStringConvertible {
 		/// A Resolved URL
 		public let url: URL
 

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -2,26 +2,26 @@ import Foundation
 import Result
 import Tentacle
 
-/// Uniquely identifies a project that can be used as a dependency.
-public enum Dependency {
-	/// Uniquely identifies a Binary Spec's resolved URL and its description
-	public struct BinaryURL: CustomStringConvertible {
-		/// A Resolved URL
-		public let url: URL
+/// Uniquely identifies a Binary Spec's resolved URL and its description
+public struct BinaryURL: CustomStringConvertible {
+	/// A Resolved URL
+	public let url: URL
 
-		/// An Optional custom description
-		public let overloadedDescription: String?
+	/// An Optional custom description
+	public let overloadedDescription: String?
 
-		public var description: String {
-			return overloadedDescription ?? url.description
-		}
-
-		init(url: URL, overloadedDescription: String? = nil) {
-			self.url = url
-			self.overloadedDescription = overloadedDescription
-		}
+	public var description: String {
+		return overloadedDescription ?? url.description
 	}
 
+	init(url: URL, overloadedDescription: String? = nil) {
+		self.url = url
+		self.overloadedDescription = overloadedDescription
+	}
+}
+
+/// Uniquely identifies a project that can be used as a dependency.
+public enum Dependency {
 	/// A repository hosted on GitHub.com or GitHub Enterprise.
 	case gitHub(Server, Repository)
 
@@ -41,7 +41,7 @@ public enum Dependency {
 			return url.name ?? url.urlString
 
 		case let .binary(url):
-			return url.url.lastPathComponent.stripping(suffix: ".json")
+			return url.name
 		}
 	}
 
@@ -119,7 +119,7 @@ extension Dependency: Hashable {
 			return url.hashValue
 
 		case let .binary(binary):
-			return binary.url.hashValue
+			return binary.hashValue
 		}
 	}
 }
@@ -221,14 +221,21 @@ extension Dependency {
 	}
 }
 
-extension Dependency.BinaryURL: Equatable {
-	public static func == (_ lhs: Dependency.BinaryURL, _ rhs: Dependency.BinaryURL) -> Bool {
+extension BinaryURL: Equatable {
+	public static func == (_ lhs: BinaryURL, _ rhs: BinaryURL) -> Bool {
 		return lhs.description == rhs.description
 	}
 }
 
-extension Dependency.BinaryURL: Hashable {
+extension BinaryURL: Hashable {
 	public var hashValue: Int {
 		return description.hashValue
+	}
+}
+
+extension BinaryURL {
+	/// The unique, user-visible name for this project.
+	public var name: String {
+		return url.lastPathComponent.stripping(suffix: ".json")
 	}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -226,23 +226,25 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.startOnQueue(cloneOrFetchQueue)
 	}
 
-	func downloadBinaryFrameworkDefinition(url: URL) -> SignalProducer<BinaryProject, CarthageError> {
+	// Dane - what is this value used for?
+	func downloadBinaryFrameworkDefinition(binary: Dependency.Binary) -> SignalProducer<BinaryProject, CarthageError> {
 		return SignalProducer<Project.CachedBinaryProjects, CarthageError>(value: self.cachedBinaryProjects)
 			.flatMap(.merge) { binaryProjectsByURL -> SignalProducer<BinaryProject, CarthageError> in
-				if let binaryProject = binaryProjectsByURL[url] {
+				if let binaryProject = binaryProjectsByURL[binary.absoluteURL] {
 					return SignalProducer(value: binaryProject)
 				} else {
-					self._projectEventsObserver.send(value: .downloadingBinaryFrameworkDefinition(.binary(url), url))
+					// What arguments create this?
+					self._projectEventsObserver.send(value: .downloadingBinaryFrameworkDefinition(.binary(binary), binary.absoluteURL))
 
-					return URLSession.shared.reactive.data(with: URLRequest(url: url))
-						.mapError { CarthageError.readFailed(url, $0 as NSError) }
+					return URLSession.shared.reactive.data(with: URLRequest(url: binary.absoluteURL))
+						.mapError { CarthageError.readFailed(binary.absoluteURL, $0 as NSError) }
 						.attemptMap { data, _ in
 							return BinaryProject.from(jsonData: data).mapError { error in
-								return CarthageError.invalidBinaryJSON(url, error)
+								return CarthageError.invalidBinaryJSON(binary.absoluteURL, error)
 							}
 						}
 						.on(value: { binaryProject in
-							self.cachedBinaryProjects[url] = binaryProject
+							self.cachedBinaryProjects[binary.absoluteURL] = binaryProject
 						})
 				}
 			}
@@ -262,8 +264,8 @@ public final class Project { // swiftlint:disable:this type_body_length
 				.flatMap(.merge) { repositoryURL in listTags(repositoryURL) }
 				.map { PinnedVersion($0) }
 
-		case let .binary(url):
-			fetchVersions = downloadBinaryFrameworkDefinition(url: url)
+		case let .binary(binary):
+			fetchVersions = downloadBinaryFrameworkDefinition(binary: binary)
 				.flatMap(.concat) { binaryProject -> SignalProducer<PinnedVersion, CarthageError> in
 					return SignalProducer(binaryProject.versions.keys)
 				}
@@ -864,23 +866,23 @@ public final class Project { // swiftlint:disable:this type_body_length
 	}
 
 	private func installBinariesForBinaryProject(
-		url: URL,
+		binary: Dependency.Binary,
 		pinnedVersion: PinnedVersion,
 		projectName: String,
 		toolchain: String?
 	) -> SignalProducer<(), CarthageError> {
 		return SignalProducer<SemanticVersion, ScannableError>(result: SemanticVersion.from(pinnedVersion))
 			.mapError { CarthageError(scannableError: $0) }
-			.combineLatest(with: self.downloadBinaryFrameworkDefinition(url: url))
+			.combineLatest(with: self.downloadBinaryFrameworkDefinition(binary: binary))
 			.attemptMap { semanticVersion, binaryProject -> Result<(SemanticVersion, URL), CarthageError> in
 				guard let frameworkURL = binaryProject.versions[pinnedVersion] else {
-					return .failure(CarthageError.requiredVersionNotFound(Dependency.binary(url), VersionSpecifier.exactly(semanticVersion)))
+					return .failure(CarthageError.requiredVersionNotFound(Dependency.binary(binary), VersionSpecifier.exactly(semanticVersion)))
 				}
 
 				return .success((semanticVersion, frameworkURL))
 			}
 			.flatMap(.concat) { semanticVersion, frameworkURL in
-				return self.downloadBinary(dependency: Dependency.binary(url), version: semanticVersion, url: frameworkURL)
+				return self.downloadBinary(dependency: Dependency.binary(binary), version: semanticVersion, url: frameworkURL)
 			}
 			.flatMap(.concat) { self.unarchiveAndCopyBinaryFrameworks(zipFile: $0, projectName: projectName, pinnedVersion: pinnedVersion, toolchain: toolchain) }
 			.flatMap(.concat) { self.removeItem(at: $0) }
@@ -1042,8 +1044,8 @@ public final class Project { // swiftlint:disable:this type_body_length
 								.filterMap { installed -> (Dependency, PinnedVersion)? in
 									return installed ? (dependency, version) : nil
 								}
-						case let .binary(url):
-							return self.installBinariesForBinaryProject(url: url, pinnedVersion: version, projectName: dependency.name, toolchain: options.toolchain)
+						case let .binary(binary):
+							return self.installBinariesForBinaryProject(binary: binary, pinnedVersion: version, projectName: dependency.name, toolchain: options.toolchain)
 								.then(.init(value: (dependency, version)))
 						}
 					}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -226,7 +226,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.startOnQueue(cloneOrFetchQueue)
 	}
 
-	func downloadBinaryFrameworkDefinition(binary: Dependency.BinaryURL) -> SignalProducer<BinaryProject, CarthageError> {
+	func downloadBinaryFrameworkDefinition(binary: BinaryURL) -> SignalProducer<BinaryProject, CarthageError> {
 		return SignalProducer<Project.CachedBinaryProjects, CarthageError>(value: self.cachedBinaryProjects)
 			.flatMap(.merge) { binaryProjectsByURL -> SignalProducer<BinaryProject, CarthageError> in
 				if let binaryProject = binaryProjectsByURL[binary.url] {
@@ -864,7 +864,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 	}
 
 	private func installBinariesForBinaryProject(
-		binary: Dependency.BinaryURL,
+		binary: BinaryURL,
 		pinnedVersion: PinnedVersion,
 		projectName: String,
 		toolchain: String?

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -1,5 +1,4 @@
 @testable import CarthageKit
-import CarthageKit
 import Foundation
 import Nimble
 import Quick
@@ -90,7 +89,7 @@ class DependencySpec: QuickSpec {
 			context("binary") {
 				it("should be the last component of the URL") {
 					let url = URL(string: "https://server.com/myproject")!
-					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+					let binary = Dependency.BinaryURL(url: url)
 					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
@@ -98,7 +97,7 @@ class DependencySpec: QuickSpec {
 
 				it("should not include the trailing git suffix") {
 					let url = URL(string: "https://server.com/myproject.json")!
-					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+					let binary = Dependency.BinaryURL(url: url)
 					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
@@ -207,7 +206,7 @@ class DependencySpec: QuickSpec {
 
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "https://mysupercoolinternalwebhost.com/")!
-					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+					let binary = Dependency.BinaryURL(url: url)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -217,7 +216,7 @@ class DependencySpec: QuickSpec {
 					
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "file:///my/domain/com/framework.json")!
-					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+					let binary = Dependency.BinaryURL(url: url)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -230,7 +229,7 @@ class DependencySpec: QuickSpec {
 					let dependency = Dependency.from(scanner, base: workingDirectory).value
 
 					let url = URL(string: "file:///current/working/directory/my/relative/path/framework.json")!
-					let binary = Dependency.Binary(absoluteURL: url, representation: relativePath)
+					let binary = Dependency.BinaryURL(url: url, overloadedDescription: relativePath)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -241,7 +240,7 @@ class DependencySpec: QuickSpec {
 
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "file:///my/absolute/path/framework.json")!
-					let binary = Dependency.Binary(absoluteURL: url, representation: absolutePath)
+					let binary = Dependency.BinaryURL(url: url, overloadedDescription: absolutePath)
 
 					expect(dependency) == .binary(binary)
 				}

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -1,3 +1,4 @@
+@testable import CarthageKit
 import CarthageKit
 import Foundation
 import Nimble
@@ -88,13 +89,17 @@ class DependencySpec: QuickSpec {
 
 			context("binary") {
 				it("should be the last component of the URL") {
-					let dependency = Dependency.binary(URL(string: "https://server.com/myproject")!)
+					let url = URL(string: "https://server.com/myproject")!
+					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
 				}
 
 				it("should not include the trailing git suffix") {
-					let dependency = Dependency.binary(URL(string: "https://server.com/myproject.json")!)
+					let url = URL(string: "https://server.com/myproject.json")!
+					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
 				}
@@ -201,16 +206,20 @@ class DependencySpec: QuickSpec {
 					let scanner = Scanner(string: "binary \"https://mysupercoolinternalwebhost.com/\"")
 
 					let dependency = Dependency.from(scanner).value
+					let url = URL(string: "https://mysupercoolinternalwebhost.com/")!
+					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
 
-					expect(dependency) == .binary(URL(string: "https://mysupercoolinternalwebhost.com/")!)
+					expect(dependency) == .binary(binary)
 				}
 
 				it("should read a URL with file scheme") {
 					let scanner = Scanner(string: "binary \"file:///my/domain/com/framework.json\"")
 					
 					let dependency = Dependency.from(scanner).value
-					
-					expect(dependency) == .binary(URL(string: "file:///my/domain/com/framework.json")!)
+					let url = URL(string: "file:///my/domain/com/framework.json")!
+					let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+
+					expect(dependency) == .binary(binary)
 				}
 
 				it("should read a URL with relative file path") {
@@ -220,7 +229,10 @@ class DependencySpec: QuickSpec {
 					let workingDirectory = URL(string: "file:///current/working/directory/")!
 					let dependency = Dependency.from(scanner, base: workingDirectory).value
 
-					expect(dependency) == .binary(URL(string: "\(workingDirectory)\(relativePath)")!)
+					let url = URL(string: "file:///current/working/directory/my/relative/path/framework.json")!
+					let binary = Dependency.Binary(absoluteURL: url, representation: relativePath)
+
+					expect(dependency) == .binary(binary)
 				}
 
 				it("should read a URL with an absolute path") {
@@ -228,8 +240,10 @@ class DependencySpec: QuickSpec {
 					let scanner = Scanner(string: "binary \"\(absolutePath)\"")
 
 					let dependency = Dependency.from(scanner).value
+					let url = URL(string: "file:///my/absolute/path/framework.json")!
+					let binary = Dependency.Binary(absoluteURL: url, representation: absolutePath)
 
-					expect(dependency) == .binary(URL(string: "file://\(absolutePath)")!)
+					expect(dependency) == .binary(binary)
 				}
 
 				it("should fail with invalid URL") {

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -89,7 +89,7 @@ class DependencySpec: QuickSpec {
 			context("binary") {
 				it("should be the last component of the URL") {
 					let url = URL(string: "https://server.com/myproject")!
-					let binary = Dependency.BinaryURL(url: url)
+					let binary = BinaryURL(url: url)
 					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
@@ -97,7 +97,7 @@ class DependencySpec: QuickSpec {
 
 				it("should not include the trailing git suffix") {
 					let url = URL(string: "https://server.com/myproject.json")!
-					let binary = Dependency.BinaryURL(url: url)
+					let binary = BinaryURL(url: url)
 					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
@@ -206,7 +206,7 @@ class DependencySpec: QuickSpec {
 
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "https://mysupercoolinternalwebhost.com/")!
-					let binary = Dependency.BinaryURL(url: url)
+					let binary = BinaryURL(url: url)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -216,7 +216,7 @@ class DependencySpec: QuickSpec {
 					
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "file:///my/domain/com/framework.json")!
-					let binary = Dependency.BinaryURL(url: url)
+					let binary = BinaryURL(url: url)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -229,7 +229,7 @@ class DependencySpec: QuickSpec {
 					let dependency = Dependency.from(scanner, base: workingDirectory).value
 
 					let url = URL(string: "file:///current/working/directory/my/relative/path/framework.json")!
-					let binary = Dependency.BinaryURL(url: url, overloadedDescription: relativePath)
+					let binary = BinaryURL(url: url, overloadedDescription: relativePath)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -240,7 +240,7 @@ class DependencySpec: QuickSpec {
 
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "file:///my/absolute/path/framework.json")!
-					let binary = Dependency.BinaryURL(url: url, overloadedDescription: absolutePath)
+					let binary = BinaryURL(url: url, overloadedDescription: absolutePath)
 
 					expect(dependency) == .binary(binary)
 				}

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -89,7 +89,7 @@ class DependencySpec: QuickSpec {
 			context("binary") {
 				it("should be the last component of the URL") {
 					let url = URL(string: "https://server.com/myproject")!
-					let binary = BinaryURL(url: url)
+					let binary = BinaryURL(url: url, resolvedDescription: url.description)
 					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
@@ -97,7 +97,7 @@ class DependencySpec: QuickSpec {
 
 				it("should not include the trailing git suffix") {
 					let url = URL(string: "https://server.com/myproject.json")!
-					let binary = BinaryURL(url: url)
+					let binary = BinaryURL(url: url, resolvedDescription: url.description)
 					let dependency = Dependency.binary(binary)
 
 					expect(dependency.name) == "myproject"
@@ -206,7 +206,7 @@ class DependencySpec: QuickSpec {
 
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "https://mysupercoolinternalwebhost.com/")!
-					let binary = BinaryURL(url: url)
+					let binary = BinaryURL(url: url, resolvedDescription: url.description)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -216,7 +216,7 @@ class DependencySpec: QuickSpec {
 					
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "file:///my/domain/com/framework.json")!
-					let binary = BinaryURL(url: url)
+					let binary = BinaryURL(url: url, resolvedDescription: url.description)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -229,7 +229,7 @@ class DependencySpec: QuickSpec {
 					let dependency = Dependency.from(scanner, base: workingDirectory).value
 
 					let url = URL(string: "file:///current/working/directory/my/relative/path/framework.json")!
-					let binary = BinaryURL(url: url, overloadedDescription: relativePath)
+					let binary = BinaryURL(url: url, resolvedDescription: relativePath)
 
 					expect(dependency) == .binary(binary)
 				}
@@ -240,7 +240,7 @@ class DependencySpec: QuickSpec {
 
 					let dependency = Dependency.from(scanner).value
 					let url = URL(string: "file:///my/absolute/path/framework.json")!
-					let binary = BinaryURL(url: url, overloadedDescription: absolutePath)
+					let binary = BinaryURL(url: url, resolvedDescription: absolutePath)
 
 					expect(dependency) == .binary(binary)
 				}

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -361,7 +361,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			it("should return definition") {
-				let binary = BinaryURL(url: testDefinitionURL)
+				let binary = BinaryURL(url: testDefinitionURL, resolvedDescription: testDefinitionURL.description)
 				let actualDefinition = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.value
 
 				let expectedBinaryProject = BinaryProject(versions: [
@@ -373,7 +373,7 @@ class ProjectSpec: QuickSpec {
 
 			it("should return read failed if unable to download") {
 				let url = URL(string: "file:///thisfiledoesnotexist.json")!
-				let binary = BinaryURL(url: url)
+				let binary = BinaryURL(url: url, resolvedDescription: testDefinitionURL.description)
 				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
 				switch actualError {
@@ -387,7 +387,7 @@ class ProjectSpec: QuickSpec {
 
 			it("should return an invalid binary JSON error if unable to parse file") {
 				let invalidDependencyURL = Bundle(for: type(of: self)).url(forResource: "BinaryOnly/invalid", withExtension: "json")!
-				let binary = BinaryURL(url: invalidDependencyURL)
+				let binary = BinaryURL(url: invalidDependencyURL, resolvedDescription: invalidDependencyURL.description)
 
 				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
@@ -404,7 +404,7 @@ class ProjectSpec: QuickSpec {
 				var events = [ProjectEvent]()
 				project.projectEvents.observeValues { events.append($0) }
 
-				let binary = BinaryURL(url: testDefinitionURL)
+				let binary = BinaryURL(url: testDefinitionURL, resolvedDescription: testDefinitionURL.description)
 				_ = project.downloadBinaryFrameworkDefinition(binary: binary).first()
 
 				expect(events) == [.downloadingBinaryFrameworkDefinition(.binary(binary), testDefinitionURL)]

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -361,7 +361,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			it("should return definition") {
-				let binary = Dependency.Binary(absoluteURL: testDefinitionURL, representation: testDefinitionURL.absoluteString)
+				let binary = Dependency.BinaryURL(url: testDefinitionURL)
 				let actualDefinition = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.value
 
 				let expectedBinaryProject = BinaryProject(versions: [
@@ -373,7 +373,7 @@ class ProjectSpec: QuickSpec {
 
 			it("should return read failed if unable to download") {
 				let url = URL(string: "file:///thisfiledoesnotexist.json")!
-				let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+				let binary = Dependency.BinaryURL(url: url)
 				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
 				switch actualError {
@@ -387,7 +387,7 @@ class ProjectSpec: QuickSpec {
 
 			it("should return an invalid binary JSON error if unable to parse file") {
 				let invalidDependencyURL = Bundle(for: type(of: self)).url(forResource: "BinaryOnly/invalid", withExtension: "json")!
-				let binary = Dependency.Binary(absoluteURL: invalidDependencyURL, representation: invalidDependencyURL.absoluteString)
+				let binary = Dependency.BinaryURL(url: invalidDependencyURL)
 
 				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
@@ -404,7 +404,7 @@ class ProjectSpec: QuickSpec {
 				var events = [ProjectEvent]()
 				project.projectEvents.observeValues { events.append($0) }
 
-				let binary = Dependency.Binary(absoluteURL: testDefinitionURL, representation: testDefinitionURL.absoluteString)
+				let binary = Dependency.BinaryURL(url: testDefinitionURL)
 				_ = project.downloadBinaryFrameworkDefinition(binary: binary).first()
 
 				expect(events) == [.downloadingBinaryFrameworkDefinition(.binary(binary), testDefinitionURL)]

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -361,7 +361,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			it("should return definition") {
-				let binary = Dependency.BinaryURL(url: testDefinitionURL)
+				let binary = BinaryURL(url: testDefinitionURL)
 				let actualDefinition = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.value
 
 				let expectedBinaryProject = BinaryProject(versions: [
@@ -373,7 +373,7 @@ class ProjectSpec: QuickSpec {
 
 			it("should return read failed if unable to download") {
 				let url = URL(string: "file:///thisfiledoesnotexist.json")!
-				let binary = Dependency.BinaryURL(url: url)
+				let binary = BinaryURL(url: url)
 				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
 				switch actualError {
@@ -387,7 +387,7 @@ class ProjectSpec: QuickSpec {
 
 			it("should return an invalid binary JSON error if unable to parse file") {
 				let invalidDependencyURL = Bundle(for: type(of: self)).url(forResource: "BinaryOnly/invalid", withExtension: "json")!
-				let binary = Dependency.BinaryURL(url: invalidDependencyURL)
+				let binary = BinaryURL(url: invalidDependencyURL)
 
 				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
@@ -404,7 +404,7 @@ class ProjectSpec: QuickSpec {
 				var events = [ProjectEvent]()
 				project.projectEvents.observeValues { events.append($0) }
 
-				let binary = Dependency.BinaryURL(url: testDefinitionURL)
+				let binary = BinaryURL(url: testDefinitionURL)
 				_ = project.downloadBinaryFrameworkDefinition(binary: binary).first()
 
 				expect(events) == [.downloadingBinaryFrameworkDefinition(.binary(binary), testDefinitionURL)]

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -361,7 +361,8 @@ class ProjectSpec: QuickSpec {
 			}
 
 			it("should return definition") {
-				let actualDefinition = project.downloadBinaryFrameworkDefinition(url: testDefinitionURL).first()?.value
+				let binary = Dependency.Binary(absoluteURL: testDefinitionURL, representation: testDefinitionURL.absoluteString)
+				let actualDefinition = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.value
 
 				let expectedBinaryProject = BinaryProject(versions: [
 					PinnedVersion("1.0"): URL(string: "https://my.domain.com/release/1.0.0/framework.zip")!,
@@ -371,7 +372,9 @@ class ProjectSpec: QuickSpec {
 			}
 
 			it("should return read failed if unable to download") {
-				let actualError = project.downloadBinaryFrameworkDefinition(url: URL(string: "file:///thisfiledoesnotexist.json")!).first()?.error
+				let url = URL(string: "file:///thisfiledoesnotexist.json")!
+				let binary = Dependency.Binary(absoluteURL: url, representation: url.absoluteString)
+				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
 				switch actualError {
 				case .some(.readFailed):
@@ -384,8 +387,9 @@ class ProjectSpec: QuickSpec {
 
 			it("should return an invalid binary JSON error if unable to parse file") {
 				let invalidDependencyURL = Bundle(for: type(of: self)).url(forResource: "BinaryOnly/invalid", withExtension: "json")!
+				let binary = Dependency.Binary(absoluteURL: invalidDependencyURL, representation: invalidDependencyURL.absoluteString)
 
-				let actualError = project.downloadBinaryFrameworkDefinition(url: invalidDependencyURL).first()?.error
+				let actualError = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.error
 
 				switch actualError {
 				case .some(CarthageError.invalidBinaryJSON(invalidDependencyURL, BinaryJSONError.invalidJSON)):
@@ -400,9 +404,10 @@ class ProjectSpec: QuickSpec {
 				var events = [ProjectEvent]()
 				project.projectEvents.observeValues { events.append($0) }
 
-				_ = project.downloadBinaryFrameworkDefinition(url: testDefinitionURL).first()
+				let binary = Dependency.Binary(absoluteURL: testDefinitionURL, representation: testDefinitionURL.absoluteString)
+				_ = project.downloadBinaryFrameworkDefinition(binary: binary).first()
 
-				expect(events) == [.downloadingBinaryFrameworkDefinition(.binary(testDefinitionURL), testDefinitionURL)]
+				expect(events) == [.downloadingBinaryFrameworkDefinition(.binary(binary), testDefinitionURL)]
 			}
 		}
 


### PR DESCRIPTION
## Problem:
PR https://github.com/Carthage/Carthage/pull/2360 which allows anyone to update and install required binaries via relative path. BUT.. once installed, the resolved file is tied to a user specific filepath

## Current Functionality/Limitation (0.29.0)
`carthage update` with current relative implementation works... but leaves an absolute file path for binary json specs, which will fail on others computers

`carthage bootstrap` fails if not run on computer which ran update b/c path is not going to be the same.

Cartfile
```
binary "CarthageSpecs/AppboyFramework.json"
```

Cartfile.resolved
```
binary "file:///Users/dmiluski/code/folder/CarthageSpecs/AppboyFramework.json" "3.3.2"
```

This means the resolved file path would only work on the original computer used to run.

## Proposed Solution/Expectation:
binary urls should appear the same for both Cartfile & Cartfile.resolved

Cartfile
```
binary "CarthageSpecs/AppboyFramework.json"
```

Cartfile.resolved
```
binary "CarthageSpecs/AppboyFramework.json"  "3.3.2"
```

This allows relative paths to still be used on multple devices/users.

## Approach:
- Package Binary dependency model with a url + representation string
- Update resolve write out to use binary representable description

### Proof of Concept: Automated Github Releases Fetch & Construct Spec file
https://github.com/dmiluski/CarthageSpecUpdater/blob/master/update_carthage_specs