### PR TITLE
Add "skip-simulators" option

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -15,7 +15,7 @@ public struct BuildOptions {
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
 	/// Whether to use platform simulators or not
-	public var noSimulators: Bool
+	public var skipSimulators: Bool
 
 	public init(
 		configuration: String,
@@ -24,7 +24,7 @@ public struct BuildOptions {
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
 		useBinaries: Bool = true,
-		noSimulators: Bool = false
+		skipSimulators: Bool = false
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -32,6 +32,6 @@ public struct BuildOptions {
 		self.derivedDataPath = derivedDataPath
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
-		self.noSimulators = noSimulators
+		self.skipSimulators = skipSimulators
 	}
 }

--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -14,6 +14,8 @@ public struct BuildOptions {
 	public var cacheBuilds: Bool
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
+	/// Whether to use platform simulators or not
+	public var noSimulators: Bool
 
 	public init(
 		configuration: String,
@@ -21,7 +23,8 @@ public struct BuildOptions {
 		toolchain: String? = nil,
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
-		useBinaries: Bool = true
+		useBinaries: Bool = true,
+		noSimulators: Bool = false
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -29,5 +32,6 @@ public struct BuildOptions {
 		self.derivedDataPath = derivedDataPath
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
+		self.noSimulators = noSimulators
 	}
 }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -482,7 +482,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 		.reduce(into: [:]) { (sdksByPlatform: inout [Platform: Set<SDK>], sdk: SDK) in
 			let platform = sdk.platform
 			
-			guard !(options.noSimulators && sdk.isSimulator) else {
+			guard !(options.skipSimulators && sdk.isSimulator) else {
 				// SDK is a simulator and build options does not support
 				// simulators
 				return

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -481,7 +481,13 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 		}
 		.reduce(into: [:]) { (sdksByPlatform: inout [Platform: Set<SDK>], sdk: SDK) in
 			let platform = sdk.platform
-
+			
+			guard !(options.noSimulators && sdk.isSimulator) else {
+				// SDK is a simulator and build options does not support
+				// simulators
+				return
+			}
+			
 			if var sdks = sdksByPlatform[platform] {
 				sdks.insert(sdk)
 				sdksByPlatform.updateValue(sdks, forKey: platform)

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -23,7 +23,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
-			<*> mode <| Option(key: "no-simulators", defaultValue: false, usage: "don't use simulators when building (for platforms which support them)")
+			<*> mode <| Option(key: "skip-simulators", defaultValue: false, usage: "skip simulators when building (for platforms which support them)")
 	}
 }
 

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -23,6 +23,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
+			<*> mode <| Option(key: "no-simulators", defaultValue: false, usage: "don't use simulators when building (for platforms which support them)")
 	}
 }
 


### PR DESCRIPTION
# Background
I now have two (specifically iOS) projects which make use of third party libraries (`lib*.a`) which do not support simulator architecture slices and therefore can not be built against simulators.

I've attempted to produce wrapper frameworks around these libraries to make their use simpler in another projects, but they can't be managed through Carthage, as Carthage wants to build them against both "Generic" and "Simulator" based platforms.

In an attempt to reduce further issues, I'd like also take advantage of Carthage's "binary only" frameworks support, but, again, I can't use my existing work flow to use Carthage to generate these results (yes, I could do it manually, but I've built a work flow around Carthage).

# Solution
Skip "sdk"s which are backed by simulators.

The intended solution is too, when requested by the user, skip building `SDK`s which report `isSimulator` as `true`.

The solution would provide a opt-in parameter `--skip-simulators` which, when used, would instruct the build process to skip any `SDK` which `isSimulator`

## Specifying device ID 
I did research using `destination` to specify the physical device to build against, but choose not to go this route due to the complexity of collecting this information and deciding when the override should be applied

# Considerations
When building a project/archive in this way, all dependencies built by Carthage will also be built in the same way (no simulator slices).

Since any resulting project won't be able to use the simulator(s) anyway, this shouldn't be a major issue anyway

# Notes
The change was made against the release branch as the current master kept failing, as it was unable to determine the Swift version