### PR TITLE
Use `#` token for comment detection instead of space when parsing semver

### DIFF
--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -7,6 +7,10 @@ public let carthageProjectCheckoutsPath = "Carthage/Checkouts"
 /// Represents a Cartfile, which is a specification of a project's dependencies
 /// and any other settings Carthage needs to build it.
 public struct Cartfile {
+	
+	/// Any text following this character is considered a comment
+	static let commentIndicator = "#"
+	
 	/// The dependencies listed in the Cartfile.
 	public var dependencies: [Dependency: VersionSpecifier]
 
@@ -26,11 +30,10 @@ public struct Cartfile {
 		var duplicates: [Dependency] = []
 		var result: Result<(), CarthageError> = .success(())
 
-		let commentIndicator = "#"
 		string.enumerateLines { line, stop in
 			let scanner = Scanner(string: line)
 
-			if scanner.scanString(commentIndicator, into: nil) {
+			if scanner.scanString(Cartfile.commentIndicator, into: nil) {
 				// Skip the rest of the line.
 				return
 			}
@@ -64,7 +67,7 @@ public struct Cartfile {
 				return
 			}
 
-			if scanner.scanString(commentIndicator, into: nil) {
+			if scanner.scanString(Cartfile.commentIndicator, into: nil) {
 				// Skip the rest of the line.
 				return
 			}

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -100,7 +100,6 @@ public struct SemanticVersion: VersionType {
 }
 
 extension SemanticVersion: Scannable {
-	
 	/// Attempts to parse a semantic version from a human-readable string of the
 	/// form "a.b.c" from a string scanner. It assumes the string might contain a
 	/// comment coming from a Cartfile and will ignore the comment if present
@@ -142,7 +141,7 @@ extension SemanticVersion: Scannable {
 			let version = versionBuffer as String? else {
 			return .failure(ScannableError(message: "expected version", currentLine: scanner.currentLine))
 		}
-		
+
 		let components = version
 			.split(omittingEmptySubsequences: true) { $0 == "." }
 		if components.isEmpty {
@@ -185,6 +184,7 @@ extension SemanticVersion: Scannable {
 		guard (preRelease == nil && buildMetadata == nil) || hasPatchComponent else {
 			return .failure(ScannableError(message: "can not have pre-release or build metadata without patch, in \"\(version)\""))
 		}
+		
 		return .success(self.init(major: major,
 		                          minor: minor,
 		                          patch: patch,

--- a/Tests/CarthageKitTests/Resources/TestCartfile
+++ b/Tests/CarthageKitTests/Resources/TestCartfile
@@ -2,7 +2,7 @@ github "ReactiveCocoa/ReactiveCocoa" >= 2.3.1
 github "Mantle/Mantle" ~> 1.0
 
 # here is a comment
-github "jspahrsummers/libextobjc" == 0.4.1
+github "jspahrsummers/libextobjc" == 0.4.1# With intra-line comment without space after version
 github "jspahrsummers/xcconfigs" # here is an intra-line comment
 
 github "ExampleOrg/ExamplePrj1" >= 3.0.2-pre # With intra-line comment after version

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -19,22 +19,22 @@ class SemanticVersionSpec: QuickSpec {
 			expect(version) < SemanticVersion(major: 10, minor: 0, patch: 0)
 			expect(version) < SemanticVersion(major: 2, minor: 10, patch: 1)
 			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 10)
-
+			
 			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 2, buildMetadata: "b421")
 			expect(version) != SemanticVersion(major: 2, minor: 1, patch: 1, buildMetadata: "b2334")
 			expect(version) > SemanticVersion(major: 2, minor: 1, patch: 0, buildMetadata: "b421")
 		}
-
+		
 		it("should order pre-release versions correctly") {
 			let version = SemanticVersion(major: 2, minor: 1, patch: 1, preRelease: "alpha8")
-
+			
 			expect(version) < SemanticVersion(major: version.major, minor: version.minor, patch: version.patch)
 			expect(version) > SemanticVersion(major: version.major, minor: version.minor, patch: version.patch-1)
 			expect(version) == SemanticVersion(major: version.major, minor: version.minor, patch: version.patch, preRelease: version.preRelease)
-
+			
 			// As specified in http://semver.org/
 			// "Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0"
-
+			
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
@@ -42,7 +42,7 @@ class SemanticVersionSpec: QuickSpec {
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) < SemanticVersion(major: 1, minor: 0, patch: 0)
-
+			
 			// now test the reverse (to catch error if the < function ALWAYS returns true)
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")
 			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
@@ -92,7 +92,7 @@ class SemanticVersionSpec: QuickSpec {
 			expect(SemanticVersion.from(Scanner(string: "2.8.2#comment"), ignoreCartfileComments: false).value).to(beNil())
 		}
 
-		it("Should not consume anything after space when scanning") {
+		it("Should not consume anything after `#` when scanning") {
 			let scanner = Scanner(string: "2.8.2+b12 #comment")
 			expect(SemanticVersion.from(scanner).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: nil, buildMetadata: "b12")
 			var remaining: NSString? = nil


### PR DESCRIPTION
Previously, the code was relying on there being a space between a version specified and a comment. This commit removes that assumption.