### PR TITLE
Fix CONTRIBUTING “make bootstrap” instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,13 @@ If you know exactly how to implement the feature being suggested or fix the bug 
 
 If you can’t make the change yourself, please open an issue after making sure that one isn’t already logged.
 
-## Target CarthageKit
-
-Unless you’re specifically improving something about the command-line experience of Carthage, please make code changes to [CarthageKit](README.md#carthagekit). This framework increases modularity, and allows other tools to integrate with Carthage more easily.
-
 ## Get started
 
 After checkout, you can run the following command from the cloned directory, and then open the workspace in Xcode:
 
 ```bash
-make bootstrap
+make xcodeproj && \
+  open Carthage.xcodeproj
 ```
 
 Then, to install your development copy of Carthage (and any local changes you've made) on your system, and test with your own repos:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MKDIR=mkdir -p
 SUDO=sudo
 CP=cp
 
-.PHONY: all clean install package test uninstall
+.PHONY: all clean install package test uninstall xcconfig xcodeproj
 
 all: installables
 
@@ -66,3 +66,13 @@ install: installables
 
 uninstall:
 	$(RM) "$(BINARIES_FOLDER)/carthage"
+	
+.build/libSwiftPM.xcconfig:
+	mkdir -p .build
+	echo "OTHER_LDFLAGS = -lncurses -lsqlite3" > "$@"
+	echo "OTHER_CFLAGS = -DSWIFT_PACKAGE" >> "$@"
+
+xcconfig: .build/libSwiftPM.xcconfig
+
+xcodeproj: xcconfig
+	 swift package generate-xcodeproj --xcconfig-overrides .build/libSwiftPM.xcconfig


### PR DESCRIPTION
Adds a `make xcodeproj` `Makefile` entry that generates a working Xcodeproj (some
extra work was required for libSwiftPM), see:

https://github.com/apple/swift-package-manager/tree/master/Examples/package-info

Fixes #2692