### PR TITLE
Fix the issue can't find available simulators on Xcode 10.1 beta

### DIFF
--- a/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101.json
+++ b/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101.json
@@ -1,0 +1,46 @@
+{
+  "devices" : {
+    "iOS 12.0" : [
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 5s",
+        "udid" : "A52BF797-F6F8-47F1-B559-68B66B553B23"
+      },
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 6",
+        "udid" : "ABDA7BC1-DB72-4332-90C2-C3D9AA8A5003"
+      },
+    ],
+    "watchOS 4.2" : [
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "Apple Watch - 38mm",
+        "udid" : "290C3D57-0FF0-407F-B33C-F1A55EA44019"
+      },
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "Apple Watch - 42mm",
+        "udid" : "6F499604-363C-4AC8-B5D4-73742CA4D674"
+      },
+    ],
+    "iOS 8.4" : [
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 4s",
+        "udid" : "F6E70576-0167-448C-AE00-4AC624552796"
+      },
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 5",
+        "udid" : "CF663E57-B922-4911-A118-C62497C77739"
+      },
+    ],
+  }
+}

--- a/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101.json
+++ b/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101.json
@@ -9,7 +9,7 @@
       },
       {
         "state" : "Shutdown",
-        "isAvailable" : "YES",
+        "isAvailable" : "NO",
         "name" : "iPhone 6",
         "udid" : "ABDA7BC1-DB72-4332-90C2-C3D9AA8A5003"
       },

--- a/Tests/CarthageKitTests/Resources/Simulators/availables.json
+++ b/Tests/CarthageKitTests/Resources/Simulators/availables.json
@@ -9,7 +9,7 @@
       },
       {
         "state" : "Shutdown",
-        "availability" : "(available)",
+        "availability" : "(unavailable, device type not supported by runtime)",
         "name" : "iPhone 6",
         "udid" : "ABDA7BC1-DB72-4332-90C2-C3D9AA8A5003"
       },

--- a/Tests/CarthageKitTests/SimulatorSpec.swift
+++ b/Tests/CarthageKitTests/SimulatorSpec.swift
@@ -26,6 +26,9 @@ class SimulatorSpec: QuickSpec {
 					expect(simulator.udid).to(equal(UUID(uuidString: "A52BF797-F6F8-47F1-B559-68B66B553B23")!))
 					expect(simulator.isAvailable).to(beTrue())
 					expect(simulator.name).to(equal("iPhone 5s"))
+					
+					let unavailableSimulator = simulators.last!
+					expect(unavailableSimulator.isAvailable).to(beFalse())
 				}
 			}
 			
@@ -42,6 +45,9 @@ class SimulatorSpec: QuickSpec {
 					expect(simulator.udid).to(equal(UUID(uuidString: "A52BF797-F6F8-47F1-B559-68B66B553B23")!))
 					expect(simulator.isAvailable).to(beTrue())
 					expect(simulator.name).to(equal("iPhone 5s"))
+					
+					let unavailableSimulator = simulators.last!
+					expect(unavailableSimulator.isAvailable).to(beFalse())
 				}
 			}
 		}

--- a/Tests/CarthageKitTests/SimulatorSpec.swift
+++ b/Tests/CarthageKitTests/SimulatorSpec.swift
@@ -11,20 +11,38 @@ class SimulatorSpec: QuickSpec {
 			let url = Bundle(for: type(of: self)).url(forResource: resource, withExtension: "json")!
 			return try! Data(contentsOf: url)
 		}
-
+		
 		describe("Simulator") {
-			it("should be parsed") {
-				let decoder = JSONDecoder()
-				let data = loadJSON(for: "Simulators/availables")
-				let dictionary = try! decoder.decode([String: [String: [Simulator]]].self, from: data)
-				let devices = dictionary["devices"]!
-
-				let simulators = devices["iOS 12.0"]!
-				expect(simulators.count).to(equal(2))
-				let simulator = simulators.first!
-				expect(simulator.udid).to(equal(UUID(uuidString: "A52BF797-F6F8-47F1-B559-68B66B553B23")!))
-				expect(simulator.isAvailable).to(beTrue())
-				expect(simulator.name).to(equal("iPhone 5s"))
+			context("Xcode 10.0 or lower") {
+				it("should be parsed") {
+					let decoder = JSONDecoder()
+					let data = loadJSON(for: "Simulators/availables")
+					let dictionary = try! decoder.decode([String: [String: [Simulator]]].self, from: data)
+					let devices = dictionary["devices"]!
+					
+					let simulators = devices["iOS 12.0"]!
+					expect(simulators.count).to(equal(2))
+					let simulator = simulators.first!
+					expect(simulator.udid).to(equal(UUID(uuidString: "A52BF797-F6F8-47F1-B559-68B66B553B23")!))
+					expect(simulator.isAvailable).to(beTrue())
+					expect(simulator.name).to(equal("iPhone 5s"))
+				}
+			}
+			
+			context("Xcode 10.1 or above") {
+				it("should be parsed") {
+					let decoder = JSONDecoder()
+					let data = loadJSON(for: "Simulators/availables-xcode101")
+					let dictionary = try! decoder.decode([String: [String: [Simulator]]].self, from: data)
+					let devices = dictionary["devices"]!
+					
+					let simulators = devices["iOS 12.0"]!
+					expect(simulators.count).to(equal(2))
+					let simulator = simulators.first!
+					expect(simulator.udid).to(equal(UUID(uuidString: "A52BF797-F6F8-47F1-B559-68B66B553B23")!))
+					expect(simulator.isAvailable).to(beTrue())
+					expect(simulator.name).to(equal("iPhone 5s"))
+				}
 			}
 		}
 		


### PR DESCRIPTION
closes #2602 

[carthage build command complains about "Could not find any available simulators for iOS" · Issue #2602 · Carthage/Carthage](https://github.com/Carthage/Carthage/issues/2602)

## Context

Since Xcode 10.1 beta, Structures of `xcrun simctl list devices --json` is changed.

### Before

```json
{
  "devices" : {
    "iOS 12.0" : [
      {
        "state" : "Shutdown",
        "availability" : "(available)",
        "name" : "iPhone 5s",
        "udid" : "A52BF797-F6F8-47F1-B559-68B66B553B23"
      }
  ]
}
```

### After

```json
{
  "devices" : {
    "iOS 12.0" : [
      {
        "state" : "Shutdown",
        "isAvailable" : "YES",
        "name" : "iPhone 5s",
        "udid" : "A52BF797-F6F8-47F1-B559-68B66B553B23"
      }
  ]
}
```

Because of this changes, parsing on Xcode 10.1 is failed.

## Description

I extended the parsers to be possible parsing results of `simctl` on Xcode 10.1.
It will work on any Xcode versions.

