### PR TITLE
remove wrong xcscheme file existence check

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -230,14 +230,6 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 /// the project.
 public func schemesInProjects(_ projects: [(ProjectLocator, [Scheme])]) -> SignalProducer<[(Scheme, ProjectLocator)], CarthageError> {
 	return SignalProducer<(ProjectLocator, [Scheme]), CarthageError>(projects)
-		.map { (project: ProjectLocator, schemes: [Scheme]) in
-			// Only look for schemes that actually reside in the project
-			let containedSchemes = schemes.filter { scheme -> Bool in
-				let schemePath = project.fileURL.appendingPathComponent("xcshareddata/xcschemes/\(scheme).xcscheme").path
-				return FileManager.default.fileExists(atPath: schemePath)
-			}
-			return (project, containedSchemes)
-		}
 		.filter { (project: ProjectLocator, schemes: [Scheme]) in
 			switch project {
 			case .projectFile where !schemes.isEmpty:


### PR DESCRIPTION
Xcode 10.1 (10B61) creates no xcscheme when xcodeproj is created.
But it treats that there is shared framework scheme.
Carthage wrongly say `Dependency "car" has no shared framework schemes` because of it assume that xcscheme file exists always when there is shared scheme in xcodeproj.
So this PR remove this check.

This is xcodeproj files dump.

``` 
$ ls -R
car           car.xcodeproj

./car:
Car.swift  Info.plist car.h

./car.xcodeproj:
project.pbxproj     project.xcworkspace xcuserdata

./car.xcodeproj/project.xcworkspace:
contents.xcworkspacedata xcshareddata             xcuserdata

./car.xcodeproj/project.xcworkspace/xcshareddata:
IDEWorkspaceChecks.plist

./car.xcodeproj/project.xcworkspace/xcuserdata:
omochi.xcuserdatad

./car.xcodeproj/project.xcworkspace/xcuserdata/omochi.xcuserdatad:
UserInterfaceState.xcuserstate

./car.xcodeproj/xcuserdata:
omochi.xcuserdatad

./car.xcodeproj/xcuserdata/omochi.xcuserdatad:
xcschemes

./car.xcodeproj/xcuserdata/omochi.xcuserdatad/xcschemes:
xcschememanagement.plist
```

and this is xcodebuild `-list` output.

```
$ xcodebuild -project car.xcodeproj -list
Information about project "car":
    Targets:
        car

    Build Configurations:
        Debug
        Release

    If no build configuration is specified and -scheme is not passed then "Release" is used.

    Schemes:
        car

```

and this is screenshot.

<img width="691" alt="ss" src="https://user-images.githubusercontent.com/312792/51070302-52124780-1682-11e9-89da-796ada95e348.png">
