### PR TITLE
Modify packages atomically

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -408,6 +408,35 @@ extension Reactive where Base: FileManager {
 		}
 		.map { URL(fileURLWithPath: $0, isDirectory: true) }
 	}
+  
+  public func copyItem(at: URL, to: URL) -> SignalProducer<URL, CarthageError> {
+    do {
+      try self.base.copyItem(at: at, to: to, avoiding·rdar·32984063: true)
+      return SignalProducer(value: to)
+    } catch {
+      return SignalProducer(error: .internalError(description: "copyItem failed: \(error)"))
+    }
+  }
+  
+  public func removeItem(at itemURL: URL) -> SignalProducer<(), CarthageError> {
+    do {
+      try FileManager().removeItem(at: itemURL)
+      return SignalProducer(.empty)
+    } catch {
+      return SignalProducer(error: .internalError(description: "removeItem failed: \(error)"))
+    }
+  }
+  
+  public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL) -> SignalProducer<URL, CarthageError> {
+    do {
+      guard let url = try FileManager().replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly) else {
+        return SignalProducer(error: .internalError(description: "replaceItem succeeded, but returned nil"))
+      }
+      return SignalProducer(value: url)
+    } catch {
+      return SignalProducer(error: .internalError(description: "replaceItem failed: \(error)"))
+    }
+  }
 }
 
 private let defaultSessionError = NSError(domain: Constants.bundleIdentifier, code: 1, userInfo: nil)


### PR DESCRIPTION
This change is to address https://github.com/Carthage/Carthage/issues/2788

When executing `stripBinary` we need to be careful about other processes modifying the same framework we're working on. To do so, we copy the source into a temporary directory, modify it in place, then copy it to the final resting place.

While there is still a chance another build phase might do the exact same thing, the end result of N copy-then-strip operations should ultimately be the same.