### PR TITLE
Allow binary assets with .zip extension.

### DIFF
--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -96,12 +96,8 @@ public struct Constants {
 		/// tried as a binary framework.
 		public static let binaryAssetPattern = ".framework"
 
-		/// The extension of a zip archive. Sometimes zip archives added to a release
-		/// have an incorrect MIME type, so check for a mime type or an extension.
-		public static let binaryAssetZipExtension = ".zip"
-
 		/// MIME types allowed for GitHub Release assets, for them to be considered as
 		/// binary frameworks.
-		public static let binaryAssetContentTypes = ["application/zip"]
+		public static let binaryAssetContentTypes = ["application/zip", "application/octet-stream"]
 	}
 }

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -96,6 +96,10 @@ public struct Constants {
 		/// tried as a binary framework.
 		public static let binaryAssetPattern = ".framework"
 
+		/// The extension of a zip archive. Sometimes zip archives added to a release
+		/// have an incorrect MIME type, so check for a mime type or an extension.
+		public static let binaryAssetZipExtension = ".zip"
+
 		/// MIME types allowed for GitHub Release assets, for them to be considered as
 		/// binary frameworks.
 		public static let binaryAssetContentTypes = ["application/zip"]

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -664,12 +664,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.flatMap(.concat) { release -> SignalProducer<URL, CarthageError> in
 				return SignalProducer<Release.Asset, CarthageError>(release.assets)
 					.filter { asset in
-						guard asset.name.contains(Constants.Project.binaryAssetPattern) else {
+						if asset.name.range(of: Constants.Project.binaryAssetPattern) == nil {
 							return false
 						}
-						// Sometimes .zip archives have the wrong MIME-type. Check for an extension also.
-						return asset.name.lowercased().hasSuffix(Constants.Project.binaryAssetZipExtension) ||
-							Constants.Project.binaryAssetContentTypes.contains(asset.contentType)
+						return Constants.Project.binaryAssetContentTypes.contains(asset.contentType)
 					}
 					.flatMap(.concat) { asset -> SignalProducer<URL, CarthageError> in
 						let fileURL = fileURLToCachedBinary(dependency, release, asset)

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -664,10 +664,12 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.flatMap(.concat) { release -> SignalProducer<URL, CarthageError> in
 				return SignalProducer<Release.Asset, CarthageError>(release.assets)
 					.filter { asset in
-						if asset.name.range(of: Constants.Project.binaryAssetPattern) == nil {
+						guard asset.name.contains(Constants.Project.binaryAssetPattern) else {
 							return false
 						}
-						return Constants.Project.binaryAssetContentTypes.contains(asset.contentType)
+						// Sometimes .zip archives have the wrong MIME-type. Check for an extension also.
+						return asset.name.lowercased().hasSuffix(Constants.Project.binaryAssetZipExtension) ||
+							Constants.Project.binaryAssetContentTypes.contains(asset.contentType)
 					}
 					.flatMap(.concat) { asset -> SignalProducer<URL, CarthageError> in
 						let fileURL = fileURLToCachedBinary(dependency, release, asset)


### PR DESCRIPTION
Sometimes framework.zip files (created with `carthage archive`) are uploaded with the incorrect MIME type. For example, if the archives are uploaded with the `github-release` utility, they end up with a MIME type of `application/octect-stream` instead of `application/zip`. 

This patch supports archives with a `.zip` extension but which may not have the expected MIME type. 