### PR TITLE
Improve instructions for prebuilding frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,10 @@ Carthage can automatically use prebuilt frameworks, instead of building from scr
 
 To offer prebuilt frameworks for a specific tag, the binaries for _all_ supported platforms should be zipped up together into _one_ archive, and that archive should be attached to a published Release corresponding to that tag. The attachment should include `.framework` in its name (e.g., `ReactiveCocoa.framework.zip`), to indicate to Carthage that it contains binaries.
 
-You can perform the archiving operation above with the `carthage archive` command as follows:
+You can perform the archiving operation using the following command:
 
 ```sh
-carthage build --no-skip-current
-carthage archive YourFrameworkName
+carthage build --archive
 ```
 
 Draft Releases will be automatically ignored, even if they correspond to the desired tag.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,14 @@ Carthage can automatically use prebuilt frameworks, instead of building from scr
 
 To offer prebuilt frameworks for a specific tag, the binaries for _all_ supported platforms should be zipped up together into _one_ archive, and that archive should be attached to a published Release corresponding to that tag. The attachment should include `.framework` in its name (e.g., `ReactiveCocoa.framework.zip`), to indicate to Carthage that it contains binaries.
 
-You can perform the archiving operation using the following command:
+You can perform the archiving operation using:
+
+```sh
+-carthage build --no-skip-current
+-carthage archive YourFrameworkName
+```
+
+or alternatively
 
 ```sh
 carthage build --archive


### PR DESCRIPTION
[0.30.1](https://github.com/Carthage/Carthage/releases/tag/0.30.1) introduces a simpler way of archiving. The command was introduced in https://github.com/Carthage/Carthage/pull/2438 and it works great!

```
carthage build --archive
```