### PR TITLE
Fix Xcode 10.1 available simulators

### DIFF
--- a/Source/CarthageKit/Simulator.swift
+++ b/Source/CarthageKit/Simulator.swift
@@ -18,8 +18,14 @@ internal struct Simulator: Decodable {
 		// Since Xcode 10.1, `availability` field is obsolated.
 		// Using `isAvailable` instead. its value is possible to be `YES` or `NO`.
 		let availability = try container.decodeIfPresent(String.self, forKey: .availability)
-		let isAvailable = try container.decodeIfPresent(String.self, forKey: .isAvailable)
-		self.isAvailable = isAvailable == "YES" || availability == "(available)"
+		
+		do {
+			let isAvailable = try container.decodeIfPresent(String.self, forKey: .isAvailable)
+			self.isAvailable = isAvailable == "YES" || availability == "(available)"
+		} catch {
+			// Xcode 10.1 uses key `isAvailable` with bool value so try to keep it backward compatible
+			self.isAvailable = try container.decode(Bool.self, forKey: .isAvailable)
+		}
 	}
 
 	var isAvailable: Bool

--- a/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101-beta.json
+++ b/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101-beta.json
@@ -1,0 +1,46 @@
+{
+  "devices" : {
+    "iOS 12.0" : [
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 5s",
+        "udid" : "A52BF797-F6F8-47F1-B559-68B66B553B23"
+      },
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "NO",
+        "name" : "iPhone 6",
+        "udid" : "ABDA7BC1-DB72-4332-90C2-C3D9AA8A5003"
+      },
+    ],
+    "watchOS 4.2" : [
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "Apple Watch - 38mm",
+        "udid" : "290C3D57-0FF0-407F-B33C-F1A55EA44019"
+      },
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "Apple Watch - 42mm",
+        "udid" : "6F499604-363C-4AC8-B5D4-73742CA4D674"
+      },
+    ],
+    "iOS 8.4" : [
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 4s",
+        "udid" : "F6E70576-0167-448C-AE00-4AC624552796"
+      },
+      {
+        "state" : "Shutdown",
+        "isAvailable" : "YES",
+        "name" : "iPhone 5",
+        "udid" : "CF663E57-B922-4911-A118-C62497C77739"
+      },
+    ],
+  }
+}

--- a/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101.json
+++ b/Tests/CarthageKitTests/Resources/Simulators/availables-xcode101.json
@@ -1,46 +1,46 @@
 {
-  "devices" : {
-    "iOS 12.0" : [
-      {
-        "state" : "Shutdown",
-        "isAvailable" : "YES",
-        "name" : "iPhone 5s",
-        "udid" : "A52BF797-F6F8-47F1-B559-68B66B553B23"
-      },
-      {
-        "state" : "Shutdown",
-        "isAvailable" : "NO",
-        "name" : "iPhone 6",
-        "udid" : "ABDA7BC1-DB72-4332-90C2-C3D9AA8A5003"
-      },
-    ],
-    "watchOS 4.2" : [
-      {
-        "state" : "Shutdown",
-        "isAvailable" : "YES",
-        "name" : "Apple Watch - 38mm",
-        "udid" : "290C3D57-0FF0-407F-B33C-F1A55EA44019"
-      },
-      {
-        "state" : "Shutdown",
-        "isAvailable" : "YES",
-        "name" : "Apple Watch - 42mm",
-        "udid" : "6F499604-363C-4AC8-B5D4-73742CA4D674"
-      },
-    ],
-    "iOS 8.4" : [
-      {
-        "state" : "Shutdown",
-        "isAvailable" : "YES",
-        "name" : "iPhone 4s",
-        "udid" : "F6E70576-0167-448C-AE00-4AC624552796"
-      },
-      {
-        "state" : "Shutdown",
-        "isAvailable" : "YES",
-        "name" : "iPhone 5",
-        "udid" : "CF663E57-B922-4911-A118-C62497C77739"
-      },
-    ],
-  }
+    "devices" : {
+        "iOS 12.0" : [
+            {
+                "state" : "Shutdown",
+                "isAvailable" : true,
+                "name" : "iPhone 5s",
+                "udid" : "A52BF797-F6F8-47F1-B559-68B66B553B23"
+            },
+            {
+                "state" : "Shutdown",
+                "isAvailable" : false,
+                "name" : "iPhone 6",
+                "udid" : "ABDA7BC1-DB72-4332-90C2-C3D9AA8A5003"
+            },
+        ],
+        "watchOS 4.2" : [
+            {
+                "state" : "Shutdown",
+                "isAvailable" : true,
+                "name" : "Apple Watch - 38mm",
+                "udid" : "290C3D57-0FF0-407F-B33C-F1A55EA44019"
+            },
+            {
+                "state" : "Shutdown",
+                "isAvailable" : false,
+                "name" : "Apple Watch - 42mm",
+                "udid" : "6F499604-363C-4AC8-B5D4-73742CA4D674"
+            },
+        ],
+        "iOS 8.4" : [
+            {
+                "state" : "Shutdown",
+                "isAvailable" : true,
+                "name" : "iPhone 4s",
+                "udid" : "F6E70576-0167-448C-AE00-4AC624552796"
+            },
+            {
+                "state" : "Shutdown",
+                "isAvailable" : false,
+                "name" : "iPhone 5",
+                "udid" : "CF663E57-B922-4911-A118-C62497C77739"
+            },
+        ],
+    }
 }

--- a/Tests/CarthageKitTests/SimulatorSpec.swift
+++ b/Tests/CarthageKitTests/SimulatorSpec.swift
@@ -32,6 +32,25 @@ class SimulatorSpec: QuickSpec {
 				}
 			}
 			
+			context("Xcode 10.1 beta") {
+				it("should be parsed") {
+					let decoder = JSONDecoder()
+					let data = loadJSON(for: "Simulators/availables-xcode101-beta")
+					let dictionary = try! decoder.decode([String: [String: [Simulator]]].self, from: data)
+					let devices = dictionary["devices"]!
+					
+					let simulators = devices["iOS 12.0"]!
+					expect(simulators.count).to(equal(2))
+					let simulator = simulators.first!
+					expect(simulator.udid).to(equal(UUID(uuidString: "A52BF797-F6F8-47F1-B559-68B66B553B23")!))
+					expect(simulator.isAvailable).to(beTrue())
+					expect(simulator.name).to(equal("iPhone 5s"))
+					
+					let unavailableSimulator = simulators.last!
+					expect(unavailableSimulator.isAvailable).to(beFalse())
+				}
+			}
+			
 			context("Xcode 10.1 or above") {
 				it("should be parsed") {
 					let decoder = JSONDecoder()


### PR DESCRIPTION
Xcode 10.1 release has broken available simulators. Everything ended with the error
```
Could not find any available simulators for iOS
```

The cause was that Apple already knows that `Bool` exists. This is already mentioned in https://github.com/Carthage/Carthage/pull/2606#issuecomment-434440690.

The change is designed to maintain backwards compatibility with the 10.1 beta releases.