### PR TITLE
Add Allow HTTP Flag

### DIFF
--- a/Documentation/Artifacts.md
+++ b/Documentation/Artifacts.md
@@ -145,7 +145,7 @@ For dependencies that do not have source code available, a binary project specif
 * The JSON specification file name **should** have the same name as the framework and **not** be named **Carthage.json**, (example: MyFramework.json).
 * The JSON structure is a top-level dictionary with the key-value pairs of version / location.
 * The version **must** be a semantic version.  Git branches, tags and commits are not valid.
-* The location **must** be an `https` url.
+* The location **must** be an `https` url unless you use the `--allow-http` flag.
 
 #### Example binary project specification
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -4,6 +4,7 @@
 * `xcodebuild -version`: 
 * Are you using `--no-build`? 
 * Are you using `--no-use-binaries`? 
+* Are you using `--allow-http`?
 * Are you using `--use-submodules`? 
 * Are you using `--cache-builds`? 
 * Are you using `--new-resolver`? 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ If the framework you want to add to your project has dependencies explicitly lis
 
 If the embedded framework in your project has dependencies to other frameworks you must  **link them to application target** (even if application target does not have dependency to that frameworks and never uses them).
 
+### Allow http for dependencies
+
+By default, Carthage does not allow downloading dependencies over http due to security issues. While it's safe to use http internally, Carthage can't know whether you're hitting an intranet server. To safeguard other users, http is not allowed. 
+
+You can override this safeguard by using the `--allow-http` flag.
+
 ### Using submodules for dependencies
 
 By default, Carthage will directly [check out][Carthage/Checkouts] dependencies’ source files into your project folder, leaving you to commit or ignore them as you choose. If you’d like to have dependencies available as Git submodules instead (perhaps so you can commit and push changes within them), you can run `carthage update` or `carthage checkout` with the `--use-submodules` flag.

--- a/Source/CarthageKit/BinaryJSONError.swift
+++ b/Source/CarthageKit/BinaryJSONError.swift
@@ -11,8 +11,8 @@ public enum BinaryJSONError: Error {
 	/// Unable to parse a URL from a framework entry.
 	case invalidURL(String)
 
-	/// URL is non-HTTPS
-	case nonHTTPSURL(URL)
+	/// URL scheme is not supported or allowed
+	case invalidURLScheme(URL)
 }
 
 extension BinaryJSONError: CustomStringConvertible {
@@ -27,8 +27,8 @@ extension BinaryJSONError: CustomStringConvertible {
 		case let .invalidURL(string):
 			return "invalid URL: \(string)"
 
-		case let .nonHTTPSURL(url):
-			return "specified URL '\(url)' must be HTTPS"
+		case let .invalidURLScheme(url):
+            return "invalid scheme in URL: '\(url)', must be file or https"
 		}
 	}
 }
