### PR TITLE
Binary dependencies are now downloaded and copied to Carthage/Checkout folder

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -808,8 +808,8 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.flatMap(.concat, unarchive(archive:))
 			.flatMap(.concat) { unarchiveContentsDirectory -> SignalProducer<URL, CarthageError> in
 				let checkoutFolderURL = self.directoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
-				return self.removeItem(at: checkoutFolderURL)
-					.then(SignalProducer(value: unarchiveContentsDirectory))
+				try? FileManager.default.removeItem(at: checkoutFolderURL)
+				return SignalProducer(value: unarchiveContentsDirectory)
 			}
 			.flatMap(.concat) { FileManager.default.reactive.enumerator(at: $0, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants], catchErrors: false).map { _, url in url } }
 			.flatMap(.concat) { itemURL -> SignalProducer<URL, CarthageError> in

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -592,7 +592,10 @@ class ProjectSpec: QuickSpec {
 			_ = zip(paths: [binaryDependencyMockResourceFile.lastPathComponent], into: binaryDependencyMockZip, workingDirectory: projectTestWorkingDirectory.path).wait()
 			
 			//make sure that the binaryDependencyZip file was created
-			XCTAssertTrue(FileManager.default.fileExists(atPath: binaryDependencyMockZip.path))
+			it("should create the binary dependency mock arhive", closure: {
+				
+				expect(FileManager.default.fileExists(atPath: binaryDependencyMockZip.path)).to(beTrue())
+			})
 			
 			//create the binary dependency definition file
 			let binaryDependencyDefinitionName = UUID().uuidString
@@ -653,7 +656,10 @@ class ProjectSpec: QuickSpec {
 			_ = zip(paths: [binaryDependencyMockResourceFile.lastPathComponent], into: binaryDependencyMockZip, workingDirectory: projectTestWorkingDirectory.path).wait()
 			
 			//make sure that the binaryDependencyZip file was created
-			XCTAssertTrue(FileManager.default.fileExists(atPath: binaryDependencyMockZip.path))
+			it("should create the binary dependency mock arhive", closure: {
+				
+				expect(FileManager.default.fileExists(atPath: binaryDependencyMockZip.path)).to(beTrue())
+			})
 			
 			//create the binary dependency definition file
 			let binaryDependencyDefinitionName = UUID().uuidString


### PR DESCRIPTION
Upon `carhage checkout` - binary dependencies are now downloaded and copied to `Carthage/Checkout` folder. 
This also implies to `carthage update --no-build` and `carthage bootstrap --no-build`

The PR is implementation for #2319 
The implementation required that binary dependencies are downloaded prior copying them, so this might be a partial fix for #2449