### PR TITLE
Fall back to get swiftlang & clang version from dSYM 

### DIFF
--- a/Source/CarthageKit/SwiftVersionError.swift
+++ b/Source/CarthageKit/SwiftVersionError.swift
@@ -5,10 +5,11 @@ internal enum SwiftVersionError: Error {
 	case unknownLocalSwiftVersion
 
 	/// An error in determining the framework Swift version
-	case unknownFrameworkSwiftVersion
+	case unknownFrameworkSwiftVersion(message: String)
 
 	/// The framework binary is not compatible with the local Swift version.
 	case incompatibleFrameworkSwiftVersions(local: String, framework: String)
+
 }
 
 extension SwiftVersionError: CustomStringConvertible {
@@ -17,8 +18,8 @@ extension SwiftVersionError: CustomStringConvertible {
 		case .unknownLocalSwiftVersion:
 			return "Unable to determine local Swift version."
 
-		case .unknownFrameworkSwiftVersion:
-			return "Unable to determine framework Swift version."
+		case let .unknownFrameworkSwiftVersion(message):
+			return "Unable to determine framework Swift version: \(message)"
 
 		case let .incompatibleFrameworkSwiftVersions(local, framework):
 			return "Incompatible Swift version - framework was built with \(framework) and the local version is \(local)."
@@ -32,8 +33,8 @@ extension SwiftVersionError: Equatable {
 		case (.unknownLocalSwiftVersion, .unknownLocalSwiftVersion):
 			return true
 
-		case (.unknownFrameworkSwiftVersion, .unknownFrameworkSwiftVersion):
-			return true
+		case let (.unknownFrameworkSwiftVersion(lhsMessage), .unknownFrameworkSwiftVersion(rhsMessage)):
+			return lhsMessage == rhsMessage
 
 		case let (.incompatibleFrameworkSwiftVersions(la, lb), .incompatibleFrameworkSwiftVersions(ra, rb)):
 			return la == ra && lb == rb

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -148,6 +148,7 @@ struct VersionFile: Codable {
 					return SignalProducer(value: true)
 				} else {
 					return frameworkSwiftVersion(frameworkURL)
+						.flatMapError { _ in dSYMSwiftVersion(frameworkURL.appendingPathExtension("dSYM")) }
 						.map { swiftVersion -> Bool in
 							return swiftVersion == localSwiftVersion
 						}

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -58,6 +58,15 @@ class XcodeSpec: QuickSpec {
 				expect(FileManager.default.fileExists(atPath: testSwiftFrameworkURL.path)) == true
 				expect(result?.value) == currentSwiftVersion
 			}
+
+			it("should determine a dSYM's Swift version") {
+
+				let dSYMURL = testSwiftFrameworkURL.appendingPathExtension("dSYM")
+				expect(FileManager.default.fileExists(atPath: dSYMURL.path)) == true
+
+				let result = dSYMSwiftVersion(dSYMURL).single()
+				expect(result?.value) == currentSwiftVersion
+			}
 			#endif
 
 			it("should determine a framework's Swift version excluding an effective version") {


### PR DESCRIPTION
See https://github.com/Carthage/Carthage/issues/2619 for reference.

This PR only implement the first fallback.