### PR TITLE
Updated documentation of the --no-use-binaries option

### DIFF
--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -22,7 +22,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
-			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "use downloaded binaries when possible")
+			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
 	}
 }
 


### PR DESCRIPTION
The description of the `-no-use-binaries option` doesn't look correct:

```
[--no-use-binaries]
	use downloaded binaries when possible
```

Updated with `don't use downloaded binaries when possible`.