@@ -45,7 +45,7 @@ extension BinaryJSONError: Equatable {
 		case let (.invalidURL(left), .invalidURL(right)):
 			return left == right
 
-		case let (.nonHTTPSURL(left), .nonHTTPSURL(right)):
+		case let (.invalidURLScheme(left), .invalidURLScheme(right)):
 			return left == right
 
 		default:

--- a/Source/CarthageKit/BinaryJSONError.swift
+++ b/Source/CarthageKit/BinaryJSONError.swift
@@ -28,7 +28,7 @@ extension BinaryJSONError: CustomStringConvertible {
 			return "invalid URL: \(string)"
 
 		case let .invalidURLScheme(url):
-            return "invalid scheme in URL: '\(url)', must be file or https"
+            return "invalid scheme in URL: '\(url)', must be \(URL.validSchemesMessage)"
 		}
 	}
 }

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -29,7 +29,7 @@ public struct BinaryProject: Equatable {
 						return .failure(BinaryJSONError.invalidURL(value))
 					}
 					guard binaryURL.scheme == "file" || binaryURL.scheme == "https" else {
-						return .failure(BinaryJSONError.nonHTTPSURL(binaryURL))
+						return .failure(BinaryJSONError.invalidURLScheme(binaryURL))
 					}
 
 					versions[pinnedVersion] = binaryURL

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -28,9 +28,9 @@ public struct BinaryProject: Equatable {
 					guard let binaryURL = URL(string: value) else {
 						return .failure(BinaryJSONError.invalidURL(value))
 					}
-					guard binaryURL.scheme == "file" || binaryURL.scheme == "https" else {
-						return .failure(BinaryJSONError.invalidURLScheme(binaryURL))
-					}
+                    guard binaryURL.schemeIsValid else {
+                        return .failure(BinaryJSONError.invalidURLScheme(binaryURL))
+                    }
 
 					versions[pinnedVersion] = binaryURL
 				}

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -10,7 +10,7 @@ public struct BinaryProject: Equatable {
 
 	public var versions: [PinnedVersion: URL]
 
-	public static func from(jsonData: Data) -> Result<BinaryProject, BinaryJSONError> {
+    public static func from(jsonData: Data, allowHTTP: Bool = false) -> Result<BinaryProject, BinaryJSONError> {
 		return Result<[String: String], AnyError>(attempt: { try jsonDecoder.decode([String: String].self, from: jsonData) })
 			.mapError { .invalidJSON($0.error) }
 			.flatMap { json -> Result<BinaryProject, BinaryJSONError> in
@@ -28,7 +28,7 @@ public struct BinaryProject: Equatable {
 					guard let binaryURL = URL(string: value) else {
 						return .failure(BinaryJSONError.invalidURL(value))
 					}
-                    guard binaryURL.schemeIsValid else {
+                    guard binaryURL.validateScheme(allowHTTP: allowHTTP) else {
                         return .failure(BinaryJSONError.invalidURLScheme(binaryURL))
                     }
 

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -94,12 +94,12 @@ extension Dependency: Comparable {
 }
 
 extension Dependency: Scannable {
-	/// Attempts to parse a Dependency.
-	public static func from(_ scanner: Scanner) -> Result<Dependency, ScannableError> {
-		return from(scanner, base: nil)
-	}
-
-	public static func from(_ scanner: Scanner, base: URL? = nil) -> Result<Dependency, ScannableError> {
+    /// Attempts to parse a Dependency.
+    public static func from(_ scanner: Scanner) -> Result<Dependency, ScannableError> {
+        return from(scanner, base: nil, allowHTTP: false)
+    }
+    /// Attempts to parse a Dependency and adds the option to allow http.
+    public static func from(_ scanner: Scanner, base: URL? = nil, allowHTTP: Bool = false) -> Result<Dependency, ScannableError> {
 		let parser: (String) -> Result<Dependency, ScannableError>
 
 		if scanner.scanString("github", into: nil) {
@@ -114,7 +114,7 @@ extension Dependency: Scannable {
 		} else if scanner.scanString("binary", into: nil) {
 			parser = { urlString in
 				if let url = URL(string: urlString) {
-					if url.schemeIsValid {
+					if url.validateScheme(allowHTTP: allowHTTP) {
 						return .success(self.binary(BinaryURL(url: url, resolvedDescription: url.description)))
 					} else if url.scheme == nil {
 						// This can use URL.init(fileURLWithPath:isDirectory:relativeTo:) once we can target 10.11+

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -114,7 +114,7 @@ extension Dependency: Scannable {
 		} else if scanner.scanString("binary", into: nil) {
 			parser = { urlString in
 				if let url = URL(string: urlString) {
-					if url.scheme == "https" || url.scheme == "file" {
+					if url.schemeIsValid {
 						return .success(self.binary(BinaryURL(url: url, resolvedDescription: url.description)))
 					} else if url.scheme == nil {
 						// This can use URL.init(fileURLWithPath:isDirectory:relativeTo:) once we can target 10.11+
@@ -123,7 +123,7 @@ extension Dependency: Scannable {
 							.standardizedFileURL
 						return .success(self.binary(BinaryURL(url: absoluteURL, resolvedDescription: url.absoluteString)))
 					} else {
-						return .failure(ScannableError(message: "invalid URL scheme found for type `binary`, must be file or https", currentLine: scanner.currentLine))
+						return .failure(ScannableError(message: "invalid URL scheme found for type `binary`, must be \(URL.validSchemesMessage)", currentLine: scanner.currentLine))
 					}
 				} else {
 					return .failure(ScannableError(message: "invalid URL found for dependency type `binary`", currentLine: scanner.currentLine))

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -175,13 +175,13 @@ extension Dependency: CustomStringConvertible {
 
 extension Dependency {
 	/// Returns the URL that the dependency's remote repository exists at.
-	func gitURL(preferHTTPS: Bool) -> GitURL? {
+	func gitURL(useSSH: Bool) -> GitURL? {
 		switch self {
 		case let .gitHub(server, repository):
-			if preferHTTPS {
-				return server.httpsURL(for: repository)
+			if useSSH {
+                return server.sshURL(for: repository)
 			} else {
-				return server.sshURL(for: repository)
+				return server.httpsURL(for: repository)
 			}
 
 		case let .git(url):

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -123,7 +123,7 @@ extension Dependency: Scannable {
 							.standardizedFileURL
 						return .success(self.binary(BinaryURL(url: absoluteURL, resolvedDescription: url.absoluteString)))
 					} else {
-						return .failure(ScannableError(message: "non-https, non-file URL found for dependency type `binary`", currentLine: scanner.currentLine))
+						return .failure(ScannableError(message: "invalid URL scheme found for type `binary`, must be file or https", currentLine: scanner.currentLine))
 					}
 				} else {
 					return .failure(ScannableError(message: "invalid URL found for dependency type `binary`", currentLine: scanner.currentLine))

--- a/Source/CarthageKit/URLExtensions.swift
+++ b/Source/CarthageKit/URLExtensions.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension URL {
+    internal var schemeIsValid: Bool {
+        return scheme == "file" || scheme == "https"
+    }
+    internal static var validSchemesMessage: String {
+        return "file or https"
+    }
+}

--- a/Source/CarthageKit/URLExtensions.swift
+++ b/Source/CarthageKit/URLExtensions.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 extension URL {
-    internal var schemeIsValid: Bool {
-        return scheme == "file" || scheme == "https"
+    internal func validateScheme(allowHTTP: Bool = false) -> Bool {
+        return scheme == "file" || scheme == "https" || (scheme == "http" && allowHTTP)
     }
     internal static var validSchemesMessage: String {
-        return "file or https"
+        return "file, https or http if allowed"
     }
 }

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -8,18 +8,21 @@ import Curry
 /// Type that encapsulates the configuration and evaluation of the `checkout` subcommand.
 public struct CheckoutCommand: CommandProtocol {
 	public struct Options: OptionsProtocol {
+        public let allowHTTP: Bool
         public let useSSH: Bool
 		public let useSubmodules: Bool
 		public let colorOptions: ColorOptions
 		public let directoryPath: String
 		public let dependenciesToCheckout: [String]?
 
-		private init(useSSH: Bool,
+        private init(allowHTTP: Bool,
+                     useSSH: Bool,
 		             useSubmodules: Bool,
 		             colorOptions: ColorOptions,
 		             directoryPath: String,
 		             dependenciesToCheckout: [String]?
 		) {
+            self.allowHTTP = allowHTTP
             self.useSSH = useSSH
 			self.useSubmodules = useSubmodules
 			self.colorOptions = colorOptions
@@ -33,6 +36,7 @@ public struct CheckoutCommand: CommandProtocol {
 
 		public static func evaluate(_ mode: CommandMode, dependenciesUsage: String) -> Result<Options, CommandantError<CarthageError>> {
 			return curry(self.init)
+                <*> mode <| Option(key: "allow-http", defaultValue: false, usage: "allow http for downloading dependencies")
 				<*> mode <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 				<*> mode <| Option(key: "use-submodules", defaultValue: false, usage: "add dependencies as Git submodules")
 				<*> ColorOptions.evaluate(mode)
@@ -44,8 +48,9 @@ public struct CheckoutCommand: CommandProtocol {
 		/// accordingly.
 		public func loadProject() -> SignalProducer<Project, CarthageError> {
 			let directoryURL = URL(fileURLWithPath: self.directoryPath, isDirectory: true)
-			let project = Project(directoryURL: directoryURL)
-			project.useSSH = self.useSSH
+            let project = Project(directoryURL: directoryURL)
+            project.allowHTTP = self.allowHTTP
+            project.useSSH = self.useSSH
 			project.useSubmodules = self.useSubmodules
 
 			var eventSink = ProjectEventSink(colorOptions: colorOptions)

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -8,7 +8,7 @@ import Curry
 /// Type that encapsulates the configuration and evaluation of the `checkout` subcommand.
 public struct CheckoutCommand: CommandProtocol {
 	public struct Options: OptionsProtocol {
-		public let useSSH: Bool
+        public let useSSH: Bool
 		public let useSubmodules: Bool
 		public let colorOptions: ColorOptions
 		public let directoryPath: String
@@ -20,7 +20,7 @@ public struct CheckoutCommand: CommandProtocol {
 		             directoryPath: String,
 		             dependenciesToCheckout: [String]?
 		) {
-			self.useSSH = useSSH
+            self.useSSH = useSSH
 			self.useSubmodules = useSubmodules
 			self.colorOptions = colorOptions
 			self.directoryPath = directoryPath
@@ -45,7 +45,7 @@ public struct CheckoutCommand: CommandProtocol {
 		public func loadProject() -> SignalProducer<Project, CarthageError> {
 			let directoryURL = URL(fileURLWithPath: self.directoryPath, isDirectory: true)
 			let project = Project(directoryURL: directoryURL)
-			project.preferHTTPS = !self.useSSH
+			project.useSSH = self.useSSH
 			project.useSubmodules = self.useSubmodules
 
 			var eventSink = ProjectEventSink(colorOptions: colorOptions)

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -25,7 +25,7 @@ public struct FetchCommand: CommandProtocol {
 		let dependency = Dependency.git(options.repositoryURL)
 		var eventSink = ProjectEventSink(colorOptions: options.colorOptions)
 
-		return cloneOrFetch(dependency: dependency, preferHTTPS: true)
+		return cloneOrFetch(dependency: dependency, useSSH: false)
 			.on(value: { event, _ in
 				if let event = event {
 					eventSink.put(event)

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -74,7 +74,7 @@ public struct OutdatedCommand: CommandProtocol {
 		public func loadProject() -> SignalProducer<Project, CarthageError> {
 			let directoryURL = URL(fileURLWithPath: self.directoryPath, isDirectory: true)
 			let project = Project(directoryURL: directoryURL)
-			project.preferHTTPS = !self.useSSH
+			project.useSSH = self.useSSH
 
 			var eventSink = ProjectEventSink(colorOptions: colorOptions)
 			project.projectEvents.observeValues { eventSink.put($0) }

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -48,6 +48,7 @@ public struct OutdatedCommand: CommandProtocol {
 	}
 
 	public struct Options: OptionsProtocol {
+		public let allowHTTP: Bool
 		public let useSSH: Bool
 		public let isVerbose: Bool
 		public let outputXcodeWarnings: Bool
@@ -62,6 +63,7 @@ public struct OutdatedCommand: CommandProtocol {
 			)
 
 			return curry(self.init)
+                <*> mode <| Option(key: "allow-http", defaultValue: false, usage: "allow http for downloading dependencies")
 				<*> mode <| Option(key: "use-ssh", defaultValue: false, usage: "use SSH for downloading GitHub repositories")
 				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "include nested dependencies")
 				<*> mode <| Option(key: "xcode-warnings", defaultValue: false, usage: "output Xcode compatible warning messages")
@@ -74,6 +76,7 @@ public struct OutdatedCommand: CommandProtocol {
 		public func loadProject() -> SignalProducer<Project, CarthageError> {
 			let directoryURL = URL(fileURLWithPath: self.directoryPath, isDirectory: true)
 			let project = Project(directoryURL: directoryURL)
+			project.allowHTTP = self.allowHTTP
 			project.useSSH = self.useSSH
 
 			var eventSink = ProjectEventSink(colorOptions: colorOptions)

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -20,9 +20,10 @@ public struct UpdateCommand: CommandProtocol {
 		/// The build options corresponding to these options.
 		public var buildCommandOptions: BuildCommand.Options {
 			return BuildCommand.Options(
+                allowHTTP: checkoutOptions.allowHTTP,
 				buildOptions: buildOptions,
-				skipCurrent: true,
-				colorOptions: checkoutOptions.colorOptions,
+                skipCurrent: true,
+                colorOptions: checkoutOptions.colorOptions,
 				isVerbose: isVerbose,
 				directoryPath: checkoutOptions.directoryPath,
 				logPath: logPath,
@@ -43,7 +44,7 @@ public struct UpdateCommand: CommandProtocol {
 			}
 		}
 
-		private init(checkoutAfterUpdate: Bool,
+        private init(checkoutAfterUpdate: Bool,
 		             buildAfterUpdate: Bool,
 		             isVerbose: Bool,
 		             logPath: String?,

--- a/Tests/CarthageKitTests/BinaryProjectSpec.swift
+++ b/Tests/CarthageKitTests/BinaryProjectSpec.swift
@@ -67,11 +67,22 @@ class BinaryProjectSpec: QuickSpec {
 				expect(actualError) == .invalidURL("💩")
 			}
 
-			it("should fail with a non HTTPS url") {
+			it("should fail with an http URL") {
 				let jsonData = "{ \"1.0\": \"http://my.domain.com/framework.zip\" }".data(using: .utf8)!
-				let actualError = BinaryProject.from(jsonData: jsonData).error
+				let actualError = BinaryProject.from(jsonData: jsonData, allowHTTP: false).error
 
 				expect(actualError) == .invalidURLScheme(URL(string: "http://my.domain.com/framework.zip")!)
+			}
+            
+			it("should parse with an http url if allowed") {
+				let jsonData = "{ \"1.0\": \"http://my.domain.com/framework.zip\" }".data(using: .utf8)!
+				let actualBinaryProject = BinaryProject.from(jsonData: jsonData, allowHTTP: true).value
+				
+				let expectedBinaryProject = BinaryProject(versions: [
+					PinnedVersion("1.0"): URL(string: "http://my.domain.com/framework.zip")!,
+				])
+				
+				expect(actualBinaryProject) == expectedBinaryProject
 			}
 
 			it("should parse with a file url") {

--- a/Tests/CarthageKitTests/BinaryProjectSpec.swift
+++ b/Tests/CarthageKitTests/BinaryProjectSpec.swift
@@ -71,7 +71,7 @@ class BinaryProjectSpec: QuickSpec {
 				let jsonData = "{ \"1.0\": \"http://my.domain.com/framework.zip\" }".data(using: .utf8)!
 				let actualError = BinaryProject.from(jsonData: jsonData).error
 
-				expect(actualError) == .nonHTTPSURL(URL(string: "http://my.domain.com/framework.zip")!)
+				expect(actualError) == .invalidURLScheme(URL(string: "http://my.domain.com/framework.zip")!)
 			}
 
 			it("should parse with a file url") {

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -210,6 +210,16 @@ class DependencySpec: QuickSpec {
 
 					expect(dependency) == .binary(binary)
 				}
+                
+				it("should read a URL with http scheme if allowed") {
+					let scanner = Scanner(string: "binary \"http://mysupercoolinternalwebhost.com/\"")
+					
+					let dependency = Dependency.from(scanner, allowHTTP: true).value
+					let url = URL(string: "http://mysupercoolinternalwebhost.com/")!
+					let binary = BinaryURL(url: url, resolvedDescription: url.description)
+					
+					expect(dependency) == .binary(binary)
+				}
 
 				it("should read a URL with file scheme") {
 					let scanner = Scanner(string: "binary \"file:///my/domain/com/framework.json\"")

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -48,7 +48,7 @@ class ProjectSpec: QuickSpec {
 				let sourceRepoUrl = directoryURL.appendingPathComponent("SourceRepos")
 				for repo in ["TestFramework1", "TestFramework2", "TestFramework3"] {
 					let urlPath = sourceRepoUrl.appendingPathComponent(repo).path
-					_ = cloneOrFetch(dependency: .git(GitURL(urlPath)), preferHTTPS: false)
+					_ = cloneOrFetch(dependency: .git(GitURL(urlPath)), useSSH: true)
 						.wait()
 				}
 			}
@@ -355,7 +355,7 @@ class ProjectSpec: QuickSpec {
 			}
 
 			func cloneOrFetch(commitish: String? = nil) -> SignalProducer<(ProjectEvent?, URL), CarthageError> {
-				return CarthageKit.cloneOrFetch(dependency: dependency, preferHTTPS: false, destinationURL: cacheDirectoryURL, commitish: commitish)
+				return CarthageKit.cloneOrFetch(dependency: dependency, useSSH: true, destinationURL: cacheDirectoryURL, commitish: commitish)
 			}
 
 			func assertProjectEvent(commitish: String? = nil, clearFetchTime: Bool = true, action: @escaping (ProjectEvent?) -> Void) {

--- a/Tests/CarthageKitTests/URLExtensionsSpec.swift
+++ b/Tests/CarthageKitTests/URLExtensionsSpec.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Nimble
+import Quick
+
+@testable import CarthageKit
+
+class URLExtensionsSpec: QuickSpec {
+    override func spec() {
+        describe("URL") {
+            describe("schemeIsValid") {
+                it("should be true") {
+                    let expected = true
+                    expect(URL(string: "https://github.com")?.schemeIsValid) == expected
+                    expect(URL(string: "file://github/com/binary.json")?.schemeIsValid) == expected
+                }
+                it("should be false") {
+                    let expected = false
+                    expect(URL(string: "invalid")?.schemeIsValid) == expected
+                    expect(URL(string: "invalid://github.com")?.schemeIsValid) == expected
+                    expect(URL(string: "http://github.com")?.schemeIsValid) == expected
+                }
+            }
+        }
+    }
+}

--- a/Tests/CarthageKitTests/URLExtensionsSpec.swift
+++ b/Tests/CarthageKitTests/URLExtensionsSpec.swift
@@ -10,14 +10,18 @@ class URLExtensionsSpec: QuickSpec {
             describe("schemeIsValid") {
                 it("should be true") {
                     let expected = true
-                    expect(URL(string: "https://github.com")?.schemeIsValid) == expected
-                    expect(URL(string: "file://github/com/binary.json")?.schemeIsValid) == expected
+                    expect(URL(string: "file://github/com/binary.json")?.validateScheme()) == expected
+                    expect(URL(string: "http://github.com")?.validateScheme(allowHTTP: true)) == expected
+                    expect(URL(string: "https://github.com")?.validateScheme()) == expected
+                    expect(URL(string: "https://github.com")?.validateScheme(allowHTTP: true)) == expected
+                    expect(URL(string: "https://github.com")?.validateScheme(allowHTTP: false)) == expected
                 }
                 it("should be false") {
                     let expected = false
-                    expect(URL(string: "invalid")?.schemeIsValid) == expected
-                    expect(URL(string: "invalid://github.com")?.schemeIsValid) == expected
-                    expect(URL(string: "http://github.com")?.schemeIsValid) == expected
+                    expect(URL(string: "invalid")?.validateScheme()) == expected
+                    expect(URL(string: "invalid://github.com")?.validateScheme()) == expected
+                    expect(URL(string: "http://github.com")?.validateScheme()) == expected
+                    expect(URL(string: "http://github.com")?.validateScheme(allowHTTP: false)) == expected
                 }
             }
         }


### PR DESCRIPTION
This is a proposal for a solution to the problem described in #1885. I have the exact same problem and as I think Carthage should safeguard its users, there should be an option available to use HTTP at your own risk. (As I worked with the changes in this PR, I discovered that http is allowed for enterprise GitHub URLs but the validation for this seems to be pretty fragile as it only relies on a certain combination of path components in the url.) 

This issue is so big for us that we cannot use Carthage unless this is implemented.