### PR TITLE
Fix merging Swift header files for Xcode 10.2

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -364,7 +364,7 @@ private func mergeSwiftHeaderFiles(_ simulatorExecutableURL: URL,
 	
 	let conditionalPrefix = "#if TARGET_OS_SIMULATOR\n"
 	let conditionalElse = "\n#else\n"
-	let conditionalSuffix = "\n#endif"
+	let conditionalSuffix = "\n#endif\n"
 	
 	let conditionalPrefixContents = conditionalPrefix.data(using: .utf8)!
 	let conditionalElseContents = conditionalElse.data(using: .utf8)!

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -362,10 +362,16 @@ private func mergeSwiftHeaderFiles(_ simulatorExecutableURL: URL,
 	precondition(deviceExecutableURL.isFileURL)
 	precondition(executableOutputURL.isFileURL)
 	
+    let includeTargetConditionals = """
+                                    #ifndef TARGET_OS_SIMULATOR
+                                    #include <TargetConditionals.h>
+                                    #endif\n
+                                    """
 	let conditionalPrefix = "#if TARGET_OS_SIMULATOR\n"
 	let conditionalElse = "\n#else\n"
 	let conditionalSuffix = "\n#endif\n"
 	
+	let includeTargetConditionalsContents = includeTargetConditionals.data(using: .utf8)!
 	let conditionalPrefixContents = conditionalPrefix.data(using: .utf8)!
 	let conditionalElseContents = conditionalElse.data(using: .utf8)!
 	let conditionalSuffixContents = conditionalSuffix.data(using: .utf8)!
@@ -378,6 +384,7 @@ private func mergeSwiftHeaderFiles(_ simulatorExecutableURL: URL,
 	
 	var fileContents = Data()
 	
+	fileContents.append(includeTargetConditionalsContents)
 	fileContents.append(conditionalPrefixContents)
 	fileContents.append(simulatorHeaderContents)
 	fileContents.append(conditionalElseContents)


### PR DESCRIPTION
This is meant to fix merging Swift header files for Xcode 10.2 by adding missing include directive for `TARGET_OS_SIMULATOR` definition.

- Xcode doesn't set `TARGET_OS_SIMULATOR` value by default and shows `undeclared identifier` errors at compilation for the symbols in generated Swift header file.
- Including `TargetConditionals.h` to the header file solves the issue.

Generated Swift header file should now look like this:
```
#include <TargetConditionals.h>
#if TARGET_OS_SIMULATOR
<simulator Swift.h>
#else
<device Swift.h>
#endif
```
Coauthored with @buranmert

Related: https://github.com/Carthage/Carthage/pull/2723