### PR TITLE
Fix issue where `carthage build` does not download binaries for dependencies in a specific situation

### DIFF
--- a/IntegrationTests/build.bats
+++ b/IntegrationTests/build.bats
@@ -17,3 +17,14 @@ EOF
     [ "$status" -eq 0 ]
     [ -e Carthage/Build/iOS/MMMarkdown.framework ]
 }
+
+@test "carthage build works right IN MY SPECIAL SCENARIO WHICH NEEDS TO BE DESCRIBED HERE" {
+cat >| Cartfile <<-EOF
+github "ReactiveX/RxSwift" ~> 4.0
+EOF
+run carthage update
+rm -rf Carthage/Build
+run carthage build
+[ "$status" -eq 0 ]
+[ -e Carthage/Build/Mac/RxSwift.framework ]
+}

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -148,7 +148,13 @@ extension Client {
 			Client.userAgent = gitHubUserAgent()
 		}
 
-		let urlSession = URLSession.proxiedSession
+        var urlSession: URLSession
+        
+        if server.url.host?.contains("github.com") == true {
+            urlSession = URLSession.proxiedSessionWithDelegate
+        } else {
+            urlSession = URLSession.proxiedSession
+        }
 
 		if !isAuthenticated {
 			self.init(server, urlSession: urlSession)
@@ -163,7 +169,14 @@ extension Client {
 }
 
 extension URLSession {
-	public static var proxiedSession: URLSession {
+    public static var proxiedSession: URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.connectionProxyDictionary = Proxy.default.connectionProxyDictionary
+        
+        return URLSession(configuration: configuration)
+    }
+    
+	public static var proxiedSessionWithDelegate: URLSession {
 		let configuration = URLSessionConfiguration.default
 		configuration.connectionProxyDictionary = Proxy.default.connectionProxyDictionary
 


### PR DESCRIPTION
This PR does not work at this time. When it was originally created I believed that the source of the problem was due to the differences between GitHub and GitHub Enterprise. Since that time I have been able to reproduce the issue on GitHub as well so this fix is not valid. 

Steps to reproduce: https://github.com/Carthage/Carthage/pull/2725#issuecomment-475957108

Fix for issue: https://github.com/Carthage/Carthage/issues/2724