### PR TITLE
Use `Bundle.executableURL` instead of `object(forInfoDictionaryKey: "CFBundleExecutable")`

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1188,21 +1188,16 @@ private func UUIDsFromDwarfdump(_ url: URL) -> SignalProducer<Set<UUID>, Carthag
 public func binaryURL(_ packageURL: URL) -> Result<URL, CarthageError> {
 	let bundle = Bundle(path: packageURL.path)
 
-	switch bundle?.packageType {
-	case .framework?, .bundle?:
-		if let binaryName = bundle?.object(forInfoDictionaryKey: "CFBundleExecutable") as? String {
-			return .success(packageURL.appendingPathComponent(binaryName))
-		}
+	if let executableURL = bundle?.executableURL {
+		return .success(executableURL)
+	}
 
-	case .dSYM?:
+	if bundle?.packageType == .dSYM {
 		let binaryName = packageURL.deletingPathExtension().deletingPathExtension().lastPathComponent
 		if !binaryName.isEmpty {
 			let binaryURL = packageURL.appendingPathComponent("Contents/Resources/DWARF/\(binaryName)")
 			return .success(binaryURL)
 		}
-
-	default:
-		break
 	}
 
 	return .failure(.readFailed(packageURL, nil))


### PR DESCRIPTION
This would fix #2491 (should work for frameworks who does not contain the `Info.plist` file).