### PR TITLE
[Archive] add xz to the supported pathExtensions for untar

### DIFF
--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -20,7 +20,7 @@ public func zip(paths: [String], into archiveURL: URL, workingDirectory: String)
 /// extension to detect archive type, then sends the file URL to that directory.
 public func unarchive(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
 	switch fileURL.pathExtension {
-	case "gz", "tgz", "bz2":
+	case "gz", "tgz", "bz2", "xz":
 		return untar(archive: fileURL)
 	default:
 		return unzip(archive: fileURL)


### PR DESCRIPTION
our framework is provided as tar.xz. Carthage tries to unzip it, this correctly untars it 