### PR TITLE
Update to README. Pipe `carthage outdated` errors to dev/null

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 1. On your application targets’ _Build Phases_ settings tab, click the _+_ icon and choose _New Run Script Phase_. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
     ```sh
-    /usr/local/bin/carthage copy-frameworks
+    /usr/local/bin/carthage copy-frameworks | 2>/dev/null
     ```
 
 1. Add the paths to the frameworks you want to use under “Input Files". For example:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Additionally, you'll need to copy debug symbols for debugging and crash reportin
 1. On your application targets’ _Build Phases_ settings tab, click the _+_ icon and choose _New Run Script Phase_. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
     ```sh
-    /usr/local/bin/carthage copy-frameworks | 2>/dev/null
+    /usr/local/bin/carthage copy-frameworks
     ```
 
 1. Add the paths to the frameworks you want to use under “Input Files". For example:
@@ -148,7 +148,7 @@ You can add a Run Script phase to automatically warn you when one of your depend
 1. On your application targets’ `Build Phases` settings tab, click the `+` icon and choose `New Run Script Phase`. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
 ```sh
-/usr/local/bin/carthage outdated --xcode-warnings
+/usr/local/bin/carthage outdated --xcode-warnings | 2>/dev/null
 ```
 
 ##### Swift binary framework download compatibility


### PR DESCRIPTION
Update to README. Small addition to the command to run `carthage outdated`. As is, if there is no network connection, it errors causing the build in Xcode to fail. This change pipes errors to dev/null silencing the warning allowing the build to succeed.