### PR TITLE
[CI] Use Xcode 9.4 image alongside Xcode 9.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,37 @@ matrix:
   include:
     - os: osx
       language: objective-c
+      osx_image: xcode9.4
+      script: make test
+      env: JOB=CI_TEST
+    - os: osx
+      language: objective-c
+      osx_image: xcode9.4
+      script:
+        - make swiftpm_test
+      env: JOB=CI_TEST_SWIFTPM
+    - os: osx
+      language: objective-c
+      osx_image: xcode9.4
+      script:
+        - brew uninstall carthage
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install bats
+        - make install
+        - bats IntegrationTests
+      env:
+        - JOB=CI_INTEGRATION_TESTS
+    - os: osx
+      language: objective-c
+      osx_image: xcode9.4
+      script:
+        - brew uninstall carthage
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install bats
+        - make swiftpm_install
+        - bats IntegrationTests
+      env:
+        - JOB=CI_INTEGRATION_TESTS_SWIFTPM
+    - os: osx
+      language: objective-c
       osx_image: xcode9.2
       script: make test
       env: JOB=CI_TEST


### PR DESCRIPTION
<blockquote>

[Homebrew](https://github.com/Homebrew/brew/)’s [bottling process](https://github.com/Homebrew/brew/blob/0c38ceb6f6b0dd6fd2120b5bea8ea979c076d2ab/docs/Bottles.md) for binaries they distribute [has a table matching Xcode versions with each bottle-build-hosting macOS version](
https://github.com/Homebrew/brew/commit/595c23286663009086509d9bdfbfa9b172d43fe5#diff-c170234aefab4dfe656ce6e8fccb4351)

[Currently](https://github.com/Homebrew/brew/commits/master/Library/Homebrew/os/mac/xcode.rb) — based on our requirement of Xcode 9+ — bottles build with Xcode 9.2 and 9.4, so our [`travis.yml` ](https://github.com/Carthage/Carthage/blob/3de4ab8ea7e24a52f0e5e71dbc8311428fd9c899/.travis.yml) should have both those `osx_image`s.

</blockquote>

Fixes #2508.