### PR TITLE
Fix build error with Xcode 10

### DIFF
--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -5,7 +5,7 @@ import Result
 import XCDBLD
 
 struct CachedFramework: Codable {
-	enum CodingKeys: CodingKey, String {
+	enum CodingKeys: String, CodingKey {
 		case name = "name"
 		case hash = "hash"
 	}
@@ -15,7 +15,7 @@ struct CachedFramework: Codable {
 }
 
 struct VersionFile: Codable {
-	enum CodingKeys: CodingKey, String {
+	enum CodingKeys: String, CodingKey {
 		case commitish = "commitish"
 		case macOS = "Mac"
 		case iOS = "iOS"


### PR DESCRIPTION
This fixes the error, "Raw type 'String' must appear first in the enum inheritance clause".