### PR TITLE
Clean up model types

### DIFF
--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -37,8 +37,4 @@ public struct BinaryProject {
 	}
 }
 
-extension BinaryProject: Equatable {
-	public static func == (lhs: BinaryProject, rhs: BinaryProject) -> Bool {
-		return lhs.versions == rhs.versions
-	}
-}
+extension BinaryProject: Equatable {}

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -2,7 +2,7 @@ import Foundation
 import Result
 
 /// Represents a binary dependency 
-public struct BinaryProject {
+public struct BinaryProject: Equatable {
 	private static let jsonDecoder = JSONDecoder()
 
 	public var versions: [PinnedVersion: URL]
@@ -36,5 +36,3 @@ public struct BinaryProject {
 			}
 	}
 }
-
-extension BinaryProject: Equatable {}

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -2,7 +2,7 @@ import Foundation
 import Result
 
 /// Identifies a dependency, its pinned version, and its compatible and incompatible requirements
-public struct CompatibilityInfo {
+public struct CompatibilityInfo: Equatable {
 	public typealias Requirements = [Dependency: [Dependency: VersionSpecifier]]
 
 	/// The dependency
@@ -65,5 +65,3 @@ public struct CompatibilityInfo {
 			}
 	}
 }
-
-extension CompatibilityInfo: Equatable {}

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -66,10 +66,4 @@ public struct CompatibilityInfo {
 	}
 }
 
-extension CompatibilityInfo: Equatable {
-	public static func == (_ lhs: CompatibilityInfo, _ rhs: CompatibilityInfo) -> Bool {
-		return lhs.dependency == rhs.dependency &&
-			lhs.pinnedVersion == rhs.pinnedVersion &&
-			lhs.requirements == rhs.requirements
-	}
-}
+extension CompatibilityInfo: Equatable {}

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -21,7 +21,7 @@ public struct BinaryURL: CustomStringConvertible {
 }
 
 /// Uniquely identifies a project that can be used as a dependency.
