### PR TITLE
Ignore anything after a space when parsing semantic versions

### DIFF
--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -27,6 +27,9 @@ class CartfileSpec: QuickSpec {
 				.enterprise(url: URL(string: "https://enterprise.local/ghe")!), Repository(owner: "desktop", name: "git-error-translations")
 			)
 			let errorTranslations2 = Dependency.git(GitURL("https://enterprise.local/desktop/git-error-translations2.git"))
+			let example1 = Dependency.gitHub(.dotCom, Repository(owner: "ExampleOrg", name: "ExamplePrj1"))
+			let example2 = Dependency.gitHub(.dotCom, Repository(owner: "ExampleOrg", name: "ExamplePrj2"))
+			let example3 = Dependency.gitHub(.dotCom, Repository(owner: "ExampleOrg", name: "ExamplePrj3"))
 
 			expect(cartfile.dependencies) == [
 				reactiveCocoa: .atLeast(SemanticVersion(major: 2, minor: 3, patch: 1)),
@@ -36,6 +39,9 @@ class CartfileSpec: QuickSpec {
 				iosCharts: .any,
 				errorTranslations: .any,
 				errorTranslations2: .gitReference("development"),
+				example1: .atLeast(SemanticVersion(major: 3, minor: 0, patch: 2, preRelease: "pre")),
+				example2: .exactly(SemanticVersion(major: 3, minor: 0, patch: 2, preRelease: nil, buildMetadata: "build")),
+				example3: .exactly(SemanticVersion(major: 3, minor: 0, patch: 2))
 			]
 		}
 

--- a/Tests/CarthageKitTests/Resources/TestCartfile
+++ b/Tests/CarthageKitTests/Resources/TestCartfile
@@ -5,6 +5,11 @@ github "Mantle/Mantle" ~> 1.0
 github "jspahrsummers/libextobjc" == 0.4.1
 github "jspahrsummers/xcconfigs" # here is an intra-line comment
 
+github "ExampleOrg/ExamplePrj1" >= 3.0.2-pre # With intra-line comment after version
+github "ExampleOrg/ExamplePrj2" == 3.0.2+build # With intra-line comment after version
+github "ExampleOrg/ExamplePrj3" == 3.0.2 # With intra-line comment after version
+
+
 # name with .git suffix
 github "danielgindi/ios-charts.git"
 

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -73,6 +73,21 @@ class SemanticVersionSpec: QuickSpec {
 			expect(SemanticVersion.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
 			expect(SemanticVersion.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
 		}
+		
+		it("Should not scan anything after a space as part of version") {
+			expect(SemanticVersion.from(Scanner(string: "1.4.5+ #comment")).value).to(beNil()) // invalid
+			expect(SemanticVersion.from(Scanner(string: "1.4.5- #comment")).value).to(beNil()) // invalid
+			expect(SemanticVersion.from(Scanner(string: "2.8.2-alpha #comment")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha")
+			expect(SemanticVersion.from(Scanner(string: "2.8.2 #comment")).value) == SemanticVersion(major: 2, minor: 8, patch: 2)
+		}
+		
+		it("Should not consume anything after space when scanning") {
+			let scanner = Scanner(string: "2.8.2+b12 #comment")
+			expect(SemanticVersion.from(scanner).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: nil, buildMetadata: "b12")
+			var remaining: NSString? = nil
+			scanner.scanUpTo("<EOF>", into: &remaining)
+			expect(remaining) == "#comment"
+		}
 	}
 }
 


### PR DESCRIPTION
According to https://git-scm.com/docs/git-check-ref-format, whitespace are not allowed in a tag, commit SHA, or branch name, so I assume the version ends at the first space.

The reason for this code change is that inline comments in the Cartfile (`#...`) should not be parsed as part of the semantic version. Since comments should at least have a space before the `#` (because otherwise they could be considered part of the commit-ish, `head/foo#2` is a valid tag for example).

I decided to use spaces to identify comments. If there is a space and it's not followed by a comment, the file parser will throw an error because it expects either a comment or the line to be over.