### PR TITLE
Sync submodules from the submodule directory

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -493,7 +493,7 @@ public func addSubmoduleToRepository(_ repositoryFileURL: URL, _ submodule: Subm
 							repositoryFileURL: repositoryFileURL
 						)
 					)
-					.then(launchGitTask([ "submodule", "--quiet", "sync", "--recursive" ], repositoryFileURL: repositoryFileURL))
+					.then(launchGitTask([ "submodule", "--quiet", "sync", "--recursive" ], repositoryFileURL: submoduleDirectoryURL))
 					.then(checkoutSubmodule(submodule, submoduleDirectoryURL))
 					.then(launchGitTask([ "add", "--force", submodule.path ], repositoryFileURL: repositoryFileURL))
 					.then(SignalProducer<(), CarthageError>.empty)

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -493,7 +493,7 @@ public func addSubmoduleToRepository(_ repositoryFileURL: URL, _ submodule: Subm
 							repositoryFileURL: repositoryFileURL
 						)
 					)
-					.then(launchGitTask([ "submodule", "--quiet", "sync", "--recursive" ], repositoryFileURL: submoduleDirectoryURL))
+					.then(launchGitTask([ "submodule", "--quiet", "sync", "--recursive", submoduleDirectoryURL.path ], repositoryFileURL: repositoryFileURL))
 					.then(checkoutSubmodule(submodule, submoduleDirectoryURL))
 					.then(launchGitTask([ "add", "--force", submodule.path ], repositoryFileURL: repositoryFileURL))
 					.then(SignalProducer<(), CarthageError>.empty)


### PR DESCRIPTION
Otherwise each submodule syncs all submodules. For projects using submodules with large numbers of dependencies, which may themselves have a large number of submodules, this can save quite a bit of time.

Tested on a project locally:

```
» time carthage checkout --use-submodules    
*** Checking out ReactiveCocoa at "8.0.0"
*** Checking out ReactiveSwift at "4.0.0"
*** Checking out Schemata at "0.2.0"
*** Checking out PersistDB at "ab564f1f91964c5e4f02bd790a454ce950ccb5cb"
*** Checking out Result at "4.0.0"
*** Checking out Differ at "1.3.0"
*** Checking out Anchorage at "4.3"
*** Checking out Standards at "89c30330fcac972a84a4876125064001b9c89f0f"
carthage checkout --use-submodules  2.49s user 2.87s system 99% cpu 5.386 total
» time carthage-dev checkout --use-submodules
*** Checking out Anchorage at "4.3"
*** Checking out ReactiveSwift at "4.0.0"
*** Checking out Standards at "89c30330fcac972a84a4876125064001b9c89f0f"
*** Checking out Result at "4.0.0"
*** Checking out Differ at "1.3.0"
*** Checking out ReactiveCocoa at "8.0.0"
*** Checking out Schemata at "0.2.0"
*** Checking out PersistDB at "ab564f1f91964c5e4f02bd790a454ce950ccb5cb"
carthage-dev checkout --use-submodules  1.76s user 1.79s system 103% cpu 3.420 total
```

(`carthage-dev` includes the changes in this PR, but is the Debug configuration)