### PR TITLE
Installing module manually only

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ With the debug information copied into the built products directory, Xcode will 
 
 When archiving your application for submission to the App Store or TestFlight, Xcode will also copy these files into the dSYMs subdirectory of your application’s `.xcarchive` bundle.
 
+##### If you're building for iOS, tvOS, or watchOS and the there is an option for manual installation
+1. Like above. Create a [Cartfile][] that lists the frameworks you’d like to use in your project.
+1. Run `carthage update --manually`. This will fetch dependencies into a [Carthage/Checkouts][] folder, but the projects won't be build, instead, the source code will be copied to your project directory on subdirectories called `Carthage-PROJECTNAME`.
+1. Just add those directories into your project using `Add Files`.
+
 ##### For both platforms
 
 Along the way, Carthage will have created some [build artifacts][Artifacts]. The most important of these is the [Cartfile.resolved][] file, which lists the versions that were actually built for each framework. **Make sure to commit your [Cartfile.resolved][]**, because anyone else using the project will need that file to build the same framework versions.

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -796,7 +796,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 				}
 
 				let symlinkCheckoutPaths = self.symlinkCheckoutPaths(for: dependency, version: version, withRepository: repositoryURL, atRootDirectory: self.directoryURL)
-                
+
 				if let submodule = submodule {
 					// In the presence of `submodule` for `dependency` — before symlinking, (not after) — add submodule and its submodules:
 					// `dependency`, subdependencies that are submodules, and non-Carthage-housed submodules.

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -944,7 +944,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 	}
 
     /// Check if manually is enable and copy all the source files in the correct directories
-    private func checkAndCopySourceManually(workingDirectoryURL: URL) /*-> SignalProducer<(), CarthageError>*/ {
+    private func checkAndCopySourceManually(workingDirectoryURL: URL) {
         if self.manually {
             // In the presence of manually for update
             if let sourceDirectory = self.sourceDirectory(workingDirectoryURL: workingDirectoryURL) {


### PR DESCRIPTION
#### Background
When installing some repo from Github, users normally get 3 options, cocoapods, carthage and manually. The last one, the developers just explains to copy the `Source` directory to their project and compile it. Most of the github repos include instructions just to copy the source code instead of using cocoapods or carthage. Most developers like the source code to modify without recompile. Helps in debugging, learning and without project modifications.

#### Context
A way to make carthage simpler and easier to download the code you need. 

Example usage:
```
carthage update --manually
```

#### Output
carthage won't compile the produced projects to a framework, instead will copy the Source directory to the project in a new directory called `Carthage-{PROJECTNAME}` where the user can compile inside their project without having to reference any framework. Of course, those are for source code without collisions in classes.

#### Assumptions
- The developer gave instructions the source code can be installed manually by a simple copy
- The developer added all the source code into a directory called `Sources`, `Source`, `Manual`

#### Improvements
- Allow the developer to create a `.manually` file in their repo when the default directory is different than the default name. But just trying to keep it very simple at this time.
