### PR TITLE
Sanitizing dependency names

### DIFF
--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -52,7 +52,8 @@ public struct GitURL {
 		return components
 			.last
 			.map(String.init)
-			.map(strippingGitSuffix)
+			.map(strippingGitSuffix)?
+			.removingPercentEncoding
 	}
 
 	public init(_ urlString: String) {

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -78,6 +78,12 @@ class DependencySpec: QuickSpec {
 
 					expect(dependency.name) == "myproject"
 				}
+                
+                it("should have percent encoding removed") {
+                    let dependency = Dependency.git(GitURL("ssh://server.com/my%20project%20with%20spaces.git"))
+                    
+                    expect(dependency.name) == "my project with spaces"
+                }
 
 				it("should be the entire URL string if there is no last component") {
 					let dependency = Dependency.git(GitURL("whatisthisurleven"))


### PR DESCRIPTION
#### Description
This removes percent escaped characters when trying to determine a dependency name from a git URL.

#### Motivation
Since the dependency name for a git URL was derived from the last path component it could potentially contain URL percent escaped characters, since the dependency name is used throughout the build processes those special characters show up in a few places. Specifically there was a problem with `xcodebuild`'s `-derivedDataPath` when the path contained a percent sign.

I considered just sanitizing the derived data path but decided to clean up the dependency name the best I could so that those characters don't work their way into the build system later on. Plus it makes the console output look better 😄 