### PR TITLE
Fix an ls-tree issue

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -269,16 +269,18 @@ private func parseConfigEntries(_ contents: String, keyPrefix: String = "", keyS
 	}
 }
 
-/// Git’s representation of file system objects at a path relative to the repository root.
+/// Lists the contents of a git tree object at a given path relative to the repository root.
+/// It can be used in a bare repository.
 ///
-/// - parameter path: Path separators at the end of `path` have significance of outputting directory contents.
-///                   Thankfully, multiple contiguous path separators seem to have no adverse effects.
 /// - note: Previously, `path` was recursed through — now, just iterated.
 internal func list(treeish: String, atPath path: String, inRepository repositoryURL: URL) -> SignalProducer<String, CarthageError> {
+	// git ls-tree treats "dir/" and "dir" differently. We make sure the path has an ending slash here.
+	// Thankfully, multiple successive slashes are considered to be the same as one slash.
+	let directoryPath = path.appending("/")
 	return launchGitTask(
 			// `ls-tree`, because `ls-files` returns no output (for all instances I’ve seen) on bare repos.
 			// flag “-z” enables output separated by the nul character (`\0`).
-			[ "ls-tree", "-z", "--full-name", "--name-only", treeish, path ],
+			[ "ls-tree", "-z", "--full-name", "--name-only", treeish, directoryPath ],
 			repositoryFileURL: repositoryURL
 		)
 		.flatMap(.merge) { (output: String) -> SignalProducer<String, CarthageError> in


### PR DESCRIPTION
The `list(treeish:atPath:inRepository:)` function was not working as expected. But this hasn't caused any actual problem since there is a further check (the `continue` statement in the `symlinkCheckoutPaths` method) afterward.