### PR TITLE
Strict to execute SwiftLint on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ matrix:
     - os: osx
       language: objective-c
       osx_image: xcode9.4
+      before_script: make lint
       script: make test
       env: JOB=CI_TEST
     - os: osx
       language: objective-c
       osx_image: xcode9.4
+      before_script: make lint
       script:
         - make swiftpm_test
       env: JOB=CI_TEST_SWIFTPM

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ bootstrap:
 test: clean bootstrap
 	xcodebuild $(XCODEFLAGS) -configuration Release ENABLE_TESTABILITY=YES test
 
+lint:
+	swiftlint --strict
+
 clean:
 	$(RM) "$(INTERNAL_PACKAGE)"
 	$(RM) "$(OUTPUT_PACKAGE)"

--- a/Source/CarthageKit/NewResolver.swift
+++ b/Source/CarthageKit/NewResolver.swift
@@ -101,7 +101,7 @@ public struct NewResolver: ResolverProtocol {
 		return self.nodePermutations(for: dependencies, in: baseGraph, withParent: parent)
 			.flatMap { permutations in
 				// Only throw an error if no valid graph was produced by any of the permutations
-				var errResult: Result<DependencyGraph, CarthageError>? = nil
+				var errResult: Result<DependencyGraph, CarthageError>?
 				for nextGraphResult in permutations {
 					// Immediately fail if graph creation fails
 					guard case let .success(nextGraph) = nextGraphResult else { return errResult! }
@@ -361,7 +361,7 @@ private struct NodePermutations: Sequence, IteratorProtocol {
 	/// Generates the next valid graph, skipping over invalid permutations
 	/// Returns an error if any graph generation results in an error
 	private mutating func nextValidGraph() -> Result<DependencyGraph, CarthageError>? {
-		var result: Result<DependencyGraph, CarthageError>? = nil
+		var result: Result<DependencyGraph, CarthageError>?
 		// Skip any invalid permutations
 		while hasNext && result == nil {
 			result = generateGraph()

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -380,7 +380,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 		tryCheckoutDirectory: Bool
 	) -> SignalProducer<CompatibilityInfo.Requirements, CarthageError> {
 		return SignalProducer(resolvedCartfile.dependencies)
-			.flatMap(.concurrent(limit: 4)) { (dependency, pinnedVersion) -> SignalProducer<(Dependency, (Dependency, VersionSpecifier)), CarthageError> in
+			.flatMap(.concurrent(limit: 4)) { dependency, pinnedVersion -> SignalProducer<(Dependency, (Dependency, VersionSpecifier)), CarthageError> in
 				return self.dependencies(for: dependency, version: pinnedVersion, tryCheckoutDirectory: tryCheckoutDirectory)
 					.map { (dependency, $0) }
 			}

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -219,7 +219,7 @@ extension Scanner {
 	fileprivate func scanStringWithPrefix(_ prefix: Character, until: String) -> String? {
 		guard !self.isAtEnd, self.remainingSubstring?.first == prefix else { return nil }
 
-		var buffer: NSString? = nil
+		var buffer: NSString?
 		self.scanUpTo(until, into: &buffer)
 		guard let stringWithPrefix = buffer as String?, stringWithPrefix.first == prefix else {
 			return nil

--- a/Source/CarthageKit/XCDBLDExtensions.swift
+++ b/Source/CarthageKit/XCDBLDExtensions.swift
@@ -41,9 +41,9 @@ extension ProjectLocator {
 			}
 			.filterMap { url -> ProjectLocator? in
 				if let uti = url.typeIdentifier.value {
-					if (UTTypeConformsTo(uti as CFString, "com.apple.dt.document.workspace" as CFString)) {
+					if UTTypeConformsTo(uti as CFString, "com.apple.dt.document.workspace" as CFString) {
 						return .workspace(url)
-					} else if (UTTypeConformsTo(uti as CFString, "com.apple.xcode.project" as CFString)) {
+					} else if UTTypeConformsTo(uti as CFString, "com.apple.xcode.project" as CFString) {
 						return .projectFile(url)
 					}
 				}


### PR DESCRIPTION
# Context

SwiftLint is already introduced. However no linters are executed on CI.
Currently, some codes raise warnings.

# Description

I added `make lint` task and execute on each CI jobs.