### PR TITLE
To destination is a symlink when archiving on macOS

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -324,7 +324,9 @@ extension FileManager: ReactiveExtensionsProvider {
 		try from.path.withCString { fromCStr in
 			try to.path.withCString { toCStr in
 				let state = copyfile_state_alloc()
-				let status = copyfile(fromCStr, toCStr, state, UInt32(COPYFILE_ALL | COPYFILE_RECURSIVE | COPYFILE_NOFOLLOW))
+				// Can't use COPYFILE_NOFOLLOW. Restriction relaxed to COPYFILE_NOFOLLOW_SRC
+				// http://openradar.appspot.com/32984063
+				let status = copyfile(fromCStr, toCStr, state, UInt32(COPYFILE_ALL | COPYFILE_RECURSIVE | COPYFILE_NOFOLLOW_SRC))
 				copyfile_state_free(state)
 				if status < 0 {
 					throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)


### PR DESCRIPTION
This PR resolves issue #2444.

Our archive build steps for a macOS application were failing when doing the `carthage copy-frameworks` step due to a problem with code signing. The error message shown in the log was:

    […]/Contents/Frameworks/Result.framework: bundle format is ambiguous (could be app or framework)

However, the real problem was that the framework has not been copied at all and therefore `codesign` had nothing to sign at the destination path.

The `copyItem` method in `FrameworkExtension.swift` contains a workaround for copying files on an APFS disk and it falls back to the `copyFile` function from the standard c lib instead of using `NSFileManager`.

When executing an archive step on macOS, the `to` target resolves to a symlink:
    …/DerivedData/…/BuildProductsPath/Release/foobar.app@ ->
    …/DerivedData/…/InstallationBuildProductsLocation/Applications/foobar.app

The `to` destination is a symlink to the app bundle within an `…/Application` folder and thus the frameworks were not copied as the `copyfile` function was called with the `COPYFILE_NOFOLLOW` option. 

The solution is to use `COPYFILE_NOFOLLOW_SRC` instead. Now the frameworks are copied to the  destination directory.
