### PR TITLE
Fix bugs with symbolic links

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -999,8 +999,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 					if dependencyCheckoutURLResource?.isSymbolicLink == true {
 						_ = dependencyCheckoutURL.path.withCString(Darwin.unlink)
 					} else if dependencyCheckoutURLResource?.isDirectory == true {
-						// This directory may already exist if Carthage/Checkouts directory is checked into the
-						// dependency repository's source control, for instance when using submodules.
+						// This directory may already exist if Carthage/Checkouts directory is checked into
+						// the dependency repository's source control, for instance when using submodules.
+						// Additionally, older versions of Carthage may have created this directory instead
+						// of symlinking it.
 						continue
 					}
 


### PR DESCRIPTION
After checking out a dependency, Carthage creates a symbolic link for each of its sub-dependencies to the main Carthage Checkouts directory, e.g. from `Carthage/Checkouts/A/Carthage/Checkouts/B` to `../../../../../Carthage/Checkouts/B`.  However, it can become confused when attempting to create these symbolic links if they already exist (from a previous checkout), resulting in an invalid symbolic link that points to a directory outside of the main Carthage directory.

Additionally, Carthage currently does not account for symbolic links in the Checkouts folder (which may be created manually as part of a custom workflow).