### PR TITLE
Bugfix 2788

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -409,30 +409,22 @@ extension Reactive where Base: FileManager {
 		.map { URL(fileURLWithPath: $0, isDirectory: true) }
 	}
   
-  public func copyItem(at: URL, to: URL) -> SignalProducer<URL, CarthageError> {
+  public func copyItem(_ source: URL, into: URL) -> SignalProducer<URL, CarthageError> {
+    let destination = into.appendingPathComponent(source.lastPathComponent)
     do {
-      try self.base.copyItem(at: at, to: to, avoiding·rdar·32984063: true)
-      return SignalProducer(value: to)
+      try self.base.copyItem(at: source, to: destination, avoiding·rdar·32984063: true)
+      return SignalProducer(value: destination)
     } catch {
       return SignalProducer(error: .internalError(description: "copyItem failed: \(error)"))
     }
   }
   
-  public func removeItem(at itemURL: URL) -> SignalProducer<(), CarthageError> {
+  public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL) -> SignalProducer<(), CarthageError> {
     do {
-      try FileManager().removeItem(at: itemURL)
-      return SignalProducer(.empty)
-    } catch {
-      return SignalProducer(error: .internalError(description: "removeItem failed: \(error)"))
-    }
-  }
-  
-  public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL) -> SignalProducer<URL, CarthageError> {
-    do {
-      guard let url = try FileManager().replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly) else {
+      guard (try FileManager().replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly)) != nil else {
         return SignalProducer(error: .internalError(description: "replaceItem succeeded, but returned nil"))
       }
-      return SignalProducer(value: url)
+      return SignalProducer(.empty)
     } catch {
       return SignalProducer(error: .internalError(description: "replaceItem failed: \(error)"))
     }

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -421,7 +421,7 @@ extension Reactive where Base: FileManager {
   
   public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL) -> SignalProducer<(), CarthageError> {
     do {
-      guard (try FileManager().replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly)) != nil else {
+      guard (try self.base.replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly)) != nil else {
         return SignalProducer(error: .internalError(description: "replaceItem succeeded, but returned nil"))
       }
       return SignalProducer(.empty)

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -408,6 +408,35 @@ extension Reactive where Base: FileManager {
 		}
 		.map { URL(fileURLWithPath: $0, isDirectory: true) }
 	}
+  
+  public func copyItem(at: URL, to: URL) -> SignalProducer<URL, CarthageError> {
+    do {
+      try self.base.copyItem(at: at, to: to, avoiding·rdar·32984063: true)
+      return SignalProducer(value: to)
+    } catch {
+      return SignalProducer(error: .internalError(description: "copyItem failed: \(error)"))
+    }
+  }
+  
+  public func removeItem(at itemURL: URL) -> SignalProducer<(), CarthageError> {
+    do {
+      try FileManager().removeItem(at: itemURL)
+      return SignalProducer(.empty)
+    } catch {
+      return SignalProducer(error: .internalError(description: "removeItem failed: \(error)"))
+    }
+  }
+  
+  public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL) -> SignalProducer<URL, CarthageError> {
+    do {
+      guard let url = try FileManager().replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly) else {
+        return SignalProducer(error: .internalError(description: "replaceItem succeeded, but returned nil"))
+      }
+      return SignalProducer(value: url)
+    } catch {
+      return SignalProducer(error: .internalError(description: "replaceItem failed: \(error)"))
+    }
+  }
 }
 
 private let defaultSessionError = NSError(domain: Constants.bundleIdentifier, code: 1, userInfo: nil)

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1034,12 +1034,12 @@ private func stripBinary(_ binaryURL: URL, keepingArchitectures: [String]) -> Si
   return createTempDir
     .flatMap(.merge) { temp in
       copyItem(binaryURL, temp)
-        .flatMap(.merge) { workspace in
-          strip(workspace, keepingArchitectures)
-            .flatMap(.merge) { workspace in
-              replace(binaryURL, workspace)
-          }
-      }
+    }
+    .flatMap(.merge) { workspace in
+      strip(workspace, keepingArchitectures)
+    }
+    .flatMap(.merge) { workspace in
+      replace(binaryURL, workspace)
   }
 }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1012,7 +1012,7 @@ public func stripDSYM(_ dSYMURL: URL, keepingArchitectures: [String]) -> SignalP
 
 /// Strips a universal file from unexpected architectures.
 private func stripBinary(_ binaryURL: URL, keepingArchitectures: [String]) -> SignalProducer<(), CarthageError> {
-  let fileManager = FileManager().reactive
+  let fileManager = FileManager.default.reactive
   
   let createTempDir: SignalProducer<URL, CarthageError> = fileManager.createTemporaryDirectoryWithTemplate("carthage-lipo-XXXXXX")
   


### PR DESCRIPTION
When stripping frameworks, copy the source into a temporary directory, process it there, and then move it back.

This is a rework of my previous PR, which didn't actually do what I thought it did.