### PR TITLE
Refactor detection of Cartfile comments

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2190FA981FD5B2F0008D8A79 /* OutdatedDependencies in Resources */ = {isa = PBXBuildFile; fileRef = 2190FA961FD5B05F008D8A79 /* OutdatedDependencies */; };
-		21F11B481FE67A26009FB783 /* DB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F11B461FE6787F009FB783 /* DB.swift */; };
 		0FDFEA7E2055D638008862E3 /* ProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFEA7D2055D638008862E3 /* ProxyTests.swift */; };
 		0FDFEA802055FACE008862E3 /* Proxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFEA7F2055FACE008862E3 /* Proxy.swift */; };
+		2190FA981FD5B2F0008D8A79 /* OutdatedDependencies in Resources */ = {isa = PBXBuildFile; fileRef = 2190FA961FD5B05F008D8A79 /* OutdatedDependencies */; };
+		21F11B481FE67A26009FB783 /* DB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F11B461FE6787F009FB783 /* DB.swift */; };
 		3A0472F31C782B4000097EC7 /* Algorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0472F21C782B4000097EC7 /* Algorithms.swift */; };
 		3A0472F61C7836EA00097EC7 /* AlgorithmsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0472F41C782D1D00097EC7 /* AlgorithmsSpec.swift */; };
 		3B19041E1E4CFE4A00A866AD /* FakeOldObjc.framework in Resources */ = {isa = PBXBuildFile; fileRef = 3B19041C1E4CFE3900A866AD /* FakeOldObjc.framework */; };
@@ -33,6 +33,7 @@
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
 		A1411ED61EFC1BFD0060461F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1411ED51EFC1BFD0060461F /* Constants.swift */; };
+		A940B2F520C0363F001C4C59 /* CartfileCommentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */; };
 		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
 		B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */; };
 		B1F27D401E4541A1002D4754 /* TestVersionFile in Resources */ = {isa = PBXBuildFile; fileRef = B1F27D3F1E4541A1002D4754 /* TestVersionFile */; };
@@ -172,10 +173,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		2190FA961FD5B05F008D8A79 /* OutdatedDependencies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = OutdatedDependencies; sourceTree = "<group>"; };
-		21F11B461FE6787F009FB783 /* DB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DB.swift; sourceTree = "<group>"; };
 		0FDFEA7D2055D638008862E3 /* ProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyTests.swift; sourceTree = "<group>"; };
 		0FDFEA7F2055FACE008862E3 /* Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proxy.swift; sourceTree = "<group>"; };
+		2190FA961FD5B05F008D8A79 /* OutdatedDependencies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = OutdatedDependencies; sourceTree = "<group>"; };
+		21F11B461FE6787F009FB783 /* DB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DB.swift; sourceTree = "<group>"; };
 		3A0472F21C782B4000097EC7 /* Algorithms.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Algorithms.swift; sourceTree = "<group>"; };
 		3A0472F41C782D1D00097EC7 /* AlgorithmsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlgorithmsSpec.swift; sourceTree = "<group>"; };
 		3B19041C1E4CFE3900A866AD /* FakeOldObjc.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FakeOldObjc.framework; sourceTree = "<group>"; };
@@ -200,6 +201,7 @@
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
 		A1411ED51EFC1BFD0060461F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A14BB69B1EFA36B90077ABF4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = SOURCE_ROOT; };
+		A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartfileCommentsSpec.swift; sourceTree = "<group>"; };
 		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
 		B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionFileSpec.swift; sourceTree = "<group>"; };
 		B1F27D3F1E4541A1002D4754 /* TestVersionFile */ = {isa = PBXFileReference; explicitFileType = text.json; fileEncoding = 4; path = TestVersionFile; sourceTree = "<group>"; };
@@ -566,6 +568,7 @@
 				D0DE89411A0F2D450030A3EC /* VersionSpec.swift */,
 				B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */,
 				D0DB09A319EA354200234B16 /* XcodeSpec.swift */,
+				A940B2F320C033C9001C4C59 /* CartfileCommentsSpec.swift */,
 				21F11B461FE6787F009FB783 /* DB.swift */,
 				D0D1217C19E87B05005E4BAA /* Supporting Files */,
 			);
