### PR TITLE
Ignore errors when getting EXPANDED_CODE_SIGN_IDENTITY

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -100,8 +100,12 @@ private func copyBCSymbolMapsForFramework(_ frameworkURL: URL, fromDirectory dir
 }
 
 private func codeSigningIdentity() -> String? {
-	return getEnvironmentVariableIfPresent("EXPANDED_CODE_SIGN_IDENTITY")
-		.flatMap { $0.isEmpty ? nil : $0 }
+	if codeSigningAllowed() {
+		return getEnvironmentVariableIfPresent("EXPANDED_CODE_SIGN_IDENTITY")
+			.flatMap { $0.isEmpty ? nil : $0 }
+	} else {
+		return nil
+	}
 }
 
 private func codeSigningAllowed() -> Bool {

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -103,9 +103,7 @@ private func copyBCSymbolMapsForFramework(_ frameworkURL: URL, fromDirectory dir
 private func codeSigningIdentity() -> SignalProducer<String?, CarthageError> {
 	return SignalProducer { () -> Result<String?, CarthageError> in
 		if codeSigningAllowed() {
-			return getEnvironmentVariable("EXPANDED_CODE_SIGN_IDENTITY")
-				.map { $0.isEmpty ? nil : $0 }
-				.flatMapError { _ in .success(nil) }
+			return .success(getEnvironmentVariableIfPresent("EXPANDED_CODE_SIGN_IDENTITY"))
 		} else {
 			return .success(nil)
 		}

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -101,6 +101,7 @@ private func copyBCSymbolMapsForFramework(_ frameworkURL: URL, fromDirectory dir
 
 private func codeSigningIdentity() -> String? {
 	return getEnvironmentVariableIfPresent("EXPANDED_CODE_SIGN_IDENTITY")
+		.flatMap { $0.isEmpty ? nil : $0 }
 }
 
 private func codeSigningAllowed() -> Bool {

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -103,7 +103,9 @@ private func copyBCSymbolMapsForFramework(_ frameworkURL: URL, fromDirectory dir
 private func codeSigningIdentity() -> SignalProducer<String?, CarthageError> {
 	return SignalProducer { () -> Result<String?, CarthageError> in
 		if codeSigningAllowed() {
-			return getEnvironmentVariable("EXPANDED_CODE_SIGN_IDENTITY").map { $0.isEmpty ? nil : $0 }
+			return getEnvironmentVariable("EXPANDED_CODE_SIGN_IDENTITY")
+				.map { $0.isEmpty ? nil : $0 }
+				.flatMapError { _ in .success(nil) }
 		} else {
 			return .success(nil)
 		}

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -46,7 +46,7 @@ public struct CopyFrameworksCommand: CommandProtocol {
 }
 
 private func copyFramework(_ source: URL, target: URL, validArchitectures: [String]) -> SignalProducer<(), CarthageError> {
-	return copyProduct(source, target).flatMap { url -> SignalProducer<(), CarthageError> in
+	return copyProduct(source, target).flatMap(.latest) { url -> SignalProducer<(), CarthageError> in
 			let strip = stripFramework(
 				url,
 				keepingArchitectures: validArchitectures,

--- a/Source/carthage/Environment.swift
+++ b/Source/carthage/Environment.swift
@@ -12,7 +12,7 @@ internal func getEnvironmentVariable(_ variable: String) -> Result<String, Carth
 	}
 }
 
-internal func getEnvironmentVariableIfPresent(_ variable: String, isOptional: Bool = false) -> String? {
+internal func getEnvironmentVariableIfPresent(_ variable: String) -> String? {
 	let environment = ProcessInfo.processInfo.environment
 
 	return environment[variable]

--- a/Source/carthage/Environment.swift
+++ b/Source/carthage/Environment.swift
@@ -12,6 +12,12 @@ internal func getEnvironmentVariable(_ variable: String) -> Result<String, Carth
 	}
 }
 
+internal func getEnvironmentVariableIfPresent(_ variable: String, isOptional: Bool = false) -> String? {
+	let environment = ProcessInfo.processInfo.environment
+
+	return environment[variable]
+}
+
 /// Information about the possible parent terminal.
 internal struct Terminal {
 	/// Terminal type retrieved from `TERM` environment variable.


### PR DESCRIPTION
Resolves #2472 

Xcode 10 is apparently omitting environment variables whose value is an empty string where previous versions would include the variable. This PR accounts for that by ignoring the missing environment variable error (in this case `EXPANDED_CODE_SIGN_IDENTITY`).

#### Other options considered (adjusting `getEnvironmentVariable`):

1. Specifying that the environment variable is optional, in which case an empty string would be returned.
```
func getEnvironmentVariable(_ variable: String, isOptional: Bool = false) -> Result<String, CarthageError> {
    let environment = ProcessInfo.processInfo.environment

    if let value = environment[variable] {
        return .success(value)
    } else if isOptional {
        return .success("")
    } else {
        return .failure(CarthageError.missingEnvironmentVariable(variable: variable))
    }
}
```
This didn't seem like the right solution since an empty string didn't seem like it had enough precedence for being the fallback value. So next I considered the following:

2. Providing a fallback value (that defaults to `nil` so that no existing code would be affected by the change.)
```
func getEnvironmentVariable(_ variable: String, fallbackValue: String? = nil) -> Result<String, CarthageError> {
    let environment = ProcessInfo.processInfo.environment

    if let value = environment[variable] {
        return .success(value)
    } else if let fallback = fallbackValue {
        return .success(fallback)
    } else {
        return .failure(CarthageError.missingEnvironmentVariable(variable: variable))
    }
}
```
This could have been the best solution, but in this specific case, we would have to provide an empty string as the fallback value, which would get ignored by the `.isEmpty` check in the `map` which seemed a little too tightly coupled to that logic. 