### PR TITLE
Use Version type from SwiftPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,13 @@ matrix:
   include:
     - os: osx
       language: objective-c
-      osx_image: xcode9.4
-      script:
-        - make test
-      env: JOB=CI_TEST_9_4
-    - os: osx
-      language: objective-c
       osx_image: xcode10.1
       script:
         - make test
       env: JOB=CI_TEST_10_1
     - os: osx
       language: objective-c
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       script:
         - brew uninstall carthage
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install bats

--- a/IntegrationTests/update.bats
+++ b/IntegrationTests/update.bats
@@ -4,8 +4,8 @@ setup() {
     cd $BATS_TMPDIR
     rm -rf UpdateTest
     mkdir UpdateTest && cd UpdateTest
-    echo 'github "antitypical/Result" == 3.2.3' > Cartfile
-    echo 'github "Quick/Nimble" == 7.0.1' > Cartfile.private
+    echo 'github "antitypical/Result" == 4.1.0' > Cartfile
+    echo 'github "Quick/Nimble" == 7.3.1' > Cartfile.private
 }
 
 teardown() {

--- a/Package.resolved
+++ b/Package.resolved
@@ -74,6 +74,24 @@
         }
       },
       {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "state": {
+          "branch": "master",
+          "revision": "c7aa6e5ea11b39362159b4edc98bfd5dd6d57cf3",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
+        "state": {
+          "branch": "master",
+          "revision": "618ec189be028484cb942dd1249a396851c7176d",
+          "version": null
+        }
+      },
+      {
         "package": "Tentacle",
         "repositoryURL": "https://github.com/mdiep/Tentacle.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "7c61d8e7e830dd37f7161ce2b894be178532163c",
-          "version": "7.3.0"
+          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
+          "version": "7.3.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "b060679e70d13c3c7dcd124201b5b1b34ce6f340",
-          "version": "1.3.1"
+          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
+          "version": "1.3.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,11 @@ let package = Package(
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "1.3.1"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.0"),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
     ],
     targets: [
         .target(
-            name: "XCDBLD", 
+            name: "XCDBLD",
             dependencies: ["Result", "ReactiveSwift", "ReactiveTask"]
         ),
         .testTarget(
@@ -29,8 +30,8 @@ let package = Package(
             dependencies: ["XCDBLD", "Quick", "Nimble"]
         ),
         .target(
-            name: "CarthageKit", 
-            dependencies: ["XCDBLD", "Tentacle", "Curry"]
+            name: "CarthageKit",
+            dependencies: ["XCDBLD", "Tentacle", "Curry", "SwiftPM-auto"]
         ),
         .testTarget(
             name: "CarthageKitTests",
@@ -38,7 +39,7 @@ let package = Package(
             exclude: ["Resources/FakeOldObjc.framework"]
         ),
         .target(
-            name: "carthage", 
+            name: "carthage",
             dependencies: ["XCDBLD", "CarthageKit", "Commandant", "Curry", "PrettyColors"],
             exclude: ["swift-is-crashy.c"]
         ),

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Result
+import Utility
+
+import struct Foundation.URL
 
 /// Represents a binary dependency 
 public struct BinaryProject: Equatable {
@@ -15,7 +18,7 @@ public struct BinaryProject: Equatable {
 
 				for (key, value) in json {
 					let pinnedVersion: PinnedVersion
-					switch SemanticVersion.from(Scanner(string: key)) {
+					switch Version.from(Scanner(string: key)) {
 					case .success:
 						pinnedVersion = PinnedVersion(key)
 					case let .failure(error):

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,6 +1,8 @@
+import Utility
+
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {
-	public let value: SemanticVersion
+	public let value: Version
 
-	public static let current = CarthageKitVersion(value: SemanticVersion(major: 0, minor: 31, patch: 2))
+	public static let current = CarthageKitVersion(value: Version(0, 31, 2))
 }

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Result
+import Utility
 
 /// Identifies a dependency, its pinned version, and its compatible and incompatible requirements
 public struct CompatibilityInfo: Equatable {
@@ -56,7 +57,7 @@ public struct CompatibilityInfo: Equatable {
 		return CompatibilityInfo.invert(requirements: requirements)
 			.map { invertedRequirements -> [CompatibilityInfo] in
 				return dependencies.compactMap { dependency, version in
-					if case .success = SemanticVersion.from(version), let requirements = invertedRequirements[dependency] {
+					if case .success = Version.from(version), let requirements = invertedRequirements[dependency] {
 						return CompatibilityInfo(dependency: dependency, pinnedVersion: version, requirements: requirements)
 					}
 					return nil

--- a/Source/CarthageKit/NewResolver.swift
+++ b/Source/CarthageKit/NewResolver.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
+import Utility
 
 /// Responsible for resolving acyclic dependency graphs.
 public struct NewResolver: ResolverProtocol {
@@ -474,8 +475,8 @@ private final class DependencyNode {
 
 extension DependencyNode: Comparable {
 	fileprivate static func < (_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
-		let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
-		let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+		let leftSemantic = Version.from(lhs.proposedVersion).value ?? Version(0, 0, 0)
+		let rightSemantic = Version.from(rhs.proposedVersion).value ?? Version(0, 0, 0)
 
 		// Try higher versions first.
 		return leftSemantic > rightSemantic
@@ -484,8 +485,8 @@ extension DependencyNode: Comparable {
 	fileprivate static func == (_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
 		guard lhs.dependency == rhs.dependency else { return false }
 
-		let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
-		let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+		let leftSemantic = Version.from(lhs.proposedVersion).value ?? Version(0, 0, 0)
+		let rightSemantic = Version.from(rhs.proposedVersion).value ?? Version(0, 0, 0)
 		return leftSemantic == rightSemantic
 	}
 }

--- a/Source/CarthageKit/RemoteVersion.swift
+++ b/Source/CarthageKit/RemoteVersion.swift
@@ -3,14 +3,15 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
+import Utility
 
 /// Synchronously returns the semantic version of the newest release,
 /// if the given producer emits it within a reasonable timeframe.
 ///
-public func remoteVersion(_ remoteVersionProducer: SignalProducer<Release, CarthageError>) -> SemanticVersion? {
+public func remoteVersion(_ remoteVersionProducer: SignalProducer<Release, CarthageError>) -> Version? {
 	let latestRemoteVersion = remoteVersionProducer
-		.attemptMap { release -> Result<SemanticVersion, CarthageError> in
-			return SemanticVersion.from(Scanner(string: release.tag)).mapError(CarthageError.init(scannableError:))
+		.attemptMap { release -> Result<Version, CarthageError> in
+			return Version.from(Scanner(string: release.tag)).mapError(CarthageError.init(scannableError:))
 		}
 		// Add timeout on different queue so that `first()` doesn't block timeout scheduling
 		.timeout(after: 0.5, raising: CarthageError.gitHubAPITimeout, on: QueueScheduler(qos: .default))

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
+import Utility
 
 /// Protocol for resolving acyclic dependency graphs.
 public protocol ResolverProtocol {
@@ -505,8 +506,8 @@ private final class DependencyNode {
 
 extension DependencyNode: Comparable {
 	fileprivate static func < (_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
-		let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
-		let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+		let leftSemantic = Version.from(lhs.proposedVersion).value ?? Version(0, 0, 0)
+		let rightSemantic = Version.from(rhs.proposedVersion).value ?? Version(0, 0, 0)
 
 		// Try higher versions first.
 		return leftSemantic > rightSemantic

--- a/Source/CarthageKit/Simulator.swift
+++ b/Source/CarthageKit/Simulator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Utility
 import XCDBLD
 
 internal struct Simulator: Decodable {
@@ -48,8 +49,8 @@ internal func selectAvailableSimulator(of sdk: SDK, from data: Data) -> Simulato
 		.filter { $0.key.hasPrefix(platformName) }
 	func sortedByVersion(_ osNames: [String]) -> [String] {
 		return osNames.sorted { lhs, rhs in
-			guard let lhsVersion = SemanticVersion.from(PinnedVersion(lhs)).value,
-				let rhsVersion = SemanticVersion.from(PinnedVersion(rhs)).value else {
+			guard let lhsVersion = Version.from(PinnedVersion(lhs)).value,
+				let rhsVersion = Version.from(PinnedVersion(rhs)).value else {
 					return lhs < rhs
 			}
 			return lhsVersion < rhsVersion

--- a/Source/carthage/RemoteVersion.swift
+++ b/Source/carthage/RemoteVersion.swift
@@ -4,9 +4,10 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
+import Utility
 
-/// The latest online version as a SemanticVersion object.
-public func remoteVersion() -> SemanticVersion? {
+/// The latest version of Carthage as a `Version`.
+public func remoteVersion() -> Version? {
 	let remoteVersionProducer = Client(.dotCom, urlSession: URLSession.proxiedSession)
 		.execute(Repository(owner: "Carthage", name: "Carthage").releases, perPage: 2)
 		.mapError(CarthageError.gitHubAPIRequestFailed)

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -4,6 +4,9 @@ import Result
 import Tentacle
 import Nimble
 import Quick
+import Utility
+
+import struct Foundation.URL
 
 // swiftlint:disable:this force_try
 
@@ -33,16 +36,16 @@ class CartfileSpec: QuickSpec {
 			let example4 = Dependency.gitHub(.dotCom, Repository(owner: "ExampleOrg", name: "ExamplePrj4"))
 			
 			expect(cartfile.dependencies) == [
-				reactiveCocoa: .atLeast(SemanticVersion(major: 2, minor: 3, patch: 1)),
-				mantle: .compatibleWith(SemanticVersion(major: 1, minor: 0, patch: 0)),
-				libextobjc: .exactly(SemanticVersion(major: 0, minor: 4, patch: 1)),
+				reactiveCocoa: .atLeast(Version(2, 3, 1)),
+				mantle: .compatibleWith(Version(1, 0, 0)),
+				libextobjc: .exactly(Version(0, 4, 1)),
 				xcconfigs: .any,
 				iosCharts: .any,
 				errorTranslations: .any,
 				errorTranslations2: .gitReference("development"),
-				example1: .atLeast(SemanticVersion(major: 3, minor: 0, patch: 2, preRelease: "pre")),
-				example2: .exactly(SemanticVersion(major: 3, minor: 0, patch: 2, preRelease: nil, buildMetadata: "build")),
-				example3: .exactly(SemanticVersion(major: 3, minor: 0, patch: 2)),
+				example1: .atLeast(Version(3, 0, 2, prereleaseIdentifiers: ["pre"])),
+				example2: .exactly(Version(3, 0, 2, buildMetadataIdentifiers: ["build"])),
+				example3: .exactly(Version(3, 0, 2)),
 				example4: .gitReference("release#2")
 			]
 		}

--- a/Tests/CarthageKitTests/DB.swift
+++ b/Tests/CarthageKitTests/DB.swift
@@ -3,6 +3,7 @@ import ReactiveSwift
 import Foundation
 import Result
 import Tentacle
+import Utility
 
 // swiftlint:disable no_extension_access_modifier
 let git1 = Dependency.git(GitURL("https://example.com/repo1"))
@@ -26,14 +27,14 @@ extension PinnedVersion {
 	static let v3_0_0 = PinnedVersion("v3.0.0")
 }
 
-extension SemanticVersion {
-	static let v0_1_0 = SemanticVersion(major: 0, minor: 1, patch: 0)
-	static let v1_0_0 = SemanticVersion(major: 1, minor: 0, patch: 0)
-	static let v1_1_0 = SemanticVersion(major: 1, minor: 1, patch: 0)
-	static let v1_2_0 = SemanticVersion(major: 1, minor: 2, patch: 0)
-	static let v2_0_0 = SemanticVersion(major: 2, minor: 0, patch: 0)
-	static let v2_0_1 = SemanticVersion(major: 2, minor: 0, patch: 1)
-	static let v3_0_0 = SemanticVersion(major: 3, minor: 0, patch: 0)
+extension Version {
+	static let v0_1_0 = Version(0, 1, 0)
+	static let v1_0_0 = Version(1, 0, 0)
+	static let v1_1_0 = Version(1, 1, 0)
+	static let v1_2_0 = Version(1, 2, 0)
+	static let v2_0_0 = Version(2, 0, 0)
+	static let v2_0_1 = Version(2, 0, 1)
+	static let v3_0_0 = Version(3, 0, 0)
 }
 // swiftlint:enable no_extension_access_modifier
 

--- a/Tests/CarthageKitTests/RemoteVersionSpec.swift
+++ b/Tests/CarthageKitTests/RemoteVersionSpec.swift
@@ -3,6 +3,9 @@ import Nimble
 import Quick
 import ReactiveSwift
 import Tentacle
+import Utility
+
+import struct Foundation.URL
 
 @testable import CarthageKit
 
@@ -10,7 +13,7 @@ class RemoteVersionSpec: QuickSpec {
 	override func spec() {
 		describe("remoteVersion") {
 			it("should time out") {
-				var version: SemanticVersion? = SemanticVersion(major: 0, minor: 0, patch: 0)
+				var version: Version? = Version(0, 0, 0)
 				DispatchQueue.main.async {
 					version = remoteVersion(SignalProducer.never)
 				}
@@ -21,7 +24,7 @@ class RemoteVersionSpec: QuickSpec {
 			it("should return version") {
 				let release = Release(id: 0, tag: "0.1.0", url: URL(string: "about:blank")!, assets: [])
 				let producer = SignalProducer<Release, CarthageError>(value: release)
-				expect(remoteVersion(producer)) == SemanticVersion(major: 0, minor: 1, patch: 0)
+				expect(remoteVersion(producer)) == Version(0, 1, 0)
 			}
 		}
 	}

--- a/Tests/CarthageKitTests/ValidateSpec.swift
+++ b/Tests/CarthageKitTests/ValidateSpec.swift
@@ -5,6 +5,9 @@ import Quick
 import ReactiveSwift
 import Result
 import Tentacle
+import Utility
+
+import struct Foundation.URL
 
 private extension CarthageError {
 	var compatibilityInfos: [CompatibilityInfo] {
@@ -47,9 +50,9 @@ class ValidateSpec: QuickSpec {
 
 		// These tuples represent the desired version of a dependency, paired with its parent dependency;
 		// moya_3_1_0 indicates that Moya expects a version compatible with 3.1.0 of *another* dependency
-		let moya_3_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(SemanticVersion(major: 3, minor: 1, patch: 0)))
-		let moya_4_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(SemanticVersion(major: 4, minor: 1, patch: 0)))
-		let reactiveSwift_3_2_1 = (reactiveSwiftDependency, VersionSpecifier.compatibleWith(SemanticVersion(major: 3, minor: 2, patch: 1)))
+		let moya_3_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(Version(3, 1, 0)))
+		let moya_4_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(Version(4, 1, 0)))
+		let reactiveSwift_3_2_1 = (reactiveSwiftDependency, VersionSpecifier.compatibleWith(Version(3, 2, 1)))
 
 		describe("requirementsByDependency") {
 			it("should group dependencies by parent dependency") {
@@ -77,10 +80,10 @@ class ValidateSpec: QuickSpec {
 				let d = Dependency.gitHub(.dotCom, Repository(owner: "d", name: "d"))
 				let e = Dependency.gitHub(.dotCom, Repository(owner: "e", name: "e"))
 
-				let v1 = VersionSpecifier.compatibleWith(SemanticVersion(major: 1, minor: 0, patch: 0))
-				let v2 = VersionSpecifier.compatibleWith(SemanticVersion(major: 2, minor: 0, patch: 0))
-				let v3 = VersionSpecifier.compatibleWith(SemanticVersion(major: 3, minor: 0, patch: 0))
-				let v4 = VersionSpecifier.compatibleWith(SemanticVersion(major: 4, minor: 0, patch: 0))
+				let v1 = VersionSpecifier.compatibleWith(Version(1, 0, 0))
+				let v2 = VersionSpecifier.compatibleWith(Version(2, 0, 0))
+				let v3 = VersionSpecifier.compatibleWith(Version(3, 0, 0))
+				let v4 = VersionSpecifier.compatibleWith(Version(4, 0, 0))
 
 				let requirements = [a: [b: v1, c: v2], d: [c: v3, e: v4]]
 				let invertedRequirements = CompatibilityInfo.invert(requirements: requirements).value!
@@ -93,11 +96,11 @@ class ValidateSpec: QuickSpec {
 		describe("incompatibilities") {
 			it("should identify incompatible dependencies") {
 				let commitish = VersionSpecifier.gitReference("commitish")
-				let v4_0_0 = VersionSpecifier.compatibleWith(SemanticVersion(major: 4, minor: 0, patch: 0))
-				let v2_0_0 = VersionSpecifier.compatibleWith(SemanticVersion(major: 2, minor: 0, patch: 0))
-				let v4_1_0 = VersionSpecifier.compatibleWith(SemanticVersion(major: 4, minor: 1, patch: 0))
-				let v3_1_0 = VersionSpecifier.compatibleWith(SemanticVersion(major: 3, minor: 1, patch: 0))
-				let v3_2_1 = VersionSpecifier.compatibleWith(SemanticVersion(major: 3, minor: 2, patch: 1))
+				let v4_0_0 = VersionSpecifier.compatibleWith(Version(4, 0, 0))
+				let v2_0_0 = VersionSpecifier.compatibleWith(Version(2, 0, 0))
+				let v4_1_0 = VersionSpecifier.compatibleWith(Version(4, 1, 0))
+				let v3_1_0 = VersionSpecifier.compatibleWith(Version(3, 1, 0))
+				let v3_2_1 = VersionSpecifier.compatibleWith(Version(3, 2, 1))
 
 				let dependencies = [rxSwiftDependency: PinnedVersion("4.1.2"),
 									moyaDependency: PinnedVersion("10.0.2"),

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -2,90 +2,42 @@ import CarthageKit
 import Foundation
 import Nimble
 import Quick
+import Utility
 
-class SemanticVersionSpec: QuickSpec {
+class VersionSpec: QuickSpec {
 	override func spec() {
-		it("should order versions correctly") {
-			let version = SemanticVersion(major: 2, minor: 1, patch: 1)
-
-			expect(version) < SemanticVersion(major: 3, minor: 0, patch: 0)
-			expect(version) < SemanticVersion(major: 2, minor: 2, patch: 0)
-			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 2)
-
-			expect(version) > SemanticVersion(major: 1, minor: 2, patch: 2)
-			expect(version) > SemanticVersion(major: 2, minor: 0, patch: 2)
-			expect(version) > SemanticVersion(major: 2, minor: 1, patch: 0)
-
-			expect(version) < SemanticVersion(major: 10, minor: 0, patch: 0)
-			expect(version) < SemanticVersion(major: 2, minor: 10, patch: 1)
-			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 10)
-			
-			expect(version) < SemanticVersion(major: 2, minor: 1, patch: 2, buildMetadata: "b421")
-			expect(version) != SemanticVersion(major: 2, minor: 1, patch: 1, buildMetadata: "b2334")
-			expect(version) > SemanticVersion(major: 2, minor: 1, patch: 0, buildMetadata: "b421")
-		}
-		
-		it("should order pre-release versions correctly") {
-			let version = SemanticVersion(major: 2, minor: 1, patch: 1, preRelease: "alpha8")
-			
-			expect(version) < SemanticVersion(major: version.major, minor: version.minor, patch: version.patch)
-			expect(version) > SemanticVersion(major: version.major, minor: version.minor, patch: version.patch-1)
-			expect(version) == SemanticVersion(major: version.major, minor: version.minor, patch: version.patch, preRelease: version.preRelease)
-			
-			// As specified in http://semver.org/
-			// "Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0"
-			
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) < SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) < SemanticVersion(major: 1, minor: 0, patch: 0)
-			
-			// now test the reverse (to catch error if the < function ALWAYS returns true)
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.1")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha.beta")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.2")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "beta.11")
-			expect(SemanticVersion(major: 1, minor: 0, patch: 0)) > SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "rc.1")
-		}
-
 		it("should parse semantic versions") {
-			expect(SemanticVersion.from(PinnedVersion("1.4")).value) == SemanticVersion(major: 1, minor: 4, patch: 0)
-			expect(SemanticVersion.from(PinnedVersion("v2.8.9")).value) == SemanticVersion(major: 2, minor: 8, patch: 9)
-			expect(SemanticVersion.from(PinnedVersion("2.8.2-alpha")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha")
-			expect(SemanticVersion.from(PinnedVersion("2.8.2-alpha+build234")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha", buildMetadata: "build234")
-			expect(SemanticVersion.from(PinnedVersion("2.8.2+build234")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, buildMetadata: "build234")
-			expect(SemanticVersion.from(PinnedVersion("2.8.2-alpha.2.1.0")).value) == SemanticVersion(major: 2, minor: 8, patch: 2, preRelease: "alpha.2.1.0")
-
+			expect(Version.from(PinnedVersion("1.4")).value) == Version(1, 4, 0)
+			expect(Version.from(PinnedVersion("v2.8.9")).value) == Version(2, 8, 9)
+			expect(Version.from(PinnedVersion("2.8.2-alpha")).value) == Version(2, 8, 2, prereleaseIdentifiers: ["alpha"])
+			expect(Version.from(PinnedVersion("2.8.2-alpha+build234")).value) == Version(2, 8, 2, prereleaseIdentifiers: ["alpha"], buildMetadataIdentifiers: ["build234"])
+			expect(Version.from(PinnedVersion("2.8.2+build234")).value) == Version(2, 8, 2, buildMetadataIdentifiers: ["build234"])
+			expect(Version.from(PinnedVersion("2.8.2-alpha.2.1.0")).value) == Version(2, 8, 2, prereleaseIdentifiers: ["alpha", "2", "1", "0"])
 		}
 
 		it("should fail on invalid semantic versions") {
-			expect(SemanticVersion.from(PinnedVersion("release#2")).value).to(beNil()) // not a valid SemVer
-			expect(SemanticVersion.from(PinnedVersion("v1")).value).to(beNil())
-			expect(SemanticVersion.from(PinnedVersion("v2.8-alpha")).value).to(beNil()) // pre-release should be after patch
-			expect(SemanticVersion.from(PinnedVersion("v2.8+build345")).value).to(beNil()) // build should be after patch
-			expect(SemanticVersion.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
-			expect(SemanticVersion.from(PinnedVersion("1.4.5+")).value).to(beNil()) // missing build metadata after '+'
-			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha+")).value).to(beNil()) // missing build metadata after '+'
-			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha#2")).value).to(beNil()) // non alphanumeric are  not allowed in pre-release
-			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha.2.01.0")).value).to(beNil()) // numeric identifiers in pre-release
+			expect(Version.from(PinnedVersion("release#2")).value).to(beNil()) // not a valid SemVer
+			expect(Version.from(PinnedVersion("v1")).value).to(beNil())
+			expect(Version.from(PinnedVersion("v2.8-alpha")).value).to(beNil()) // pre-release should be after patch
+			expect(Version.from(PinnedVersion("v2.8+build345")).value).to(beNil()) // build should be after patch
+			expect(Version.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
+			expect(Version.from(PinnedVersion("1.4.5+")).value).to(beNil()) // missing build metadata after '+'
+			expect(Version.from(PinnedVersion("1.4.5-alpha+")).value).to(beNil()) // missing build metadata after '+'
+			expect(Version.from(PinnedVersion("1.4.5-alpha#2")).value).to(beNil()) // non alphanumeric are  not allowed in pre-release
+			expect(Version.from(PinnedVersion("1.4.5-alpha.2.01.0")).value).to(beNil()) // numeric identifiers in pre-release
 																								//version must not include leading zeros
-			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha.2..0")).value).to(beNil()) // empty pre-release component
-			expect(SemanticVersion.from(PinnedVersion("1.4.5+build@2")).value).to(beNil()) // non alphanumeric are not allowed in build metadata
-			expect(SemanticVersion.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
-			expect(SemanticVersion.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
-			expect(SemanticVersion.from(PinnedVersion("1.４.5")).value).to(beNil()) // Note that the `４` in this string is
+			expect(Version.from(PinnedVersion("1.4.5-alpha.2..0")).value).to(beNil()) // empty pre-release component
+			expect(Version.from(PinnedVersion("1.4.5+build@2")).value).to(beNil()) // non alphanumeric are not allowed in build metadata
+			expect(Version.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
+			expect(Version.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
+			expect(Version.from(PinnedVersion("1.４.5")).value).to(beNil()) // Note that the `４` in this string is
 																					// a fullwidth character, not a halfwidth `4`
-			expect(SemanticVersion.from(PinnedVersion("1.8.0.1")).value).to(beNil()) // not a valid SemVer, too many dots
-			expect(SemanticVersion.from(PinnedVersion("1.8..1")).value).to(beNil()) // not a valid SemVer, double dots
-			expect(SemanticVersion.from(PinnedVersion("1.8.1.")).value).to(beNil()) // not a valid SemVer, ends with dot
-			expect(SemanticVersion.from(PinnedVersion("1.8.")).value).to(beNil()) // not a valid SemVer, ends with dot
-			expect(SemanticVersion.from(PinnedVersion("1.")).value).to(beNil()) // not a valid SemVer, ends with dot
-			expect(SemanticVersion.from(PinnedVersion("1.8.0.alpha")).value).to(beNil()) // not a valid SemVer, pre-release is dot-separated
+			expect(Version.from(PinnedVersion("1.8.0.1")).value).to(beNil()) // not a valid SemVer, too many dots
+			expect(Version.from(PinnedVersion("1.8..1")).value).to(beNil()) // not a valid SemVer, double dots
+			expect(Version.from(PinnedVersion("1.8.1.")).value).to(beNil()) // not a valid SemVer, ends with dot
+			expect(Version.from(PinnedVersion("1.8.")).value).to(beNil()) // not a valid SemVer, ends with dot
+			expect(Version.from(PinnedVersion("1.")).value).to(beNil()) // not a valid SemVer, ends with dot
+			expect(Version.from(PinnedVersion("1.8.0.alpha")).value).to(beNil()) // not a valid SemVer, pre-release is dot-separated
 
 		}
 	}
@@ -142,7 +94,7 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 
 			it("should allow greater or equal versions for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == true
@@ -151,47 +103,47 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 			
 			it("should allow a non-semantic version for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow for a pre-release of the same non-pre-release version for .atLeast")
 			{
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 			
 			it("should allow for a build version of the same version for .atLeast")
 			{
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
 			}
 			
 			it("should not allow for a build version of a different version for .atLeast")
 			{
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v3_0_0).value!)
+				let specifier = VersionSpecifier.atLeast(Version.from(v3_0_0).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
 			it("should allow for a build version of the same version for .compatibleWith")
 			{
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
 			}
 			
 			it("should not allow for a build version of a different version for .compatibleWith")
 			{
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v1_3_2).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v1_3_2).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
 			it("should not allow for a greater pre-release version for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_0_2).value!)
+				let specifier = VersionSpecifier.atLeast(Version.from(v2_0_2).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 			it("should allow greater or equal minor and patch versions for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == true
@@ -200,18 +152,18 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 			
 			it("should allow a non-semantic version for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow equal minor and patch pre-release version for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 
 			it("should only allow exact versions for .exactly") {
-				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_2_0).value!)
+				let specifier = VersionSpecifier.exactly(Version.from(v2_2_0).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == false
@@ -220,32 +172,32 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 			
 			it("should not allow a build version of a different version for .exactly") {
-				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v1_3_2).value!)
+				let specifier = VersionSpecifier.exactly(Version.from(v1_3_2).value!)
 				expect(specifier.isSatisfied(by: v0_1_0_build123)) == false
 			}
 			
 			it("should not allow a build version of the same version for .exactly") {
-				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.exactly(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
 			it("should allow for a non-semantic version for .exactly") {
-				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.exactly(Version.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow any pre-release versions to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_1_0_pre23)) == false
 			}
 			
 			it("should not allow a pre-release versions of a different version to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_2_0_candidate)) == false
 			}
 
 			it("should allow only greater patch versions to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(Version.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_1_0)) == true
 				expect(specifier.isSatisfied(by: v0_1_1)) == true
 				expect(specifier.isSatisfied(by: v0_2_0)) == false
@@ -253,14 +205,14 @@ class VersionSpecifierSpec: QuickSpec {
 		}
 
 		describe("intersection") {
-			let v0_1_0 = SemanticVersion(major: 0, minor: 1, patch: 0)
-			let v0_1_1 = SemanticVersion(major: 0, minor: 1, patch: 1)
-			let v0_2_0 = SemanticVersion(major: 0, minor: 2, patch: 0)
-			let v1_3_2 = SemanticVersion(major: 1, minor: 3, patch: 2)
-			let v2_1_1 = SemanticVersion(major: 2, minor: 1, patch: 1)
-			let v2_2_0 = SemanticVersion(major: 2, minor: 2, patch: 0)
-			let v2_2_0_b421 = SemanticVersion(major: 2, minor: 2, patch: 0, buildMetadata: "b421")
-			let v2_2_0_alpha = SemanticVersion(major: 2, minor: 2, patch: 0, preRelease: "alpha")
+			let v0_1_0 = Version(0, 1, 0)
+			let v0_1_1 = Version(0, 1, 1)
+			let v0_2_0 = Version(0, 2, 0)
+			let v1_3_2 = Version(1, 3, 2)
+			let v2_1_1 = Version(2, 1, 1)
+			let v2_2_0 = Version(2, 2, 0)
+			let v2_2_0_b421 = Version(2, 2, 0, buildMetadataIdentifiers: ["b421"])
+			let v2_2_0_alpha = Version(2, 2, 0, prereleaseIdentifiers: ["alpha"])
 
 			it("should return the tighter specifier when one is .any") {
 				testIntersection(.any, .any, expected: .any)


### PR DESCRIPTION
Depends on #2665.

This is the first step in building more off of SwiftPM. I think if we do this, then use their equivalent of `VersionSpecifier`, we can start reading `Package.resolved` and/or using the Swift PM resolver. Using common types will make those things easier.