### PR TITLE
Reject archives containing duplicated framework names

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,10 @@ Tags without any version number, or with any characters following the version nu
 
 Carthage can automatically use prebuilt frameworks, instead of building from scratch, if they are attached to a [GitHub Release](https://help.github.com/articles/about-releases/) on your project’s repository or via a binary project definition file.
 
-To offer prebuilt frameworks for a specific tag, the binaries for _all_ supported platforms should be zipped up together into _one_ archive, and that archive should be attached to a published Release corresponding to that tag. The attachment should include `.framework` in its name (e.g., `ReactiveCocoa.framework.zip`), to indicate to Carthage that it contains binaries.
+To offer prebuilt frameworks for a specific tag, the binaries for _all_ supported platforms should be zipped up together into _one_ archive, and that archive should be attached to a published Release corresponding to that tag. The attachment should include `.framework` in its name (e.g., `ReactiveCocoa.framework.zip`), to indicate to Carthage that it contains binaries. The directory structure of the acthive is free form but, __frameworks should only appear once in the archive__ as they will be copied
+to `Carthage/Build/<platform>` based on their name (e.g. `ReactiveCocoa.framework`).
 
-You can perform the archiving operation using:
+You can perform the archiving operation with carthage itself using:
 
 ```sh
 -carthage build --no-skip-current

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -572,6 +572,29 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.then(shouldCheckout ? checkoutResolvedDependencies(dependenciesToUpdate, buildOptions: buildOptions) : .empty)
 	}
 
+	/// Constructs the file:// URL at which a given .framework
+	/// will be found. Depends on the location of the current project.
+	private func frameworkURLInCarthageBuildFolder(
+		forPlatform platform: Platform,
+		frameworkNameAndExtension: String
+	) -> Result<URL, CarthageError> {
+		guard let lastComponent = URL(string: frameworkNameAndExtension)?.pathExtension,
+			lastComponent == "framework" else {
+				return .failure(.internalError(description: "\(frameworkNameAndExtension) is not a valid framework identifier"))
+		}
+
+		guard let destinationURLInWorkingDir = platform
+			.relativeURL?
+			.appendingPathComponent(frameworkNameAndExtension, isDirectory: true) else {
+				return .failure(.internalError(description: "failed to construct framework destination url from \(platform) and \(frameworkNameAndExtension)"))
+		}
+
+		return .success(self
+			.directoryURL
+			.appendingPathComponent(destinationURLInWorkingDir.path, isDirectory: true)
+			.standardizedFileURL)
+	}
+
 	/// Unzips the file at the given URL and copies the frameworks, DSYM and
 	/// bcsymbolmap files into the corresponding folders for the project. This
 	/// step will also check framework compatibility and create a version file
@@ -584,21 +607,82 @@ public final class Project { // swiftlint:disable:this type_body_length
 		pinnedVersion: PinnedVersion,
 		toolchain: String?
 	) -> SignalProducer<URL, CarthageError> {
+
+		// Helper type
+		typealias SourceURLAndDestinationURL = (frameworkSourceURL: URL, frameworkDestinationURL: URL)
+
+		// Returns the unique pairs in the input array
+		// or the duplicate keys by .frameworkDestinationURL
+		func uniqueSourceDestinationPairs(
+			_ sourceURLAndDestinationURLpairs: [SourceURLAndDestinationURL]
+			) -> Result<[SourceURLAndDestinationURL], CarthageError> {
+			let destinationMap = sourceURLAndDestinationURLpairs
+				.reduce(into: [URL: [URL]]()) { result, pair in
+					result[pair.frameworkDestinationURL] =
+						(result[pair.frameworkDestinationURL] ?? []) + [pair.frameworkSourceURL]
+			}
+
+			let dupes = destinationMap.filter { $0.value.count > 1 }
+			guard dupes.count == 0 else {
+				return .failure(CarthageError
+					.duplicatesInArchive(duplicates: CarthageError
+						.DuplicatesInArchive(dictionary: dupes)))
+			}
+
+			let uniquePairs = destinationMap
+				.filter { $0.value.count == 1}
+				.map { SourceURLAndDestinationURL(frameworkSourceURL:$0.key,
+												  frameworkDestinationURL: $0.value.first!)}
+			return .success(uniquePairs)
+		}
+
 		return SignalProducer<URL, CarthageError>(value: zipFile)
 			.flatMap(.concat, unarchive(archive:))
 			.flatMap(.concat) { directoryURL -> SignalProducer<URL, CarthageError> in
+				// For all frameworks in the directory where the archive has been expanded
 				return frameworksInDirectory(directoryURL)
-					.flatMap(.merge) { url -> SignalProducer<URL, CarthageError> in
-						return checkFrameworkCompatibility(url, usingToolchain: toolchain)
-							.mapError { error in CarthageError.internalError(description: error.description) }
+					.collect()
+					// Check if multiple frameworks resolve to the same unique destination URL in the Carthage/Build/ folder.
+					// This is needed because frameworks might overwrite each others.
+					.flatMap(.merge) { frameworksUrls -> SignalProducer<SourceURLAndDestinationURL, CarthageError> in
+						return SignalProducer<URL, CarthageError>(frameworksUrls)
+							.flatMap(.merge) { url -> SignalProducer<URL, CarthageError> in
+								return platformForFramework(url)
+									.attemptMap { self.frameworkURLInCarthageBuildFolder(forPlatform: $0,
+																				 frameworkNameAndExtension: url.lastPathComponent) }
+							}
+							.collect()
+							.flatMap(.merge) { destinationUrls -> SignalProducer<SourceURLAndDestinationURL, CarthageError> in
+								let frameworkUrlAndDestinationUrlPairs = zip(frameworksUrls.map{$0.standardizedFileURL},
+																			 destinationUrls.map{$0.standardizedFileURL})
+									.map { SourceURLAndDestinationURL(frameworkSourceURL:$0,
+																	  frameworkDestinationURL: $1) }
+
+								return uniqueSourceDestinationPairs(frameworkUrlAndDestinationUrlPairs)
+									.producer
+									.flatMap(.merge) { SignalProducer($0) }
+							}
 					}
-					.flatMap(.merge, self.copyFrameworkToBuildFolder)
-					.flatMap(.merge) { frameworkURL -> SignalProducer<URL, CarthageError> in
-						return self.copyDSYMToBuildFolderForFramework(frameworkURL, fromDirectoryURL: directoryURL)
-							.then(self.copyBCSymbolMapsToBuildFolderForFramework(frameworkURL, fromDirectoryURL: directoryURL))
-							.then(SignalProducer(value: frameworkURL))
+					// Check if the framework are compatible with the current Swift version
+					.flatMap(.merge) { pair -> SignalProducer<SourceURLAndDestinationURL, CarthageError> in
+						return checkFrameworkCompatibility(pair.frameworkSourceURL, usingToolchain: toolchain)
+							.mapError { error in CarthageError.internalError(description: error.description) }
+							.then(SignalProducer<SourceURLAndDestinationURL, CarthageError>(value: pair))
+					}
+					// If the framework is compatible copy it over to the destination folder in Carthage/Build
+					.flatMap(.merge) { pair -> SignalProducer<URL, CarthageError> in
+						return SignalProducer<URL, CarthageError>(value: pair.frameworkSourceURL)
+							.copyFileURLsIntoDirectory(pair.frameworkDestinationURL.deletingLastPathComponent())
+							.then(SignalProducer<URL, CarthageError>(value: pair.frameworkDestinationURL))
+					}
+					// Copy .dSYM & .bcsymbolmap too
+					.flatMap(.merge) { frameworkDestinationURL -> SignalProducer<URL, CarthageError> in
+						return self.copyDSYMToBuildFolderForFramework(frameworkDestinationURL, fromDirectoryURL: directoryURL)
+							.then(self.copyBCSymbolMapsToBuildFolderForFramework(frameworkDestinationURL, fromDirectoryURL: directoryURL))
+							.then(SignalProducer(value: frameworkDestinationURL))
 					}
 					.collect()
+					// Write the .version file
 					.flatMap(.concat) { frameworkURLs -> SignalProducer<(), CarthageError> in
 						return self.createVersionFilesForFrameworks(
 							frameworkURLs,
@@ -712,19 +796,6 @@ public final class Project { // swiftlint:disable:this type_body_length
 			}
 	}
 
-	/// Copies the framework at the given URL into the current project's build
-	/// folder.
-	///
-	/// Sends the URL to the framework after copying.
-	private func copyFrameworkToBuildFolder(_ frameworkURL: URL) -> SignalProducer<URL, CarthageError> {
-		return platformForFramework(frameworkURL)
-			.flatMap(.merge) { platform -> SignalProducer<URL, CarthageError> in
-				let platformFolderURL = self.directoryURL.appendingPathComponent(platform.relativePath, isDirectory: true)
-				return SignalProducer(value: frameworkURL)
-					.copyFileURLsIntoDirectory(platformFolderURL)
-			}
-	}
-
 	/// Copies the DSYM matching the given framework and contained within the
 	/// given directory URL to the directory that the framework resides within.
 	///
@@ -733,6 +804,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 	/// Sends the URL of the dSYM after copying.
 	public func copyDSYMToBuildFolderForFramework(_ frameworkURL: URL, fromDirectoryURL directoryURL: URL) -> SignalProducer<URL, CarthageError> {
 		let destinationDirectoryURL = frameworkURL.deletingLastPathComponent()
+		print(destinationDirectoryURL)
 		return dSYMForFramework(frameworkURL, inDirectoryURL: directoryURL)
 			.copyFileURLsIntoDirectory(destinationDirectoryURL)
 	}

--- a/Source/CarthageKit/XCDBLDExtensions.swift
+++ b/Source/CarthageKit/XCDBLDExtensions.swift
@@ -18,6 +18,13 @@ extension Platform {
 		let subfolderName = rawValue
 		return (Constants.binariesFolderPath as NSString).appendingPathComponent(subfolderName)
 	}
+
+	/// The relative URL at which binaries corresponding to this platform will
+	/// be stored.
+	public var relativeURL: URL? {
+		let subfolderName = rawValue
+		return URL(string: Constants.binariesFolderPath)?.appendingPathComponent(subfolderName, isDirectory: true)
+	}
 }
 
 extension ProjectLocator {


### PR DESCRIPTION
See #2764 in which the archive contains "TealiumIOS.framework" multiple times.