### PR TITLE
JSON specification file name recommendation for binary projects

### DIFF
--- a/Documentation/Artifacts.md
+++ b/Documentation/Artifacts.md
@@ -140,6 +140,7 @@ If you need to reclaim disk space, you can safely delete this folder, or any of 
 
 For dependencies that do not have source code available, a binary project specification can be used to list the locations and versions of compiled frameworks.  This data **must** be available via `https` and could be served from a static file or dynamically.
 
+* The JSON specification file name **should** have the same name as the framework and **not** be named **Carthage.json**, (example: MyFramework.json).
 * The JSON structure is a top-level dictionary with the key-value pairs of version / location.
 * The version **must** be a semantic version.  Git branches, tags and commits are not valid.
 * The location **must** be an `https` url.


### PR DESCRIPTION
As there is a lot of binary framework developers that call their specification file Carthage.json, updating frameworks becomes difficult and confusing
Updating those frameworks needs the command `carthage update Carthage` that first sounds weird, but also does update all binary dependencies with this same specification name.