### PR TITLE
Implement comparison and intersection of pre-release and build versions

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -332,10 +332,9 @@ public enum VersionSpecifier: VersionType {
 			if let semanticVersion = SemanticVersion.from(version).value {
 				return predicate(semanticVersion)
 			} else {
-				// Consider non-semantic versions (e.g., branches) not to meet
-				// any requirement as we can't guarantee any ordering nor
-				// compatibility
-				return false
+				// Consider non-semantic versions (e.g., branches) to meet every
+				// version range requirement
+				return true
 			}
 		}
 

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -112,9 +112,9 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
 			}
 			
-			it("should not allow a non-semantic version for Any") {
+			it("should allow a non-semantic version for Any") {
 				let specifier = VersionSpecifier.any
-				expect(specifier.isSatisfied(by: nonSemantic)) == false
+				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow a pre-release version for Any") {
@@ -131,9 +131,9 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v3_0_0)) == true
 			}
 			
-			it("should not allow a non-semantic version for .atLeast") {
+			it("should allow a non-semantic version for .atLeast") {
 				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: nonSemantic)) == false
+				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow for a pre-release of the same non-pre-release version for .atLeast")
@@ -180,12 +180,12 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v3_0_0)) == false
 			}
 			
-			it("should not allow a non-semantic version for .atLeast") {
+			it("should allow a non-semantic version for .compatibleWith") {
 				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: nonSemantic)) == false
+				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
-			it("should not allow equal minor and patch pre-release version for CompatibleWith") {
+			it("should not allow equal minor and patch pre-release version for .compatibleWith") {
 				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
@@ -210,9 +210,9 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
-			it("should not allow for a non-semantic version for .exactly") {
+			it("should allow for a non-semantic version for .exactly") {
 				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: nonSemantic)) == false
+				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow any pre-release versions to satisfy 0.x") {

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -21,7 +21,7 @@ class SemanticVersionSpec: QuickSpec {
 			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 10)
 			
 			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 2, buildMetadata: "b421")
-			expect(version) == SemanticVersion(major: 2, minor: 1, patch: 1, buildMetadata: "b2334")
+			expect(version) != SemanticVersion(major: 2, minor: 1, patch: 1, buildMetadata: "b2334")
 			expect(version) > SemanticVersion(major: 2, minor: 1, patch: 0, buildMetadata: "b421")
 		}
 		

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -19,7 +19,38 @@ class SemanticVersionSpec: QuickSpec {
 			expect(version) < SemanticVersion(major: 10, minor: 0, patch: 0)
 			expect(version) < SemanticVersion(major: 2, minor: 10, patch: 1)
 			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 10)
