### PR TITLE
Fix a warning of "String interpolation produces a debug description f…

### DIFF
--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -458,7 +458,7 @@ internal func beFramework(ofType: FrameworkType) -> Predicate<String> {
 		}
 
 		if !resultBool {
-			message += ", got \(stringOutput)"
+			message += ", got \(stringOutput!)"
 		}
 
 		return PredicateResult(


### PR DESCRIPTION
…or an optional value; did you mean to make this explicit?" on Swift 4.2 (Xcode 10)