### PR TITLE
Truncate log file before writing new one

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -167,10 +167,7 @@ public struct BuildCommand: CommandProtocol {
 	private func openLogFile(_ path: String?) -> SignalProducer<(FileHandle, URL), CarthageError> {
 		return SignalProducer { () -> Result<(FileHandle, URL), CarthageError> in
 			if let path = path {
-				if !FileManager.default.fileExists(atPath: path) {
-					FileManager.default.createFile(atPath: path, contents: nil, attributes: nil)
-				}
-
+				FileManager.default.createFile(atPath: path, contents: nil, attributes: nil)
 				let fileURL = URL(fileURLWithPath: path, isDirectory: false)
 
 				guard let handle = FileHandle(forUpdatingAtPath: path) else {


### PR DESCRIPTION
Carthage was just writing on top of the log file so you could see old logs if the new output was smaller than the previous output. This forces the file to be truncated first. (Alternatively, you could also use `handle.truncateFile(atOffset: 0)` method to achieve the same thing.)