@@ -877,6 +880,7 @@
 				549B47B11A4F1A34002498C7 /* ProjectSpec.swift in Sources */,
 				D01D82DD1A10B01D00F0DD94 /* ResolverSpec.swift in Sources */,
 				BF3199C01E32E078007DC0D1 /* DependencySpec.swift in Sources */,
+				A940B2F520C0363F001C4C59 /* CartfileCommentsSpec.swift in Sources */,
 				CDA0B6CA1C468E67006C499C /* GitURLSpec.swift in Sources */,
 				B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */,
 			);

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -181,11 +181,12 @@ extension String {
 	/// comment starts with the first `commentIndicator` that is not embedded in any quote
 	var strippingTrailingCartfileComment: String {
 		
-		// since Cartfile syntax doesn't support nested quotes, such as `"version-\"alpha\""`
-		// I can just consider any odd-number occurence of a quote as a quote-start, and any
+		// Since the Cartfile syntax doesn't support nested quotes, such as `"version-\"alpha\""`,
+		// simply consider any odd-number occurence of a quote as a quote-start, and any
 		// even-numbered occurrence of a quote as quote-end.
 		// The comment indicator (e.g. `#`) is the start of a comment if it's not nested in quotes.
-		// The following code works also for comment indicators that are are more than one character long (e.g. "//")
+		// The following code works also for comment indicators that are are more than one character
+		// long (e.g. double slashes)
 		
 		let quote = "\""
 		

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -38,14 +38,21 @@ public struct Cartfile {
 				return
 			}
 
-			guard !scannerWithComments.isAtEnd,
-				let remainingString = scannerWithComments.remainingSubstring else {
+			if scannerWithComments.isAtEnd {
 				// The line was all whitespace.
 				return
 			}
 			
+			guard let remainingString = scannerWithComments.remainingSubstring.map(String.init) else {
+				result = .failure(CarthageError.internalError(
+					description: "Can NSScanner split an extended grapheme cluster? If it does, this will be the error…"
+				))
+				stop = true
+				return
+			}
+			
 			let scannerWithoutComments = Scanner(
-				string: String(remainingString).strippingTrailingCartfileComment
+				string: remainingString.strippingTrailingCartfileComment
 					.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 			)
 

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -204,7 +204,8 @@ extension String {
 			}
 			if let range = chunk.range(of: Cartfile.commentIndicator) {
 				// there is a comment, return everything before its position
-				let previousChunks = quoteDelimitedChunks[..<offset]
+				let advancedOffset = (..<offset).relative(to: quoteDelimitedChunks)
+				let previousChunks = quoteDelimitedChunks[advancedOffset]
 				let chunkBeforeComment = chunk[..<range.lowerBound]
 				return (previousChunks + [chunkBeforeComment])
 					.joined(separator: quote) // readd the quotes that were removed in the initial split

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -186,22 +186,23 @@ extension String {
 		// even-numbered occurrence of a quote as quote-end.
 		// The comment indicator (e.g. `#`) is the start of a comment if it's not nested in quotes.
 		// The following code works also for comment indicators that are are more than one character
-		// long (e.g. double slashes)
+		// long (e.g. double slashes).
 		
 		let quote = "\""
 		
 		// Splitting the string by quote will make odd-numbered chunks outside of quotes, and
 		// even-numbered chunks inside of quotes.
 		// `omittingEmptySubsequences` is needed to maintain this property even in case of empty quotes.
-		let quoteDelimitedChunks = self.split(separator: quote.first!,
-											  maxSplits: Int.max,
-											  omittingEmptySubsequences: false)
-		
+		let quoteDelimitedChunks = self.split(
+			separator: quote.first!,
+			maxSplits: Int.max,
+			omittingEmptySubsequences: false
+		)
 		
 		for (offset, chunk) in quoteDelimitedChunks.enumerated() {
 			let isInQuote = offset % 2 == 1 // even chunks are not in quotes, see comment above
 			if isInQuote {
-				continue // we don't consider comment indicators inside quotes
+				continue // don't consider comment indicators inside quotes
 			}
 			if let range = chunk.range(of: Cartfile.commentIndicator) {
 				// there is a comment, return everything before its position

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -107,43 +107,11 @@ public struct SemanticVersion: VersionType {
 
 extension SemanticVersion: Scannable {
 	/// Attempts to parse a semantic version from a human-readable string of the
-	/// form "a.b.c" from a string scanner. It assumes the string might contain a
-	/// comment coming from a Cartfile and will ignore the comment if present
-	public static func from(_ scanner: Scanner) -> Result<SemanticVersion, ScannableError> {
-		return self.from(scanner, ignoreCartfileComments: true)
-	}
-	
-	/// Attempts to parse a semantic version from a human-readable string of the
 	/// form "a.b.c" from a string scanner.
-	/// - parameter ignoreCartfileComments: If `true`, it will ignore any potential Cartfile comment,
-	/// without consuming the following characters in the scanner. If `false`, Cartfile comments will cause
-	/// this method to return a failure.
-	/// - Note: Side effects on state of `scanner`: it will consume the parsed string
-	public static func from(_ scanner: Scanner, ignoreCartfileComments: Bool) -> Result<SemanticVersion, ScannableError> {
-		let numericVersionScanner: Scanner
-		
-		if ignoreCartfileComments {
-			// scan everything before the comment, and continue the parsing
-			// considering only the scanned part
-			var semanticVersionBuffer: NSString?
-			scanner.scanUpToCharacters(
-				from: CharacterSet(charactersIn: Cartfile.commentIndicator),
-				into: &semanticVersionBuffer
-			)
-			guard let semanticVersionString = semanticVersionBuffer as String? else {
-				return .failure(ScannableError(message: "expected version", currentLine: scanner.currentLine))
-			}
-			numericVersionScanner = Scanner(
-				string: semanticVersionString.trimmingCharacters(
-					in: CharacterSet.whitespacesAndNewlines
-				)
-			)
-		} else {
-			numericVersionScanner = scanner
-		}
+	public static func from(_ scanner: Scanner) -> Result<SemanticVersion, ScannableError> {
 		
 		var versionBuffer: NSString?
-		guard numericVersionScanner.scanCharacters(from: versionCharacterSet, into: &versionBuffer),
+        guard scanner.scanCharacters(from: versionCharacterSet, into: &versionBuffer),
 			let version = versionBuffer as String? else {
 			return .failure(ScannableError(message: "expected version", currentLine: scanner.currentLine))
 		}
@@ -169,9 +137,9 @@ extension SemanticVersion: Scannable {
 		let hasPatchComponent = components.count > 2
 		let patch = parseVersion(at: 2) ?? 0
 		
-		let preRelease = numericVersionScanner.scanStringWithPrefix("-", until: "+")
-		let buildMetadata = numericVersionScanner.scanStringWithPrefix("+", until: "")
-		guard numericVersionScanner.isAtEnd else {
+		let preRelease = scanner.scanStringWithPrefix("-", until: "+")
+		let buildMetadata = scanner.scanStringWithPrefix("+", until: "")
+		guard scanner.isAtEnd else {
 			return .failure(ScannableError(message: "expected valid version", currentLine: scanner.currentLine))
 		}
 		
@@ -265,7 +233,7 @@ extension Scanner {
 	}
 	
 	/// The string that is left to scan. Accessing this variable will not advance the scanner location.
-	fileprivate var remainingString: String {
+	var remainingString: String {
 		guard !self.isAtEnd else {
 			return ""
 		}

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -111,7 +111,7 @@ extension SemanticVersion: Scannable {
 	public static func from(_ scanner: Scanner) -> Result<SemanticVersion, ScannableError> {
 		
 		var versionBuffer: NSString?
-        guard scanner.scanCharacters(from: versionCharacterSet, into: &versionBuffer),
+		guard scanner.scanCharacters(from: versionCharacterSet, into: &versionBuffer),
 			let version = versionBuffer as String? else {
 			return .failure(ScannableError(message: "expected version", currentLine: scanner.currentLine))
 		}

--- a/Tests/CarthageKitTests/CartfileCommentsSpec.swift
+++ b/Tests/CarthageKitTests/CartfileCommentsSpec.swift
@@ -27,9 +27,9 @@ class CarfileCommentsSpec: QuickSpec {
 					"foo bar \"#baz\"",
 					"\"#quotes\" is the new \"quotes\"",
 					"\"#\""
-					]
-					.forEach {
-						expect($0.strippingTrailingCartfileComment) == $0
+				]
+				.forEach {
+					expect($0.strippingTrailingCartfileComment) == $0
 				}
 			}
 			

--- a/Tests/CarthageKitTests/CartfileCommentsSpec.swift
+++ b/Tests/CarthageKitTests/CartfileCommentsSpec.swift
@@ -1,0 +1,51 @@
+@testable import CarthageKit
+import Nimble
+import Quick
+
+class CarfileCommentsSpec: QuickSpec {
+	override func spec() {
+		
+		describe("removing carfile comments") {
+			it("should not alter strings with no comments") {
+				[
+					"foo bar\nbaz",
+					"",
+					"\n",
+					"this is a \"value\"",
+					"\"value\" this is",
+					"\"unclosed",
+					"unopened\"",
+					"I say \"hello\" you say \"goodbye\"!"
+				]
+				.forEach {
+					expect($0.strippingTrailingCartfileComment) == $0
+				}
+			}
+			
+			it("should not alter strings with comment marker in quotes") {
+				[
+					"foo bar \"#baz\"",
+					"\"#quotes\" is the new \"quotes\"",
+					"\"#\""
+					]
+					.forEach {
+						expect($0.strippingTrailingCartfileComment) == $0
+				}
+			}
+			
+			it("should remove comments") {
+				expect("#".strippingTrailingCartfileComment)
+					== ""
+				expect("\n  #\n".strippingTrailingCartfileComment)
+					== "\n  "
+				expect("I have some #comments!".strippingTrailingCartfileComment)
+					== "I have some "
+				expect("Some don't \"#matter\" and some # do!".strippingTrailingCartfileComment)
+					== "Some don't \"#matter\" and some "
+				expect("\"a\" b# # \"c\" #".strippingTrailingCartfileComment)
+					== "\"a\" b"
+			}
+		}
+	}
+}
+

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -81,27 +81,6 @@ class SemanticVersionSpec: QuickSpec {
 			expect(SemanticVersion.from(PinnedVersion("1.４.5")).value).to(beNil()) // Note that the `４` in this string is
 																					// a fullwidth character, not a halfwidth `4`
 		}
-
-		it("Should ignore everything after a `#` as part of version") {
-			expect(SemanticVersion.from(Scanner(string: "1.4.5+ #comment")).value).to(beNil()) // invalid
-			expect(SemanticVersion.from(Scanner(string: "1.4.5- #comment")).value).to(beNil()) // invalid
-			expect(SemanticVersion.from(Scanner(string: "2.8.2-alpha #comment")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha")
-			expect(SemanticVersion.from(Scanner(string: "2.8.2 #comment")).value) == SemanticVersion(major: 2, minor: 8, patch: 2)
-			expect(SemanticVersion.from(Scanner(string: "2.8.2#comment")).value) == SemanticVersion(major: 2, minor: 8, patch: 2)
-		}
-		
-		it("Should not ignore everything after a `#` if told not to") {
-			expect(SemanticVersion.from(Scanner(string: "2.8.2-alpha #comment"), ignoreCartfileComments: false).value).to(beNil())
-			expect(SemanticVersion.from(Scanner(string: "2.8.2#comment"), ignoreCartfileComments: false).value).to(beNil())
-		}
-
-		it("Should not consume anything after `#` when scanning") {
-			let scanner = Scanner(string: "2.8.2+b12 #comment")
-			expect(SemanticVersion.from(scanner).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: nil, buildMetadata: "b12")
-			var remaining: NSString? = nil
-			scanner.scanUpTo("<EOF>", into: &remaining)
-			expect(remaining) == "#comment"
-		}
 	}
 }
 


### PR DESCRIPTION
## Problem
Having the detection of Cartfile comments inside the version parser makes the parser unnecessarily tied to the Cartfile syntax. Additionally, since there is no case in which we would parse a version specifier and not ignore the comments, either we have to live with a parameter that is always set to `true` in the entire codebase, or remove the parameter and make strong assumptions on how the version parsing is used.

## Solution
This PR moves comment filtering to the Cartfile parsing code. Comments are stripped from each line before passing lines to the version parser.

The detection of comments is done with the following strategy:
- any `#` character that is not inside "quotes" is considered the beginning of the comment
- for the purpose of determining whether a character is inside quotes, the code relies on the fact that there should not be nested quotes (e.g. `quotes "like \"this\""`) inside a cartfile specification.

Even if not necessary at the moment, as the comment indicator is a single character, the implementation is designed to handle multi-character comment indicators. This has influenced the choice of using `String.components(separatedBy:)` over other solutions.

All the above is documented in code comments, and the PR includes tests to cover the comment stripping.