### PR TITLE
Add fetch-interval to `outdated` command to skip fetching the dependencies

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -23,7 +23,7 @@ public struct FetchCache {
 	}
 
     internal static func needsFetch(forURL url: GitURL) -> Bool {
-		guard let lastFetch = lastFetchTimes[url] ?? repositoriesLastFetchTime()?.timeIntervalSince1970 else {
+		guard let lastFetch = lastFetchTimes[url] ?? repositoriesLastFetchTime() else {
 			return true
 		}
 
@@ -37,17 +37,50 @@ public struct FetchCache {
 		}
 	}
 
-    fileprivate static func repositoriesLastFetchTime() -> Date? {
-        do {
-            let attr = try FileManager.default.attributesOfItem(atPath: Constants.Dependency.repositoriesURL.path)
-            return attr[FileAttributeKey.modificationDate] as? Date
-        } catch {
+    fileprivate static func repositoriesLastFetchTime() -> TimeInterval? {
+        guard let data = try? Constants.Dependency.repositoriesURL.extendedAttribute(for: "\(Constants.bundleIdentifier).repositories.last.fetch.time") else {
             return nil
         }
+        return data.withUnsafeBytes { $0.pointee as TimeInterval }
     }
 
     public static func updateRepositoriesLastFetchTime() {
-        try? FileManager.default.setAttributes([FileAttributeKey.modificationDate: Date()], ofItemAtPath: Constants.Dependency.repositoriesURL.path)
+        var now = Date().timeIntervalSince1970
+        let data = Data(bytes: &now, count: MemoryLayout<TimeInterval>.size)
+        try? Constants.Dependency.repositoriesURL.setExtendedAttribute(for: "\(Constants.bundleIdentifier).repositories.last.fetch.time", data: data)
+    }
+}
+
+/// URL extension to support operations on extended attributes of a file
+fileprivate extension URL {
+
+    enum ExtendedAttributesError: Error {
+        case cannotReadAttribute
+        case cannotSetAttribute
+    }
+
+    func extendedAttribute(for name: String) throws -> Data  {
+        let data = try withUnsafeFileSystemRepresentation { path -> Data in
+            let length = getxattr(path, name, nil, 0, 0, 0)
+            guard length >= 0 else { throw ExtendedAttributesError.cannotReadAttribute }
+
+            var data = Data(count: length)
+            let result =  data.withUnsafeMutableBytes { [count = data.count] in
+                getxattr(path, name, $0.baseAddress, count, 0, 0)
+            }
+            guard result >= 0 else { throw ExtendedAttributesError.cannotReadAttribute }
+            return data
+        }
+        return data
+    }
+
+    func setExtendedAttribute(for name: String, data: Data) throws {
+        try withUnsafeFileSystemRepresentation { path in
+            let result = data.withUnsafeBytes {
+                setxattr(path, name, $0, data.count, 0, 0)
+            }
+            guard result >= 0 else { throw ExtendedAttributesError.cannotSetAttribute }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation and Context

`carthage outdated --xcode-warnings` (Xcode build phase) command fetches the dependencies each time when executed. In order to improve the performance of the command, we'd like to introduce a new parameter `fetch-interval`. This parameter specifies how often the dependencies should be fetched from the remote location. Example usage:

```bash
carthage outdated --xcode-warning --fetch-interval 30
```

`fetch-interval` - the minimum amount of time that must elapse between dependencies fetch operation (provided in ~~minutes~~ seconds)

https://github.com/Carthage/Carthage/issues/2698

### Description

~~This PR is draft one [WIP]. Kindly ask you to check the review comments~~  🙏
EDIT: PR is ready for review 🙏 

_It's my first Carthage contribution_ 🎉 