### PR TITLE
Discard fullwidth digits in semver parsing

### DIFF
--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -81,11 +81,15 @@ public struct SemanticVersion: VersionType {
 		                       preRelease: self.preRelease)
 	}
 	
-	/// Set of valid characters for SemVer major.minor.patch section
+	/// Set of valid digts for SemVer versions
 	/// - note: Please use this instead of `CharacterSet.decimalDigits`, as
 	/// `decimalDigits` include more characters that are not contemplated in
 	/// the SemVer spects (e.g. `FULLWIDTH` version of digits, like `４`)
-	fileprivate static let versionCharacterSet = CharacterSet(charactersIn: "0123456789.")
+	fileprivate static let semVerDecimalDigits = CharacterSet(charactersIn: "0123456789")
+	
+	/// Set of valid characters for SemVer major.minor.patch section
+	fileprivate static let versionCharacterSet = CharacterSet(charactersIn: ".")
+		.union(SemanticVersion.semVerDecimalDigits)
 	
 	fileprivate static let asciiAlphabeth = CharacterSet(
 		charactersIn: "abcdefghijklmnopqrstuvxyzABCDEFGHIJKLMNOPQRSTUVXYZ"
@@ -93,7 +97,7 @@ public struct SemanticVersion: VersionType {
 	
 	/// Set of valid character for SemVer build metadata section
 	fileprivate static let invalidBuildMetadataCharacters = asciiAlphabeth
-		.union(CharacterSet.decimalDigits)
+		.union(SemanticVersion.semVerDecimalDigits)
 		.union(CharacterSet.init(charactersIn: "-"))
 		.inverted
 	
@@ -196,7 +200,7 @@ extension SemanticVersion: Scannable {
 		}
 		
 		guard components
-			.filter({ !$0.containsAny(CharacterSet.decimalDigits.inverted) && $0 != "0" })
+			.filter({ !$0.containsAny(SemanticVersion.semVerDecimalDigits.inverted) && $0 != "0" })
 			.first(where: { $0.hasPrefix("0")}) // MUST NOT include leading zeros
 			== nil else
 		{
@@ -315,7 +319,7 @@ extension String {
 	
 	/// Returns the Int value of the string, if the string is only composed of digits
 	private var numericValue : Int? {
-		if !self.isEmpty && self.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil {
+		if !self.isEmpty && self.rangeOfCharacter(from: SemanticVersion.semVerDecimalDigits.inverted) == nil {
 			return Int(self)
 		}
 		return nil

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -82,8 +82,10 @@ public struct SemanticVersion: VersionType {
 	}
 	
 	/// Set of valid characters for SemVer major.minor.patch section
-	fileprivate static let versionCharacterSet = CharacterSet(charactersIn: ".")
-		.union(CharacterSet.decimalDigits)
+	/// - note: Please use this instead of `CharacterSet.decimalDigits`, as
+	/// `decimalDigits` include more characters that are not contemplated in
+	/// the SemVer spects (e.g. `FULLWIDTH` version of digits, like `４`)
+	fileprivate static let versionCharacterSet = CharacterSet(charactersIn: "0123456789.")
 	
 	fileprivate static let asciiAlphabeth = CharacterSet(
 		charactersIn: "abcdefghijklmnopqrstuvxyzABCDEFGHIJKLMNOPQRSTUVXYZ"

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -77,6 +77,8 @@ class SemanticVersionSpec: QuickSpec {
 			expect(SemanticVersion.from(PinnedVersion("1.4.5+build@2")).value).to(beNil()) // non alphanumeric are not allowed in build metadata
 			expect(SemanticVersion.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
 			expect(SemanticVersion.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
+			expect(SemanticVersion.from(PinnedVersion("1.４.5")).value).to(beNil()) // Note that the `４` in this string is
+																					// a fullwidth character, not a halfwidth `4`
 		}
 		
 		it("Should not scan anything after a space as part of version") {


### PR DESCRIPTION
As mentioned here https://github.com/Carthage/Carthage/pull/2453#discussion_r189330964, `CharacterSet.decimalDigits` contains some characters that should not be parsed as valid version