### PR TITLE
Discard invalid build metadata and pre-release semantic version

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -118,6 +118,14 @@ extension SemanticVersion: Scannable {
 		
 		let preRelease = scanner.scanStringWithPrefix("-", until: "+")
 		let buildMetadata = scanner.scanStringWithPrefix("+", until: "")
+		
+		if let buildMetadata = buildMetadata, buildMetadata.isEmpty {
+			return .failure(ScannableError(message: "Build metadata is empty after '+', in \"\(version)\""))
+		}
+		
+		if let preRelease = preRelease, preRelease.isEmpty {
+			return .failure(ScannableError(message: "Pre-release is empty after '-', in \"\(version)\""))
+		}
 
 		guard (preRelease == nil && buildMetadata == nil) || hasPatchComponent else {
 			return .failure(ScannableError(message: "can not have pre-release or build metadata without patch, in \"\(version)\""))

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -68,6 +68,10 @@ class SemanticVersionSpec: QuickSpec {
 			expect(SemanticVersion.from(PinnedVersion("v2.8-alpha")).value).to(beNil()) // pre-release should be after patch
 			expect(SemanticVersion.from(PinnedVersion("v2.8+build345")).value).to(beNil()) // build should be after patch
 			expect(SemanticVersion.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("1.4.5+")).value).to(beNil()) // missing build metadata after '+'
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha+")).value).to(beNil()) // missing build metadata after '+'
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
 		}
 	}
 }


### PR DESCRIPTION
Any version with `-` but without pre-release, or with `+` but without build metadata, is discarded as invalid