### PR TITLE
Proposed Behavior Change: Binary Only Downloads

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -14,6 +14,8 @@ public struct BuildOptions {
 	public var cacheBuilds: Bool
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
+	// Whether to build dependencies
+	public var build: Bool
 
 	public init(
 		configuration: String,
@@ -21,7 +23,8 @@ public struct BuildOptions {
 		toolchain: String? = nil,
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
-		useBinaries: Bool = true
+		useBinaries: Bool = true,
+		build: Bool = true
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -29,5 +32,6 @@ public struct BuildOptions {
 		self.derivedDataPath = derivedDataPath
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
+		self.build = build
 	}
 }

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -23,6 +23,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "use downloaded binaries when possible")
+			<*> mode <| Option(key: "build", defaultValue: true, usage: "whether or not to build, if --no-build BINARY specified dependencies will still be downloaded")
 	}
 }
 

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -36,7 +36,7 @@ public struct UpdateCommand: CommandProtocol {
 		///
 		/// Otherwise, this producer will be empty.
 		public var buildProducer: SignalProducer<(), CarthageError> {
-			if checkoutAfterUpdate && buildAfterUpdate {
+			if checkoutAfterUpdate {
 				return BuildCommand().buildWithOptions(buildCommandOptions)
 			} else {
 				return .empty
@@ -72,7 +72,7 @@ public struct UpdateCommand: CommandProtocol {
 				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
 				<*> mode <| Option(key: "log-path", defaultValue: nil, usage: "path to the xcode build output. A temporary file is used by default")
 				<*> mode <| Option(key: "new-resolver", defaultValue: false, usage: "use the new resolver codeline when calculating dependencies. Default is false")
-				<*> BuildOptions.evaluate(mode, addendum: "\n(ignored if --no-build option is present)")
+				<*> BuildOptions.evaluate(mode, addendum: "")
 				<*> CheckoutCommand.Options.evaluate(mode, dependenciesUsage: dependenciesUsage)
 		}
 


### PR DESCRIPTION
## 🔨 Issue :
[Binaries are no longer pulled if using submodules](https://github.com/Carthage/Carthage/issues/2449)

Which occurred after this change: 
Move binary download to build process [#2342](https://github.com/Carthage/Carthage/pull/2342)

## 📦 Use Case:
```
# Third Party
github "SwiftKickMobile/SwiftMessages" ~> 4.0

# Binary Only Third Party
binary "https://raw.githubusercontent.com/dmiluski/CarthageSpecs/master/AppboyFramework.json"
```
Given this change, and use case:
`carthage update --no-build --use-ssh --use-submodules`

A users directly is not propagated with the binary-only dependency.

A mix of submodule internal/external Carthage Dependencies, plus a few additional Carthage Binary only dependencies based on those developer's project distribution preferences. This allows us to pull in dependencies and only build required architectures while developing.

## ❓ Why:
Given Binary only downloads has moved to building phase, build patterns which opt to not build do not get the benefit of being able to download BinaryOnly.

## 💍 Proposal:
Provide additional option to verbosely specify downloading binaries

## 🗒  Options:
`--download-binaries-and-skip-build`     // I felt this one could conflict with `--no-build`
`--download-binaries-if-skip-build`         // Conveys we still want to download binaries even if build skipped
`--download-binaries`                                // Simpler, but does this conflict with `--use-binaries`
`--download-binary-only-dependencies` // Too Long?
   others?

## ❓ Questions:
Is this a step completely separate from sync, build? ✅ 
Will this affect build? 🚫 
Is this option naming confusing given the parameter: --use-binaries ❓
When should this now happen: Checkout : Build : Other ❓ 

## Additional Comments:
Current PR Diff does not accurately represent proposal yet

## Initial Attempt: 🤧 
[First Commit](https://github.com/Carthage/Carthage/pull/2478/commits)
Goal:
Not require --build in order to provide a buildProducer. Instead, inspect --build within buildProducer to make the determination.

Problem
Per @ikesyo 
```That’s because the build option key is already defined and consumed by UpdateCommand.Options so BuildOptions would not get the option and the default value will be used.```

Option:
- Pass correctly vs currying (didn't understand this part of parsing)
- move forward with build approach, or use additional flag