-public enum Dependency {
+public enum Dependency: Hashable {
 	/// A repository hosted on GitHub.com or GitHub Enterprise.
 	case gitHub(Server, Repository)
 
@@ -87,15 +87,11 @@ extension Dependency {
 	}
 }
 
-extension Dependency: Equatable {}
-
 extension Dependency: Comparable {
 	public static func < (_ lhs: Dependency, _ rhs: Dependency) -> Bool {
 		return lhs.name.caseInsensitiveCompare(rhs.name) == .orderedAscending
 	}
 }
-
-extension Dependency: Hashable {}
 
 extension Dependency: Scannable {
 	/// Attempts to parse a Dependency.

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -87,42 +87,15 @@ extension Dependency {
 	}
 }
 
+extension Dependency: Equatable {}
+
 extension Dependency: Comparable {
-	public static func == (_ lhs: Dependency, _ rhs: Dependency) -> Bool {
-		switch (lhs, rhs) {
-		case let (.gitHub(left), .gitHub(right)):
-			return left == right
-
-		case let (.git(left), .git(right)):
-			return left == right
-
-		case let (.binary(left), .binary(right)):
-			return left == right
-
-		default:
-			return false
-		}
-	}
-
 	public static func < (_ lhs: Dependency, _ rhs: Dependency) -> Bool {
 		return lhs.name.caseInsensitiveCompare(rhs.name) == .orderedAscending
 	}
 }
 
-extension Dependency: Hashable {
-	public var hashValue: Int {
-		switch self {
-		case let .gitHub(server, repo):
-			return server.hashValue ^ repo.hashValue
-
-		case let .git(url):
-			return url.hashValue
-
-		case let .binary(binary):
-			return binary.hashValue
-		}
-	}
-}
+extension Dependency: Hashable {}
 
 extension Dependency: Scannable {
 	/// Attempts to parse a Dependency.

--- a/Source/CarthageKit/DuplicateDependency.swift
+++ b/Source/CarthageKit/DuplicateDependency.swift
@@ -32,11 +32,9 @@ extension DuplicateDependency: CustomStringConvertible {
 	}
 }
 
-extension DuplicateDependency: Comparable {
-	public static func == (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {
-		return lhs.dependency == rhs.dependency && lhs.locations == rhs.locations
-	}
+extension DuplicateDependency: Equatable {}
 
+extension DuplicateDependency: Comparable {
 	public static func < (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {
 		if lhs.description < rhs.description {
 			return true

--- a/Source/CarthageKit/DuplicateDependency.swift
+++ b/Source/CarthageKit/DuplicateDependency.swift
@@ -1,5 +1,5 @@
 /// A duplicate dependency, used in CarthageError.duplicateDependencies.
-public struct DuplicateDependency {
+public struct DuplicateDependency: Equatable {
 	/// The duplicate dependency
 	public let dependency: Dependency
 
@@ -31,8 +31,6 @@ extension DuplicateDependency: CustomStringConvertible {
 			+ ")"
 	}
 }
-
-extension DuplicateDependency: Equatable {}
 
 extension DuplicateDependency: Comparable {
 	public static func < (_ lhs: DuplicateDependency, _ rhs: DuplicateDependency) -> Bool {

--- a/Source/CarthageKit/ScannableError.swift
+++ b/Source/CarthageKit/ScannableError.swift
@@ -15,8 +15,4 @@ extension ScannableError: CustomStringConvertible {
 	}
 }
 
-extension ScannableError: Equatable {
-	public static func == (lhs: ScannableError, rhs: ScannableError) -> Bool {
-		return lhs.description == rhs.description && lhs.currentLine == rhs.currentLine
-	}
-}
+extension ScannableError: Equatable {}

--- a/Source/CarthageKit/ScannableError.swift
+++ b/Source/CarthageKit/ScannableError.swift
@@ -1,5 +1,5 @@
 /// Error parsing strings into types, used in Scannable protocol
-public struct ScannableError: Error {
+public struct ScannableError: Error, Equatable {
 	let message: String
 	let currentLine: String?
 
@@ -14,5 +14,3 @@ extension ScannableError: CustomStringConvertible {
 		return currentLine.map { "\(message) in line: \($0)" } ?? message
 	}
 }
-
-extension ScannableError: Equatable {}

--- a/Source/CarthageKit/Submodule.swift
+++ b/Source/CarthageKit/Submodule.swift
@@ -1,5 +1,5 @@
 /// A Git submodule.
-public struct Submodule {
+public struct Submodule: Hashable {
 	/// The name of the submodule. Usually (but not always) the same as the
 	/// path.
 	public let name: String
@@ -20,8 +20,6 @@ public struct Submodule {
 		self.sha = sha
 	}
 }
-
-extension Submodule: Hashable {}
 
 extension Submodule: CustomStringConvertible {
 	public var description: String {

--- a/Source/CarthageKit/Submodule.swift
+++ b/Source/CarthageKit/Submodule.swift
@@ -21,15 +21,7 @@ public struct Submodule {
 	}
 }
 
-extension Submodule: Hashable {
-	public static func == (_ lhs: Submodule, _ rhs: Submodule) -> Bool {
-		return lhs.name == rhs.name && lhs.path == rhs.path && lhs.url == rhs.url && lhs.sha == rhs.sha
-	}
-
-	public var hashValue: Int {
-		return name.hashValue
-	}
-}
+extension Submodule: Hashable {}
 
 extension Submodule: CustomStringConvertible {
 	public var description: String {

--- a/Source/CarthageKit/SwiftVersionError.swift
+++ b/Source/CarthageKit/SwiftVersionError.swift
@@ -27,20 +27,4 @@ extension SwiftVersionError: CustomStringConvertible {
 	}
 }
 
-extension SwiftVersionError: Equatable {
-	static func == (lhs: SwiftVersionError, rhs: SwiftVersionError) -> Bool {
-		switch (lhs, rhs) {
-		case (.unknownLocalSwiftVersion, .unknownLocalSwiftVersion):
-			return true
-
-		case let (.unknownFrameworkSwiftVersion(lhsMessage), .unknownFrameworkSwiftVersion(rhsMessage)):
-			return lhsMessage == rhsMessage
-
-		case let (.incompatibleFrameworkSwiftVersions(la, lb), .incompatibleFrameworkSwiftVersions(ra, rb)):
-			return la == ra && lb == rb
-
-		default:
-			return false
-		}
-	}
-}
+extension SwiftVersionError: Equatable {}

--- a/Source/CarthageKit/SwiftVersionError.swift
+++ b/Source/CarthageKit/SwiftVersionError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal enum SwiftVersionError: Error {
+internal enum SwiftVersionError: Error, Equatable {
 	/// An error in determining the local Swift version
 	case unknownLocalSwiftVersion
 
@@ -26,5 +26,3 @@ extension SwiftVersionError: CustomStringConvertible {
 		}
 	}
 }
-
-extension SwiftVersionError: Equatable {}

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -243,6 +243,8 @@ extension Scanner {
 	}
 }
 
+extension SemanticVersion: Equatable {}
+
 extension SemanticVersion: Comparable {
 	public static func < (_ lhs: SemanticVersion, _ rhs: SemanticVersion) -> Bool {
 		if lhs.components == rhs.components {
@@ -250,19 +252,9 @@ extension SemanticVersion: Comparable {
 		}
 		return lhs.components.lexicographicallyPrecedes(rhs.components)
 	}
-
-	public static func == (_ lhs: SemanticVersion, _ rhs: SemanticVersion) -> Bool {
-		return lhs.components == rhs.components
-			&& lhs.preRelease == rhs.preRelease
-			&& lhs.buildMetadata == rhs.buildMetadata
-	}
 }
 
-extension SemanticVersion: Hashable {
-	public var hashValue: Int {
-		return components.reduce(0) { $0 ^ $1.hashValue }
-	}
-}
+extension SemanticVersion: Hashable {}
 
 extension SemanticVersion: CustomStringConvertible {
 	public var description: String {
@@ -372,14 +364,6 @@ public struct PinnedVersion: Hashable {
 	public init(_ commitish: String) {
 		self.commitish = commitish
 	}
-
-	public var hashValue: Int {
-		return commitish.hashValue
-	}
-
-	public static func == (_ lhs: PinnedVersion, _ rhs: PinnedVersion) -> Bool {
-		return lhs.commitish == rhs.commitish
-	}
 }
 
 extension PinnedVersion: Scannable {
@@ -470,47 +454,6 @@ public enum VersionSpecifier: Hashable {
 
 				return version.major == requirement.major && versionIsNewer
 			}
-		}
-	}
-
-	public var hashValue: Int {
-		switch self {
-		case .any:
-			return 0
-
-		case let .atLeast(version):
-			return 1 + version.hashValue
-
-		case let .compatibleWith(version):
-			return 2 + version.hashValue
-
-		case let .exactly(version):
-			return 3 + version.hashValue
-
-		case let .gitReference(commitish):
-			return commitish.hashValue
-		}
-	}
-
-	public static func == (_ lhs: VersionSpecifier, _ rhs: VersionSpecifier) -> Bool {
-		switch (lhs, rhs) {
-		case (.any, .any):
-			return true
-
-		case let (.exactly(left), .exactly(right)):
-			return left == right
-
-		case let (.atLeast(left), .atLeast(right)):
-			return left == right
-
-		case let (.compatibleWith(left), .compatibleWith(right)):
-			return left == right
-
-		case let (.gitReference(left), .gitReference(right)):
-			return left == right
-
-		default:
-			return false
 		}
 	}
 }

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -52,6 +52,12 @@ public struct SemanticVersion: Hashable {
 		self.buildMetadata = buildMetadata
 	}
 
+	public var hashValue: Int {
+		return components.reduce(0) { $0 ^ $1.hashValue }
+	}
+}
+
+extension SemanticVersion {
 	/// Attempts to parse a semantic version from a PinnedVersion.
 	public static func from(_ pinnedVersion: PinnedVersion) -> Result<SemanticVersion, ScannableError> {
 		let scanner = Scanner(string: pinnedVersion.commitish)

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -4,12 +4,9 @@ import Foundation
 import Result
 import ReactiveSwift
 
-/// An abstract type representing a way to specify versions.
-public protocol VersionType: Hashable {}
-
 /// A semantic version.
 /// - Note: See <http://semver.org/>
-public struct SemanticVersion: VersionType {
+public struct SemanticVersion {
 	/// The major version.
 	///
 	/// Increments to this component represent incompatible API changes.
@@ -368,7 +365,7 @@ extension String {
 }
 
 /// An immutable version that a project can be pinned to.
-public struct PinnedVersion: VersionType {
+public struct PinnedVersion: Hashable {
 	/// The commit SHA, or name of the tag, to pin to.
 	public let commitish: String
 
@@ -412,7 +409,7 @@ extension PinnedVersion: CustomStringConvertible {
 
 /// Describes which versions are acceptable for satisfying a dependency
 /// requirement.
-public enum VersionSpecifier: VersionType {
+public enum VersionSpecifier: Hashable {
 	case any
 	case atLeast(SemanticVersion)
 	case compatibleWith(SemanticVersion)

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -6,7 +6,7 @@ import ReactiveSwift
 
 /// A semantic version.
 /// - Note: See <http://semver.org/>
-public struct SemanticVersion {
+public struct SemanticVersion: Hashable {
 	/// The major version.
 	///
 	/// Increments to this component represent incompatible API changes.
@@ -243,8 +243,6 @@ extension Scanner {
 	}
 }
 
-extension SemanticVersion: Equatable {}
-
 extension SemanticVersion: Comparable {
 	public static func < (_ lhs: SemanticVersion, _ rhs: SemanticVersion) -> Bool {
 		if lhs.components == rhs.components {
@@ -253,8 +251,6 @@ extension SemanticVersion: Comparable {
 		return lhs.components.lexicographicallyPrecedes(rhs.components)
 	}
 }
-
-extension SemanticVersion: Hashable {}
 
 extension SemanticVersion: CustomStringConvertible {
 	public var description: String {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -214,7 +214,7 @@ public struct BuildCommand: CommandProtocol {
 }
 
 /// Represents the user's chosen platform to build for.
-public enum BuildPlatform {
+public enum BuildPlatform: Equatable {
 	/// Build for all available platforms.
 	case all
 
@@ -258,8 +258,6 @@ public enum BuildPlatform {
 		}
 	}
 }
-
-extension BuildPlatform: Equatable {}
 
 extension BuildPlatform: CustomStringConvertible {
 	public var description: String {

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -259,20 +259,7 @@ public enum BuildPlatform {
 	}
 }
 
-extension BuildPlatform: Equatable {
-	public static func == (_ lhs: BuildPlatform, _ rhs: BuildPlatform) -> Bool {
-		switch (lhs, rhs) {
-		case let (.multiple(left), .multiple(right)):
-			return left == right
-
-		case (.all, .all), (.iOS, .iOS), (.macOS, .macOS), (.watchOS, .watchOS), (.tvOS, .tvOS):
-			return true
-
-		case _:
-			return false
-		}
-	}
-}
+extension BuildPlatform: Equatable {}
 
 extension BuildPlatform: CustomStringConvertible {
 	public var description: String {


### PR DESCRIPTION
Remove an unused protocol and use synthesized `Equatable`/`Hashable` implementations where possible.