### PR TITLE
Prefer SSH over HTTPS by default

### DIFF
--- a/Source/Scripts/carthage-bash-completion
+++ b/Source/Scripts/carthage-bash-completion
@@ -28,7 +28,7 @@ _carthage() {
                 ;;
             bootstrap|update)
                 COMPREPLY=($(compgen -W '--no-checkout --no-build --verbose --configuration \
-                    --platform --toolchain --derived-data --use-ssh --use-submodules \
+                    --platform --toolchain --derived-data --use-submodules \
                     --no-use-binaries --color --project-directory --cache-builds' -- ${cur}))
                 return 0
                 ;;
@@ -38,7 +38,7 @@ _carthage() {
                 return 0
                 ;;
             checkout)
-                COMPREPLY=($(compgen -W '--use-ssh --use-submodules --no-use-binaries \
+                COMPREPLY=($(compgen -W '--use-submodules --no-use-binaries \
                     --color --project-directory' -- ${cur}))
                 return 0
                 ;;
@@ -47,7 +47,7 @@ _carthage() {
                 return 0
                 ;;
             outdated)
-                COMPREPLY=($(compgen -W '--use-ssh --verbose --color \
+                COMPREPLY=($(compgen -W '--verbose --color \
                     --project-directory' -- ${cur}))
                 return 0
                 ;;

--- a/Source/Scripts/carthage-fish-completion
+++ b/Source/Scripts/carthage-fish-completion
@@ -29,7 +29,7 @@ complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l configuratio
 complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l platform -x -a "all macOS iOS watchOS tvOS"
 complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l toolchain -x -a "com.apple.dt.toolchain.Swift_2_3 com.apple.dt.toolchain.XcodeDefault"
 complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l derived-data -x -a '(__fish_complete_directories (commandline -ct))'
-complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l use-ssh
+complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l use-https
 complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l use-submodules
 complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l no-use-binaries
 complete -c carthage -n '__fish_prog_using_subcommand bootstrap' -l color -a "auto always never" -x
@@ -46,7 +46,7 @@ complete -c carthage -n '__fish_prog_using_subcommand build' -l verbose
 complete -c carthage -n '__fish_prog_using_subcommand build' -l project-directory -x -a '(__fish_complete_directories (commandline -ct))'
 complete -c carthage -n '__fish_prog_using_subcommand build' -l cache-builds
 
-complete -c carthage -n '__fish_prog_using_subcommand checkout' -l use-ssh
+complete -c carthage -n '__fish_prog_using_subcommand checkout' -l use-https
 complete -c carthage -n '__fish_prog_using_subcommand checkout' -l use-submodules
 complete -c carthage -n '__fish_prog_using_subcommand checkout' -l no-use-binaries
 complete -c carthage -n '__fish_prog_using_subcommand checkout' -l color -a "auto always never" -x
@@ -56,7 +56,7 @@ complete -c carthage -n '__fish_prog_using_subcommand fetch' -l color -a "auto a
 
 complete -c carthage -n '__fish_prog_using_subcommand help' -a "archive bootstrap build checkout copy-frameworks fetch help outdated update version" -f
 
-complete -c carthage -n '__fish_prog_using_subcommand outdated' -l use-ssh
+complete -c carthage -n '__fish_prog_using_subcommand outdated' -l use-https
 complete -c carthage -n '__fish_prog_using_subcommand outdated' -l verbose
 complete -c carthage -n '__fish_prog_using_subcommand outdated' -l color -a "auto always never" -x
 complete -c carthage -n '__fish_prog_using_subcommand outdated' -l project-directory -x -a '(__fish_complete_directories (commandline -ct))'
@@ -68,7 +68,7 @@ complete -c carthage -n '__fish_prog_using_subcommand update' -l configuration -
 complete -c carthage -n '__fish_prog_using_subcommand update' -l platform -x -a "all macOS iOS watchOS tvOS"
 complete -c carthage -n '__fish_prog_using_subcommand update' -l toolchain -x -a "com.apple.dt.toolchain.Swift_2_3 com.apple.dt.toolchain.XcodeDefault"
 complete -c carthage -n '__fish_prog_using_subcommand update' -l derived-data -x -a '(__fish_complete_directories (commandline -ct))'
-complete -c carthage -n '__fish_prog_using_subcommand update' -l use-ssh
+complete -c carthage -n '__fish_prog_using_subcommand update' -l use-https
 complete -c carthage -n '__fish_prog_using_subcommand update' -l use-submodules
 complete -c carthage -n '__fish_prog_using_subcommand update' -l no-use-binaries
 complete -c carthage -n '__fish_prog_using_subcommand update' -l color -a "auto always never" -x

--- a/Source/Scripts/carthage-zsh-completion
+++ b/Source/Scripts/carthage-zsh-completion
@@ -54,7 +54,6 @@ _carthage() {
                         '--platform: :(all macOS iOS watchOS tvOS)' \
                         '--toolchain: :(com.apple.dt.toolchain.Swift_2_3 com.apple.dt.toolchain.XcodeDefault)' \
                         '--derived-data: :_directories' \
-                        '--use-ssh' \
                         '--use-submodules' \
                         '--no-use-binaries' \
                         '--color: :(auto always never)' \
@@ -79,7 +78,6 @@ _carthage() {
                         ;;
                 (checkout)
                     _arguments \
-                        '--use-ssh' \
                         '--use-submodules' \
                         '--no-use-binaries' \
                         '--color: :(auto always never)' \
@@ -101,7 +99,6 @@ _carthage() {
                     ;;
                 (outdated)
                     _arguments \
-                        '--use-ssh' \
                         '--verbose' \
                         '--color: :(auto always never)' \
                         '--project-directory: :_directories' \

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -8,19 +8,19 @@ import Curry
 /// Type that encapsulates the configuration and evaluation of the `checkout` subcommand.
 public struct CheckoutCommand: CommandProtocol {
 	public struct Options: OptionsProtocol {
-		public let useSSH: Bool
+		public let useHTTPS: Bool
 		public let useSubmodules: Bool
 		public let colorOptions: ColorOptions
 		public let directoryPath: String
 		public let dependenciesToCheckout: [String]?
 
-		private init(useSSH: Bool,
+		private init(useHTTPS: Bool,
 		             useSubmodules: Bool,
 		             colorOptions: ColorOptions,
 		             directoryPath: String,
 		             dependenciesToCheckout: [String]?
 		) {
-			self.useSSH = useSSH
+			self.useHTTPS = useHTTPS
 			self.useSubmodules = useSubmodules
 			self.colorOptions = colorOptions
 			self.directoryPath = directoryPath
@@ -33,7 +33,7 @@ public struct CheckoutCommand: CommandProtocol {
 
 		public static func evaluate(_ mode: CommandMode, dependenciesUsage: String) -> Result<Options, CommandantError<CarthageError>> {
 			return curry(self.init)
-				<*> mode <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
+				<*> mode <| Option(key: "use-https", defaultValue: false, usage: "use HTTPS for downloading GitHub repositories")
 				<*> mode <| Option(key: "use-submodules", defaultValue: false, usage: "add dependencies as Git submodules")
 				<*> ColorOptions.evaluate(mode)
 				<*> mode <| Option(key: "project-directory", defaultValue: FileManager.default.currentDirectoryPath, usage: "the directory containing the Carthage project")
@@ -45,7 +45,7 @@ public struct CheckoutCommand: CommandProtocol {
 		public func loadProject() -> SignalProducer<Project, CarthageError> {
 			let directoryURL = URL(fileURLWithPath: self.directoryPath, isDirectory: true)
 			let project = Project(directoryURL: directoryURL)
-			project.preferHTTPS = !self.useSSH
+			project.preferHTTPS = self.useHTTPS
 			project.useSubmodules = self.useSubmodules
 
 			var eventSink = ProjectEventSink(colorOptions: colorOptions)

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -48,7 +48,7 @@ public struct OutdatedCommand: CommandProtocol {
 	}
 
 	public struct Options: OptionsProtocol {
-		public let useSSH: Bool
+		public let useHTTPS: Bool
 		public let isVerbose: Bool
 		public let outputXcodeWarnings: Bool
 		public let colorOptions: ColorOptions
@@ -62,7 +62,7 @@ public struct OutdatedCommand: CommandProtocol {
 			)
 
 			return curry(self.init)
-				<*> mode <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
+				<*> mode <| Option(key: "use-https", defaultValue: false, usage: "use HTTPS for downloading GitHub repositories")
 				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "include nested dependencies")
 				<*> mode <| Option(key: "xcode-warnings", defaultValue: false, usage: "output Xcode compatible warning messages")
 				<*> ColorOptions.evaluate(mode, additionalUsage: UpdateType.legend)
@@ -74,7 +74,7 @@ public struct OutdatedCommand: CommandProtocol {
 		public func loadProject() -> SignalProducer<Project, CarthageError> {
 			let directoryURL = URL(fileURLWithPath: self.directoryPath, isDirectory: true)
 			let project = Project(directoryURL: directoryURL)
-			project.preferHTTPS = !self.useSSH
+			project.preferHTTPS = self.useHTTPS
 
 			var eventSink = ProjectEventSink(colorOptions: colorOptions)
 			project.projectEvents.observeValues { eventSink.put($0) }


### PR DESCRIPTION
I think that SSH should be the default with the option to use HTTPS via `--use-https` available.

This saves time when a user has Private dependancies written in their Cartfile and goes ahead with cloning the repository as long as SSH access is properly setup. 

If SSH is the new default having `--use-ssh` does not make sense anymore but having an option for `--use-https` does. 

What do you think? Am I far off the mark on this one?