### PR TITLE
Use just the host part of the URL for proxy values, drop the scheme

### DIFF
--- a/Source/CarthageKit/Proxy.swift
+++ b/Source/CarthageKit/Proxy.swift
@@ -21,7 +21,7 @@ struct Proxy {
 
 		var dictionary: [AnyHashable: Any] = [:]
 		dictionary[kCFNetworkProxiesHTTPEnable] = true
-		dictionary[kCFNetworkProxiesHTTPProxy] = proxyURL
+		dictionary[kCFNetworkProxiesHTTPProxy] = proxyURL.host
 
 		if let port = proxyURL.port {
 			dictionary[kCFNetworkProxiesHTTPPort] = port
@@ -38,7 +38,7 @@ struct Proxy {
 
 		var dictionary: [AnyHashable: Any] = [:]
 		dictionary[kCFNetworkProxiesHTTPSEnable] = true
-		dictionary[kCFNetworkProxiesHTTPSProxy] = proxyURL
+		dictionary[kCFNetworkProxiesHTTPSProxy] = proxyURL.host
 
 		if let port = proxyURL.port {
 			dictionary[kCFNetworkProxiesHTTPSPort] = port

--- a/Tests/CarthageKitTests/ProxyTests.swift
+++ b/Tests/CarthageKitTests/ProxyTests.swift
@@ -27,7 +27,7 @@ class ProxySpec: QuickSpec {
 			it("should set the http properties") {
 				expect(proxy.connectionProxyDictionary).toNot(beNil())
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPEnable] as? Bool).to(beTrue())
-				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPProxy] as? URL) == URL(string: "http://github.com:8888")
+				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPProxy] as? String) == URL(string: "http://github.com:8888")?.host
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPPort] as? Int) == 8888
 			}
 
@@ -44,7 +44,7 @@ class ProxySpec: QuickSpec {
 			it("should set the https properties") {
 				expect(proxy.connectionProxyDictionary).toNot(beNil())
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSEnable] as? Bool).to(beTrue())
-				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSProxy] as? URL) == URL(string: "https://github.com:8888")
+				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSProxy] as? String) == URL(string: "https://github.com:8888")?.host
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSPort] as? Int) == 8888
 			}
 
@@ -66,10 +66,10 @@ class ProxySpec: QuickSpec {
 			it("should set the http properties") {
 				expect(proxy.connectionProxyDictionary).toNot(beNil())
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPEnable] as? Bool).to(beTrue())
-				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPProxy] as? URL) == URL(string: "http://github.com:8888")
+				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPProxy] as? String) == URL(string: "http://github.com:8888")?.host
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPPort] as? Int) == 8888
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSEnable] as? Bool).to(beTrue())
-				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSProxy] as? URL) == URL(string: "https://github.com:443")
+				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSProxy] as? String) == URL(string: "https://github.com:443")?.host
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSPort] as? Int) == 443
 			}
 		}


### PR DESCRIPTION
~Tentative~ fix for #2419 