### PR TITLE
Bugfix/concurrent dsym stripping

### DIFF
--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -415,10 +415,10 @@ extension Reactive where Base: FileManager {
       try self.base.copyItem(at: source, to: destination, avoiding·rdar·32984063: true)
       return SignalProducer(value: destination)
     } catch {
-      return SignalProducer(error: .internalError(description: "copyItem failed: \(error)"))
+      return SignalProducer(error: .internalError(description: "copyItem failed: \(error)\n\(source)\n\(into)"))
     }
   }
-  
+
   public func replaceItem(at originalItemURL: URL, withItemAt newItemURL: URL) -> SignalProducer<(), CarthageError> {
     do {
       guard (try self.base.replaceItemAt(originalItemURL, withItemAt: newItemURL, backupItemName: nil, options: .usingNewMetadataOnly)) != nil else {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1017,12 +1017,12 @@ private func stripBinary(_ binaryURL: URL, keepingArchitectures: [String]) -> Si
   // same framework.
   //
   // In a nutshell:
-  //  pid 1094 copyProduct(MyFrameworkframework.dSYM)
+  //  pid 1094 copyProduct(MyFramework.framework)
   //  pid 1094 stripArchitecture(armv7)
   //  pid 1094 stripArchitecture(arm64)
-  //  pid 1684 copyProduct(MyFramework.framework.dSYM)
+  //  pid 1684 copyProduct(MyFramework.framework)
   //  pid 1684 stripArchitecture(armv7)
-  //  pid 1916 copyProduct(MyFrameworkframework.dSYM)
+  //  pid 1916 copyProduct(MyFramework.framework)
   //  pid 1916 stripArchitecture(armv7)
   //  pid 1684 stripArchitecture(arm64)
   //  pid 1916 stripArchitecture(arm64)  <-- already stripped, so an error occurs
@@ -1030,7 +1030,7 @@ private func stripBinary(_ binaryURL: URL, keepingArchitectures: [String]) -> Si
   //  A shell task (/usr/bin/xcrun lipo -remove armv7 […] failed with exit code 1:
   //  fatal error: […]MyFramework.framework does not contain that architecture
   //
-  // So we copy it to /tmp, modify it there, and copy it back to thie original
+  // So we copy it to /tmp, modify it there, and copy it back to the original
   // location. Problem averted!
 
   let fileManager = FileManager.default.reactive


### PR DESCRIPTION
The previous fix for concurrency was slightly flawed.

It turns out the dSYMs introduce a wrinkle: They are all copied to ($BUILT_PRODUCTS_DIR), regardless of where the frameworks go, so that whole lipo scenario still exists. After many overly-complex attempts to handle cross-process & cross-thread locking, I came up with a simplified solution.
 
 - Continue to do all the work in tmp
 - Check to see if the product in tmp is exactly the same as the destination
 - If not, overwrite the dest (this handles updates to an existing dSYM)
