### PR TITLE
Make swiftToolchainVersion optional for ObjC only frameworks

### DIFF
--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -13,7 +13,10 @@ struct CachedFramework: Codable {
 
 	let name: String
 	let hash: String
-	let swiftToolchainVersion: String
+	let swiftToolchainVersion: String?
+	var isSwiftFramework: Bool {
+		return swiftToolchainVersion != nil
+	}
 }
 
 struct VersionFile: Codable {
@@ -403,7 +406,7 @@ public func createVersionFileForCommitish(
 	struct FrameworkDetail {
 		let platformName: String
 		let frameworkName: String
-		let frameworkSwiftVersion: String
+		let frameworkSwiftVersion: String?
 	}
 
 	if !buildProducts.isEmpty {
@@ -411,7 +414,7 @@ public func createVersionFileForCommitish(
 			.flatMap(.merge) { url -> SignalProducer<(String, FrameworkDetail), CarthageError> in
 				let frameworkName = url.deletingPathExtension().lastPathComponent
 				let platformName = url.deletingLastPathComponent().lastPathComponent
-				return frameworkSwiftVersion(url)
+				return frameworkSwiftVersionIfIsSwiftFramework(url)
 					.mapError { swiftVersionError -> CarthageError in .unknownFrameworkSwiftVersion(swiftVersionError.description) }
 					.flatMap(.merge) { frameworkSwiftVersion -> SignalProducer<(String, FrameworkDetail), CarthageError> in
 					let frameworkDetail: FrameworkDetail = .init(platformName: platformName,

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -51,6 +51,14 @@ private func parseSwiftVersionCommand(output: String?) -> String? {
 }
 
 /// Determines the Swift version of a framework at a given `URL`.
+internal func frameworkSwiftVersionIfIsSwiftFramework(_ frameworkURL: URL) -> SignalProducer<String?, SwiftVersionError> {
+	guard isSwiftFramework(frameworkURL) else {
+		return SignalProducer(value: nil)
+	}
+	return frameworkSwiftVersion(frameworkURL).map(Optional.some)
+}
+
+/// Determines the Swift version of a framework at a given `URL`.
 internal func frameworkSwiftVersion(_ frameworkURL: URL) -> SignalProducer<String, SwiftVersionError> {
 
 	guard

--- a/Tests/CarthageKitTests/VersionFileSpec.swift
+++ b/Tests/CarthageKitTests/VersionFileSpec.swift
@@ -74,6 +74,7 @@ class VersionFileSpec: QuickSpec {
 			expect(newCachedFramework[0].name) == framework.name
 			expect(newCachedFramework[0].hash) == framework.hash
 			expect(newCachedFramework[0].swiftToolchainVersion) == framework.swiftToolchainVersion
+			expect(newCachedFramework[0].isSwiftFramework) == framework.isSwiftFramework
 		}
 
 		it("should encode and decode correctly") {
@@ -102,6 +103,7 @@ class VersionFileSpec: QuickSpec {
 			expect(iOSCache![0].name) == "TestFramework"
 			expect(iOSCache![0].hash) == "TestHASH"
 			expect(iOSCache![0].swiftToolchainVersion) == "4.2 (swiftlang-1000.11.37.1 clang-1000.11.45.1)"
+			expect(iOSCache![0].isSwiftFramework) == true
 
 			let value = (try? JSONSerialization.jsonObject(with: JSONEncoder().encode(versionFile))) as? [String: Any]
 			expect(value).notTo(beNil())
@@ -161,6 +163,25 @@ class VersionFileSpec: QuickSpec {
 			validate(
 				file: versionFile, matches: false, platform: .watchOS,
 				commitish: "v1.0", hashes: [nil, nil], swiftVersionMatches: [true, true]
+			)
+		}
+		
+		it("should do proper validation with objc framework") {
+			let jsonDictionary: [String: Any] = [
+				"commitish": "v1.0",
+				"iOS": [
+					[
+						"name": "TestObjCFramework",
+						"hash": "TestHASH",
+						],
+				],
+				]
+			let jsonData = try! JSONSerialization.data(withJSONObject: jsonDictionary)
+			
+			let versionFile: VersionFile! = try? JSONDecoder().decode(VersionFile.self, from: jsonData)
+			validate(
+				file: versionFile, matches: true, platform: .iOS,
+				commitish: "v1.0", hashes: ["TestHASH"], swiftVersionMatches: [true]
 			)
 		}
 	}

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -344,6 +344,11 @@ class XcodeSpec: QuickSpec {
 			let path = buildFolderURL.appendingPathComponent("Mac/\(dependency.name).framework").path
 			expect(path).to(beExistingDirectory())
 
+			// Verify that the version file exists.
+			let versionFileURL = URL(fileURLWithPath: buildFolderURL.appendingPathComponent(".Archimedes.version").path)
+			let versionFile = VersionFile(url: versionFileURL)
+			expect(versionFile).notTo(beNil())
+			
 			// Verify that the other platform wasn't built.
 			let incorrectPath = buildFolderURL.appendingPathComponent("iOS/\(dependency.name).framework").path
 			expect(FileManager.default.fileExists(atPath: incorrectPath, isDirectory: nil)) == false


### PR DESCRIPTION
Fix issue #2677 