-
+			
+			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 2, buildMetadata: "b421")
+			expect(version) == SemanticVersion(major: 2, minor: 1, patch: 1, buildMetadata: "b2334")
+			expect(version) > SemanticVersion(major: 2, minor: 1, patch: 0, buildMetadata: "b421")
+		}
+		
+		it("should order pre-release versions correctly") {
+			let version = SemanticVersion(major: 2, minor: 1, patch: 1, preRelease: "alpha8")
+			
+			expect(version) < SemanticVersion(major: version.major, minor: version.minor, patch: version.patch)
+			expect(version) > SemanticVersion(major: version.major, minor: version.minor, patch: version.patch-1)
+			expect(version) == SemanticVersion(major: version.major, minor: version.minor, patch: version.patch, preRelease: version.preRelease)
+			
+			// As specified in http://semver.org/
+			// "Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0"
+			
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) < SemanticVersion(major: 1, minor: 0, patch: 0)
+			
+			// now test the reverse (to catch error if the < function ALWAYS returns true)
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
+			expect(SemanticVersion(major: 1, minor: 0, patch: 0)) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
 		}
 
 		it("should parse semantic versions") {
@@ -56,7 +87,7 @@ class VersionSpecifierSpec: QuickSpec {
 		describe("isSatisfied(by:)") {
 			let v0_1_0 = PinnedVersion("0.1.0")
 			let v0_1_0_pre23 = PinnedVersion("0.1.0-pre23")
-			let v0_1_0_build123 = PinnedVersion("v0_1_0+build123")
+			let v0_1_0_build123 = PinnedVersion("v0.1.0+build123")
 			let v0_1_1 = PinnedVersion("0.1.1")
 			let v0_2_0 = PinnedVersion("0.2.0")
 			let v0_2_0_candidate = PinnedVersion("0.2.0-candidate")
@@ -81,16 +112,14 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow a non-semantic version for Any") {
+			it("should not allow a non-semantic version for Any") {
 				let specifier = VersionSpecifier.any
-				expect(specifier.isSatisfied(by: nonSemantic)) == true
+				expect(specifier.isSatisfied(by: nonSemantic)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow a pre-release version for Any") {
+			it("should not allow a pre-release version for Any") {
 				let specifier = VersionSpecifier.any
-				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == true
+				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 			it("should allow greater or equal versions for .atLeast") {
@@ -102,17 +131,15 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v3_0_0)) == true
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow a non-semantic version for .atLeast") {
+			it("should not allow a non-semantic version for .atLeast") {
 				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: nonSemantic)) == true
+				expect(specifier.isSatisfied(by: nonSemantic)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow for a pre-release of the same non-pre-release version for .atLeast")
+			it("should not allow for a pre-release of the same non-pre-release version for .atLeast")
 			{
 				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == true
+				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 			
 			it("should allow for a build version of the same version for .atLeast")
@@ -139,10 +166,9 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow for a greater pre-release version for .atLeast") {
+			it("should not allow for a greater pre-release version for .atLeast") {
 				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_0_2).value!)
-				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == true
+				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 			it("should allow greater or equal minor and patch versions for .compatibleWith") {
@@ -154,16 +180,14 @@ class VersionSpecifierSpec: QuickSpec {
 				expect(specifier.isSatisfied(by: v3_0_0)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow a non-semantic version for .atLeast") {
+			it("should not allow a non-semantic version for .atLeast") {
 				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: nonSemantic)) == true
+				expect(specifier.isSatisfied(by: nonSemantic)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow equal minor and patch pre-release version for CompatibleWith") {
+			it("should not allow equal minor and patch pre-release version for CompatibleWith") {
 				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == true
+				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 
@@ -178,24 +202,22 @@ class VersionSpecifierSpec: QuickSpec {
 			
 			it("should not allow a build version of a different version for .exactly") {
 				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v1_3_2).value!)
-				expect(specifier.isSatisfied(by: v0_1_0_build123)) == true
+				expect(specifier.isSatisfied(by: v0_1_0_build123)) == false
 			}
 			
 			it("should not allow a build version of the same version for .exactly") {
 				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
+				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow for a non-semantic version for .exactly") {
+			it("should not allow for a non-semantic version for .exactly") {
 				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
-				expect(specifier.isSatisfied(by: nonSemantic)) == true
+				expect(specifier.isSatisfied(by: nonSemantic)) == false
 			}
 			
-			/// The following behavior does not follow the SemVer <https://semver.org/> specifications
-			it("should allow any pre-release versions to satisfy 0.x") {
+			it("should not allow any pre-release versions to satisfy 0.x") {
 				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
-				expect(specifier.isSatisfied(by: v0_1_0_pre23)) == true
+				expect(specifier.isSatisfied(by: v0_1_0_pre23)) == false
 			}
 			
 			it("should not allow a pre-release versions of a different version to satisfy 0.x") {
@@ -218,20 +240,32 @@ class VersionSpecifierSpec: QuickSpec {
 			let v1_3_2 = SemanticVersion(major: 1, minor: 3, patch: 2)
 			let v2_1_1 = SemanticVersion(major: 2, minor: 1, patch: 1)
 			let v2_2_0 = SemanticVersion(major: 2, minor: 2, patch: 0)
+			let v2_2_0_b421 = SemanticVersion(major: 2, minor: 2, patch: 0, buildMetadata: "b421")
+			let v2_2_0_alpha = SemanticVersion(major: 2, minor: 2, patch: 0, preRelease: "alpha")
 
 			it("should return the tighter specifier when one is .any") {
 				testIntersection(.any, .any, expected: .any)
 				testIntersection(.any, .atLeast(v1_3_2), expected: .atLeast(v1_3_2))
 				testIntersection(.any, .compatibleWith(v1_3_2), expected: .compatibleWith(v1_3_2))
 				testIntersection(.any, .exactly(v1_3_2), expected: .exactly(v1_3_2))
+				testIntersection(.any, .exactly(v2_2_0_b421), expected: .exactly(v2_2_0_b421))
+				testIntersection(.any, .exactly(v2_2_0_alpha), expected: .exactly(v2_2_0_alpha))
 			}
 
 			it("should return the higher specifier when one is .atLeast") {
 				testIntersection(.atLeast(v1_3_2), .atLeast(v1_3_2), expected: .atLeast(v1_3_2))
 				testIntersection(.atLeast(v1_3_2), .atLeast(v2_1_1), expected: .atLeast(v2_1_1))
+				testIntersection(.atLeast(v2_2_0), .atLeast(v2_2_0_b421), expected: .atLeast(v2_2_0))
+				testIntersection(.atLeast(v2_2_0), .atLeast(v2_2_0_alpha), expected: .atLeast(v2_2_0))
 				testIntersection(.atLeast(v1_3_2), .compatibleWith(v2_1_1), expected: .compatibleWith(v2_1_1))
 				testIntersection(.atLeast(v2_1_1), .compatibleWith(v2_2_0), expected: .compatibleWith(v2_2_0))
+				testIntersection(.atLeast(v2_2_0), .compatibleWith(v2_2_0_b421), expected: .compatibleWith(v2_2_0))
+				testIntersection(.atLeast(v2_2_0), .compatibleWith(v2_2_0_alpha), expected: .compatibleWith(v2_2_0))
+				testIntersection(.atLeast(v2_2_0_alpha), .compatibleWith(v2_2_0), expected: .compatibleWith(v2_2_0))
 				testIntersection(.atLeast(v1_3_2), .exactly(v2_2_0), expected: .exactly(v2_2_0))
+				testIntersection(.atLeast(v2_2_0), .exactly(v2_2_0_b421), expected: .exactly(v2_2_0_b421))
+				testIntersection(.atLeast(v2_2_0_b421), .exactly(v2_2_0), expected: .exactly(v2_2_0))
+				testIntersection(.atLeast(v2_2_0_alpha), .exactly(v2_2_0), expected: .exactly(v2_2_0))
 			}
 
 			it("should return the higher minor or patch version when one is .compatibleWith") {
@@ -239,6 +273,10 @@ class VersionSpecifierSpec: QuickSpec {
 				testIntersection(.compatibleWith(v1_3_2), .compatibleWith(v2_1_1), expected: nil)
 				testIntersection(.compatibleWith(v2_1_1), .compatibleWith(v2_2_0), expected: .compatibleWith(v2_2_0))
 				testIntersection(.compatibleWith(v2_1_1), .exactly(v2_2_0), expected: .exactly(v2_2_0))
+				testIntersection(.compatibleWith(v2_2_0), .exactly(v2_2_0_alpha), expected: nil)
+				testIntersection(.compatibleWith(v2_2_0), .exactly(v2_2_0_b421), expected: .exactly(v2_2_0_b421))
+				testIntersection(.compatibleWith(v2_2_0_alpha), .exactly(v2_2_0), expected: .exactly(v2_2_0))
+				testIntersection(.compatibleWith(v2_2_0_b421), .exactly(v2_2_0), expected: .exactly(v2_2_0))
 			}
 
 			it("should only match exact specifiers for .exactly") {
@@ -247,9 +285,11 @@ class VersionSpecifierSpec: QuickSpec {
 				testIntersection(.exactly(v2_1_1), .compatibleWith(v2_2_0), expected: nil)
 				testIntersection(.exactly(v1_3_2), .exactly(v1_3_2), expected: VersionSpecifier.exactly(v1_3_2))
 				testIntersection(.exactly(v2_1_1), .exactly(v1_3_2), expected: nil)
+				testIntersection(.exactly(v2_2_0_alpha), .exactly(v2_2_0), expected: nil)
+				testIntersection(.exactly(v2_2_0_b421), .exactly(v2_2_0), expected: nil)
 			}
 
-			it("should not let ~> 0.1.1 be compatible with 0.1.2, but not 0.2") {
+			it("should let ~> 0.1.1 be compatible with 0.1.2, but not 0.2") {
 				testIntersection(.compatibleWith(v0_1_0), .compatibleWith(v0_1_1), expected: .compatibleWith(v0_1_1))
 				testIntersection(.compatibleWith(v0_1_0), .compatibleWith(v0_2_0), expected: nil)
 			}


### PR DESCRIPTION
This commit introduces the logic for comparison of pre-release versions and versions with build metadata.

For the purpose of comparison:
- pre-release versions follow the specifications at http://semver.org/
- build metadata is ignored when performing comparisons

For the purpose of intersection of requirements (i.e. find a version that satisfies two requirements):
- pre-release versions follow the specifications at http://semver.org/
- build metadata is ignored when using a `.atLeast`, `.any` or `.compatibleWith` requirement, but taken into account when using an `.exactly` requirement.