### PR TITLE
Feature/skip archive and custom cartfile

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -16,6 +16,8 @@ public struct BuildOptions {
 	public var useBinaries: Bool
     /// Skip archive when build Device SDK
     public var skipArchive: Bool
+    /// Custom suffix for Cartfile
+    public var custom: String?
     
 	public init(
 		configuration: String,
@@ -24,7 +26,8 @@ public struct BuildOptions {
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
 		useBinaries: Bool = true,
-        skipArchive: Bool = false
+        skipArchive: Bool = false,
+        custom: String? = nil
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -33,5 +36,9 @@ public struct BuildOptions {
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
         self.skipArchive = skipArchive
+        self.custom = custom
+        if let custom = custom {
+            Constants.Project.configure(with: custom)
+        }
 	}
 }

--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -14,14 +14,17 @@ public struct BuildOptions {
 	public var cacheBuilds: Bool
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
-
+    /// Skip archive when build Device SDK
+    public var skipArchive: Bool
+    
 	public init(
 		configuration: String,
 		platforms: Set<Platform> = [],
 		toolchain: String? = nil,
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
-		useBinaries: Bool = true
+		useBinaries: Bool = true,
+        skipArchive: Bool = false
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -29,5 +32,6 @@ public struct BuildOptions {
 		self.derivedDataPath = derivedDataPath
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
+        self.skipArchive = skipArchive
 	}
 }

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -1,9 +1,6 @@
 import Foundation
 import Result
 
-/// The relative path to a project's checked out dependencies.
-public let carthageProjectCheckoutsPath = "Carthage/Checkouts"
-
 /// Represents a Cartfile, which is a specification of a project's dependencies
 /// and any other settings Carthage needs to build it.
 public struct Cartfile {
@@ -21,7 +18,7 @@ public struct Cartfile {
 	/// Returns the location where Cartfile should exist within the given
 	/// directory.
 	public static func url(in directoryURL: URL) -> URL {
-		return directoryURL.appendingPathComponent("Cartfile")
+		return directoryURL.appendingPathComponent(Constants.Project.cartfilePath)
 	}
 
 	/// Attempts to parse Cartfile information from a string.
@@ -141,7 +138,7 @@ public struct ResolvedCartfile {
 	/// Returns the location where Cartfile.resolved should exist within the given
 	/// directory.
 	public static func url(in directoryURL: URL) -> URL {
-		return directoryURL.appendingPathComponent("Cartfile.resolved")
+		return directoryURL.appendingPathComponent(Constants.Project.resolvedCartfilePath)
 	}
 
 	/// Attempts to parse Cartfile.resolved information from a string.

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -5,11 +5,14 @@ import Result
 public struct Constants {
 	/// Carthage's bundle identifier.
 	public static let bundleIdentifier: String = "org.carthage.CarthageKit"
-
+    
 	/// The name of the folder into which Carthage puts binaries it builds (relative
 	/// to the working directory).
-	public static let binariesFolderPath = "Carthage/Build"
-
+    public static internal(set) var binariesFolderPath = "Carthage/Build"
+    
+    /// The relative path to a project's checked out dependencies.
+    public static internal(set) var carthageProjectCheckoutsPath = "Carthage/Checkouts"
+    
 	/// The fallback dependencies URL to be used in case
 	/// the intended ~/Library/Caches/org.carthage.CarthageKit cannot
 	/// be found or created.
@@ -83,14 +86,34 @@ public struct Constants {
 	}
 
 	public struct Project {
-		/// The relative path to a project's Cartfile.
-		public static let cartfilePath = "Cartfile"
-
-		/// The relative path to a project's Cartfile.private.
-		public static let privateCartfilePath = "Cartfile.private"
-
-		/// The relative path to a project's Cartfile.resolved.
-		public static let resolvedCartfilePath = "Cartfile.resolved"
+        
+        public static func configure(with custom: String) {
+            guard !custom.isEmpty else { return }
+            guard custom.lowercased() != "private" && custom.lowercased() != "resolved" && !custom.contains(".") else {
+                fatalError("Invalid custom value: \(custom)")
+            }
+            
+            cartfilePath = "Cartfile\(custom)"
+            privateCartfilePath = "Cartfile\(custom).private"
+            resolvedCartfilePath = "Cartfile\(custom).resolved"
+            
+            Constants.binariesFolderPath = "Carthage\(custom)/Build"
+            Constants.carthageProjectCheckoutsPath = "Carthage\(custom)/Checkouts"
+            
+            self.custom = custom
+        }
+        
+        /// The relative path to a project's Cartfile.
+        public static private(set) var cartfilePath = "Cartfile"
+        
+        /// The relative path to a project's Cartfile.private.
+        public static private(set) var privateCartfilePath = "Cartfile.private"
+        
+        /// The relative path to a project's Cartfile.resolved.
+        public static private(set) var resolvedCartfilePath = "Cartfile.resolved"
+        
+        /// Custom suffix
+        public static private(set) var custom: String?
 
 		/// The text that needs to exist in a GitHub Release asset's name, for it to be
 		/// tried as a binary framework.

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -48,7 +48,7 @@ public enum Dependency: Hashable {
 	/// The path at which this project will be checked out, relative to the
 	/// working directory of the main project.
 	public var relativePath: String {
-		return (carthageProjectCheckoutsPath as NSString).appendingPathComponent(name)
+		return (Constants.carthageProjectCheckoutsPath as NSString).appendingPathComponent(name)
 	}
 }
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1015,12 +1015,12 @@ public final class Project { // swiftlint:disable:this type_body_length
 	) -> SignalProducer<(), CarthageError> {
 		let rawDependencyURL = rootDirectoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 		let dependencyURL = rawDependencyURL.resolvingSymlinksInPath()
-		let dependencyCheckoutsURL = dependencyURL.appendingPathComponent(carthageProjectCheckoutsPath, isDirectory: true).resolvingSymlinksInPath()
+		let dependencyCheckoutsURL = dependencyURL.appendingPathComponent(Constants.carthageProjectCheckoutsPath, isDirectory: true).resolvingSymlinksInPath()
 		let fileManager = FileManager.default
 
 		return self.dependencySet(for: dependency, version: version)
 			// file system objects which might conflict with symlinks
-			.zip(with: list(treeish: version.commitish, atPath: carthageProjectCheckoutsPath, inRepository: repositoryURL)
+			.zip(with: list(treeish: version.commitish, atPath: Constants.carthageProjectCheckoutsPath, inRepository: repositoryURL)
 									.map { (path: String) in (path as NSString).lastPathComponent }
 									.collect()
 			)
@@ -1052,7 +1052,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 
 				for name in names {
 					let dependencyCheckoutURL = dependencyCheckoutsURL.appendingPathComponent(name)
-					let subdirectoryPath = (carthageProjectCheckoutsPath as NSString).appendingPathComponent(name)
+					let subdirectoryPath = (Constants.carthageProjectCheckoutsPath as NSString).appendingPathComponent(name)
 					let linkDestinationPath = relativeLinkDestination(for: dependency, subdirectory: subdirectoryPath)
 
 					let dependencyCheckoutURLResource = try? dependencyCheckoutURL.resourceValues(forKeys: [

--- a/Source/CarthageKit/XCDBLDExtensions.swift
+++ b/Source/CarthageKit/XCDBLDExtensions.swift
@@ -36,7 +36,7 @@ extension ProjectLocator {
 
 		return gitmodulesEntriesInRepository(directoryURL, revision: nil)
 			.map { directoryURL.appendingPathComponent($0.path) }
-			.concat(value: directoryURL.appendingPathComponent(carthageProjectCheckoutsPath))
+			.concat(value: directoryURL.appendingPathComponent(Constants.carthageProjectCheckoutsPath))
 			.collect()
 			.flatMap(.merge) { directoriesToSkip -> SignalProducer<URL, CarthageError> in
 				return FileManager.default.reactive

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -577,7 +577,8 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 		scheme: scheme,
 		configuration: options.configuration,
 		derivedDataPath: options.derivedDataPath,
-		toolchain: options.toolchain
+		toolchain: options.toolchain,
+        skipArchive: options.skipArchive
 	)
 
 	return BuildSettings.SDKsForScheme(scheme, inProject: project)
@@ -772,7 +773,7 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 			//
 			// See https://github.com/Carthage/Carthage/issues/2056
 			// and https://developer.apple.com/library/content/qa/qa1964/_index.html.
-			let xcodebuildAction: BuildArguments.Action = sdk.isDevice ? .archive : .build
+			let xcodebuildAction: BuildArguments.Action = (sdk.isDevice && argsForBuilding.skipArchive != true) ? .archive : .build
 			return BuildSettings.load(with: argsForLoading, for: xcodebuildAction)
 				.filter { settings in
 					// Only copy build products that are frameworks

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -783,7 +783,7 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 
 					// Do not copy build products that originate from the current project's own carthage dependencies
 					let projectURL = URL(fileURLWithPath: projectPath)
-					let dependencyCheckoutDir = workingDirectoryURL.appendingPathComponent(carthageProjectCheckoutsPath, isDirectory: true)
+					let dependencyCheckoutDir = workingDirectoryURL.appendingPathComponent(Constants.carthageProjectCheckoutsPath, isDirectory: true)
 					return !dependencyCheckoutDir.hasSubdirectory(projectURL)
 				}
 				.flatMap(.concat) { settings in resolveSameTargetName(for: settings) }

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -56,13 +56,17 @@ public struct BuildArguments {
 	/// The build setting whether full bitcode should be embedded in the binary.
 	public var bitcodeGenerationMode: BitcodeGenerationMode?
 
+    /// Skip archive when build Device SDK
+    public var skipArchive: Bool?
+    
 	public init(
 		project: ProjectLocator,
 		scheme: Scheme? = nil,
 		configuration: String? = nil,
 		derivedDataPath: String? = nil,
 		sdk: SDK? = nil,
-		toolchain: String? = nil
+		toolchain: String? = nil,
+        skipArchive: Bool? = nil
 	) {
 		self.project = project
 		self.scheme = scheme
@@ -70,6 +74,7 @@ public struct BuildArguments {
 		self.derivedDataPath = derivedDataPath
 		self.sdk = sdk
 		self.toolchain = toolchain
+        self.skipArchive = skipArchive
 	}
 
 	/// The `xcodebuild` invocation corresponding to the receiver.

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -23,6 +23,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
+            <*> mode <| Option<Bool>(key: "skip-archive", defaultValue: false, usage: "Skip archive when build Device SDK")
 	}
 }
 

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -21,9 +21,10 @@ extension BuildOptions: OptionsProtocol {
 			<*> (mode <| Option<BuildPlatform>(key: "platform", defaultValue: .all, usage: platformUsage)).map { $0.platforms }
 			<*> mode <| Option<String?>(key: "toolchain", defaultValue: nil, usage: "the toolchain to build with")
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
-			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
-			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
+			<*> mode <| Option<Bool>(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
+			<*> mode <| Option<Bool>(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
             <*> mode <| Option<Bool>(key: "skip-archive", defaultValue: false, usage: "Skip archive when build Device SDK")
+            <*> mode <| Option<String?>(key: "custom", defaultValue: nil, usage: "Custom suffix for Cartfile")
 	}
 }
 


### PR DESCRIPTION
Features:
1. pass --skip-archive to skip archive framework during build/bootstrap/update if SDK is Device. Speed up 30% build time when develop.
2. pass --custom XXX to custom Cartfile/Cartfile.private/Cartfile.resolved/Carthage Name. Useful when have multi branch eg: develop and master , avoid merge conflict

