### PR TITLE
Symlink the Build folder for binary downloads

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1050,6 +1050,8 @@ public final class Project { // swiftlint:disable:this type_body_length
 						}
 					}
 					.flatMap(.merge) { dependency, version -> SignalProducer<(Dependency, PinnedVersion), CarthageError> in
+						// Symlink the build folder of binary downloads for consistency with regular checkouts
+						// (even though it's not necessary since binary downloads aren't built by Carthage)
 						return self.symlinkBuildPathIfNeeded(for: dependency, version: version)
 							.then(.init(value: (dependency, version)))
 					}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1108,8 +1108,8 @@ public final class Project { // swiftlint:disable:this type_body_length
 	private func symlinkBuildPathIfNeeded(for dependency: Dependency, version: PinnedVersion) -> SignalProducer<(), CarthageError> {
 		return dependencySet(for: dependency, version: version)
 			.flatMap(.merge) { dependencies -> SignalProducer<(), CarthageError> in
-				// Don't create symlink the build folder if the dependencies doesn't have
-				// any Carthage dependencies.
+				// Don't symlink the build folder if the dependency doesn't have
+				// any Carthage dependencies
 				if dependencies.isEmpty {
 					return .empty
 				}


### PR DESCRIPTION
Carthage creates a symlink to the main Build folder from the Carthage directory of each dependency.  However, these symlinks are created in the process of building each dependency, and as a result they are not created for binary downloads (which are not built by Carthage).  This PR fixes this inconsistency.

I am not sure if this change will be useful for normal Carthage users; however, it would be useful for my team as our project has two workspaces, one of which includes the contents of Carthage/Checkout as sub-projects.  Xcode needs all of the Build folders to be symlinked in order to build the project.

I would appreciate advice as to how this change could be tested.  As far as I can tell there are currently no tests that verify the Build symlinks are created, nor tests that check out a binary framework (although I might not be looking in the right places).