### PR TITLE
Add support for forcing legacy build system.

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -14,6 +14,8 @@ public struct BuildOptions {
 	public var cacheBuilds: Bool
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
+	/// The build system to use for build
+	public var buildSystemType: BuildArguments.BuildSystemType
 
 	public init(
 		configuration: String,
@@ -21,7 +23,8 @@ public struct BuildOptions {
 		toolchain: String? = nil,
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
-		useBinaries: Bool = true
+		useBinaries: Bool = true,
+		buildSystemType: BuildArguments.BuildSystemType = .defaultForProject
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -29,5 +32,6 @@ public struct BuildOptions {
 		self.derivedDataPath = derivedDataPath
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
+		self.buildSystemType = buildSystemType
 	}
 }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -461,7 +461,8 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 		scheme: scheme,
 		configuration: options.configuration,
 		derivedDataPath: options.derivedDataPath,
-		toolchain: options.toolchain
+		toolchain: options.toolchain,
+		buildSystemType: options.buildSystemType
 	)
 
 	return BuildSettings.SDKsForScheme(scheme, inProject: project)

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -25,6 +25,18 @@ public struct BuildArguments {
 		case bitcode = "bitcode"
 	}
 
+	/// Represents a project setting used to decide which build system will be used.
+	public enum BuildSystemType {
+		/// Use the value from the project/workspace.
+		case defaultForProject
+
+		/// Force new build system introduced in Xcode 9
+		case new
+
+		/// Force legacy build system deprecated in Xcode 10
+		case legacy
+	}
+
 	/// The project to build.
 	public let project: ProjectLocator
 
@@ -56,13 +68,17 @@ public struct BuildArguments {
 	/// The build setting whether full bitcode should be embedded in the binary.
 	public var bitcodeGenerationMode: BitcodeGenerationMode?
 
+	/// The build setting whether to use the new, legacy or project's default build system.
+	public var buildSystemType: BuildSystemType?
+
 	public init(
 		project: ProjectLocator,
 		scheme: Scheme? = nil,
 		configuration: String? = nil,
 		derivedDataPath: String? = nil,
 		sdk: SDK? = nil,
-		toolchain: String? = nil
+		toolchain: String? = nil,
+		buildSystemType: BuildSystemType = .defaultForProject
 	) {
 		self.project = project
 		self.scheme = scheme
@@ -70,6 +86,7 @@ public struct BuildArguments {
 		self.derivedDataPath = derivedDataPath
 		self.sdk = sdk
 		self.toolchain = toolchain
+		self.buildSystemType = buildSystemType
 	}
 
 	/// The `xcodebuild` invocation corresponding to the receiver.
@@ -121,6 +138,17 @@ public struct BuildArguments {
 
 		if let destinationTimeout = destinationTimeout {
 			args += [ "-destination-timeout", String(destinationTimeout) ]
+		}
+
+		if let buildSystemType = buildSystemType {
+			switch buildSystemType {
+			case .new:
+				args += [ "-UseNewBuildSystem=YES"]
+			case .legacy:
+				args += [ "-UseNewBuildSystem=NO"]
+			case .defaultForProject:
+				break
+			}
 		}
 
 		if let onlyActiveArchitecture = onlyActiveArchitecture {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -23,6 +23,9 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
+			<*> mode <| Option<BuildArguments.BuildSystemType>(key: "forced-build-system",
+															   defaultValue: .defaultForProject,
+															   usage: "force specific build system version (either 'new' or 'legacy')")
 	}
 }
 
@@ -337,5 +340,18 @@ extension BuildPlatform: ArgumentProtocol {
 			}
 			return .multiple(buildPlatforms)
 		}
+	}
+}
+
+extension BuildArguments.BuildSystemType: ArgumentProtocol {
+	public static let name = "forced-build-system"
+
+	private static let acceptedString: [String: BuildArguments.BuildSystemType] = [
+		"new": .new,
+		"legacy": .legacy,
+	]
+
+	public static func from(string: String) -> BuildArguments.BuildSystemType? {
+		return acceptedString.first { $0.key == string }?.value
 	}
 }


### PR DESCRIPTION
# Context:

Xcode 10 uses the new build system by default but some projects still have not updated to it or are affected by bugs and won't compile without switching to legacy build system. (i.e. http://www.openradar.me/radar?id=4928568907792384) 

# Description:

This PR adds a new argument to the `build` action, allowing the user to force the use of either new or legacy build system. Without this argument specified, `carthage` will default to using whatever has been specified in the project/workspace file.