### PR TITLE
Use specific SwiftPM tag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
-          "version": "7.3.1"
+          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
+          "version": "7.3.4"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
-          "version": "1.3.2"
+          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
+          "version": "1.3.4"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       },
       {
@@ -78,7 +78,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "master",
-          "revision": "c7aa6e5ea11b39362159b4edc98bfd5dd6d57cf3",
+          "revision": "ed7a4a1c010002f2646b8aaf9f9e88e6f20795c1",
           "version": null
         }
       },
@@ -86,8 +86,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "master",
-          "revision": "618ec189be028484cb942dd1249a396851c7176d",
+          "branch": "swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a",
+          "revision": "916450f7e8a5aef13630edf9e6fc0b16ed9f5f65",
           "version": null
         }
       },
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/mdiep/Tentacle.git",
         "state": {
           "branch": null,
-          "revision": "ace0aedb5bd90a41de254808dbe633813f7b1882",
-          "version": "0.12.0"
+          "revision": "d7f05e586195303174f108a11d0433b204369f4d",
+          "version": "0.12.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "carthage", targets: ["carthage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/antitypical/Result.git", from: "4.0.0"),
+        .package(url: "https://github.com/antitypical/Result.git", from: "4.1.0"),
         .package(url: "https://github.com/Carthage/ReactiveTask.git", from: "0.15.0"),
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.15.0"),
         .package(url: "https://github.com/jdhealy/PrettyColors.git", from: "5.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "1.3.1"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.0"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a")),
     ],
     targets: [
         .target(

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Result
-import Utility
+import SPMUtility
 
 import struct Foundation.URL
 

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -96,7 +96,7 @@ public struct Cartfile {
 
 	/// Attempts to parse a Cartfile from a file at a given URL.
 	public static func from(file cartfileURL: URL) -> Result<Cartfile, CarthageError> {
-		return Result(attempt: { try String(contentsOf: cartfileURL, encoding: .utf8) })
+		return Result(catching: { try String(contentsOf: cartfileURL, encoding: .utf8) })
 			.mapError { .readFailed(cartfileURL, $0) }
 			.flatMap(Cartfile.from(string:))
 			.mapError { error in

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,4 +1,4 @@
-import Utility
+import SPMUtility
 
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Result
-import Utility
+import SPMUtility
 
 /// Identifies a dependency, its pinned version, and its compatible and incompatible requirements
 public struct CompatibilityInfo: Equatable {

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -27,7 +27,7 @@ public struct Constants {
 	private static let userCachesURL: URL = {
 		let fileManager = FileManager.default
 
-		let urlResult: Result<URL, NSError> = Result(attempt: {
+		let urlResult: Result<URL, NSError> = Result(catching: {
 			try fileManager.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
 		}).flatMap { cachesURL in
 			let dependenciesURL = cachesURL.appendingPathComponent(Constants.bundleIdentifier, isDirectory: true)
@@ -41,7 +41,7 @@ public struct Constants {
 					return Result(error: error)
 				}
 			} else {
-				return Result(attempt: {
+				return Result(catching: {
 					try fileManager.createDirectory(
 						at: dependenciesURL,
 						withIntermediateDirectories: true,

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -161,7 +161,7 @@ public func checkoutRepositoryToDirectory(
 			return .success(environment)
 	}
 	.attempt { _ in
-		Result(attempt: { try FileManager.default.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true) })
+		Result(catching: { try FileManager.default.createDirectory(at: workingDirectoryURL, withIntermediateDirectories: true) })
 			.mapError {
 				CarthageError.repositoryCheckoutFailed(
 					workingDirectoryURL: workingDirectoryURL,

--- a/Source/CarthageKit/NewResolver.swift
+++ b/Source/CarthageKit/NewResolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
-import Utility
+import SPMUtility
 
 /// Responsible for resolving acyclic dependency graphs.
 public struct NewResolver: ResolverProtocol {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -196,7 +196,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 	/// Reads the project's Cartfile.resolved.
 	public func loadResolvedCartfile() -> SignalProducer<ResolvedCartfile, CarthageError> {
 		return SignalProducer {
-			Result(attempt: { try String(contentsOf: self.resolvedCartfileURL, encoding: .utf8) })
+			Result(catching: { try String(contentsOf: self.resolvedCartfileURL, encoding: .utf8) })
 				.mapError { .readFailed(self.resolvedCartfileURL, $0) }
 				.flatMap(ResolvedCartfile.from)
 		}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -6,7 +6,7 @@ import ReactiveSwift
 import Tentacle
 import XCDBLD
 import ReactiveTask
-import Utility
+import SPMUtility
 
 import struct Foundation.URL
 import enum XCDBLD.Platform

--- a/Source/CarthageKit/RemoteVersion.swift
+++ b/Source/CarthageKit/RemoteVersion.swift
@@ -3,7 +3,7 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
-import Utility
+import SPMUtility
 
 /// Synchronously returns the semantic version of the newest release,
 /// if the given producer emits it within a reasonable timeframe.

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
-import Utility
+import SPMUtility
 
 /// Protocol for resolving acyclic dependency graphs.
 public protocol ResolverProtocol {

--- a/Source/CarthageKit/Simulator.swift
+++ b/Source/CarthageKit/Simulator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Utility
+import SPMUtility
 import XCDBLD
 
 internal struct Simulator: Decodable {

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Result
 import ReactiveSwift
-import Utility
+import SPMUtility
 
 extension Version {
 	/// Attempts to parse a semantic version from a PinnedVersion.

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -201,7 +201,7 @@ private func scriptInputFileLists() -> SignalProducer<String, CarthageError> {
 				.attemptMap { getEnvironmentVariable("SCRIPT_INPUT_FILE_LIST_\($0)") }
 				.flatMap(.merge) { fileList -> SignalProducer<String, CarthageError> in
 					let fileListURL = URL(fileURLWithPath: fileList, isDirectory: true)
-					return SignalProducer<String, NSError>(result: Result(attempt: { try String(contentsOfFile: fileList) }))
+					return SignalProducer<String, NSError>(result: Result(catching: { try String(contentsOfFile: fileList) }))
 						.mapError { CarthageError.readFailed(fileListURL, $0) }
 				}
 				.map { $0.split(separator: "\n").map(String.init) }

--- a/Source/carthage/RemoteVersion.swift
+++ b/Source/carthage/RemoteVersion.swift
@@ -4,7 +4,7 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
-import Utility
+import SPMUtility
 
 /// The latest version of Carthage as a `Version`.
 public func remoteVersion() -> Version? {

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -4,7 +4,7 @@ import Result
 import Tentacle
 import Nimble
 import Quick
-import Utility
+import SPMUtility
 
 import struct Foundation.URL
 

--- a/Tests/CarthageKitTests/DB.swift
+++ b/Tests/CarthageKitTests/DB.swift
@@ -3,7 +3,7 @@ import ReactiveSwift
 import Foundation
 import Result
 import Tentacle
-import Utility
+import SPMUtility
 
 // swiftlint:disable no_extension_access_modifier
 let git1 = Dependency.git(GitURL("https://example.com/repo1"))

--- a/Tests/CarthageKitTests/RemoteVersionSpec.swift
+++ b/Tests/CarthageKitTests/RemoteVersionSpec.swift
@@ -3,7 +3,7 @@ import Nimble
 import Quick
 import ReactiveSwift
 import Tentacle
-import Utility
+import SPMUtility
 
 import struct Foundation.URL
 

--- a/Tests/CarthageKitTests/ValidateSpec.swift
+++ b/Tests/CarthageKitTests/ValidateSpec.swift
@@ -5,7 +5,7 @@ import Quick
 import ReactiveSwift
 import Result
 import Tentacle
-import Utility
+import SPMUtility
 
 import struct Foundation.URL
 

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -2,7 +2,7 @@ import CarthageKit
 import Foundation
 import Nimble
 import Quick
-import Utility
+import SPMUtility
 
 class VersionSpec: QuickSpec {
 	override func spec() {


### PR DESCRIPTION
Resolves #2705.

Before, we specified SwiftPM `master`. This works fine in our repo, since `Package.resolved` specifies a revision. But if you used Carthage as a dependency, it wouldn't compile.

This also updates to Result 4.1.0 and fixes the deprecation warnings from the adoption of the `Swift.Result` method names.