### PR TITLE
WIP - Create single XCFramework for all platforms

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -15,13 +15,17 @@ public struct BuildOptions {
 	/// Whether to use downloaded binaries if possible.
 	public var useBinaries: Bool
 
+	/// Whether to use xcframeworks or not
+	public var useXCFrameworks: Bool
+
 	public init(
 		configuration: String,
 		platforms: Set<Platform> = [],
 		toolchain: String? = nil,
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
-		useBinaries: Bool = true
+		useBinaries: Bool = true,
+		useXCFrameworks: Bool = false
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -29,5 +33,6 @@ public struct BuildOptions {
 		self.derivedDataPath = derivedDataPath
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
+		self.useXCFrameworks = useXCFrameworks
 	}
 }

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -217,8 +217,8 @@ public struct BuildSettings {
 		}
 
 		// TODO: could use self["variant"] maybe, is SDK is passed with variant
-		let isUIKitForMac = (self.supportsUIKitForMac.value ?? false) && (self["SDK_NAME"].map { $0.contains("macos") }.value ?? false)
-		let path = (basePath as NSString).appendingPathComponent(isUIKitForMac ? "\(pathComponent)-uikitformac" : pathComponent)
+		let isMacCatalyst = (self.supportsMacCatalyst.value ?? false) && (self["SDK_NAME"].map { $0.contains("macos") }.value ?? false)
+		let path = (basePath as NSString).appendingPathComponent(isMacCatalyst ? "\(pathComponent)-maccatalyst" : pathComponent)
 		return .success(path)
 	}
 
@@ -300,8 +300,8 @@ public struct BuildSettings {
 	}
 
 	/// Attepts to determine if UIKit for Mac is supported
-	public var supportsUIKitForMac: Result<Bool, CarthageError> {
-		self["SUPPORTS_UIKITFORMAC"].map { $0 == "YES" }
+	public var supportsMacCatalyst: Result<Bool, CarthageError> {
+		self["SUPPORTS_MACCATALYST"].map { $0 == "YES" }
 	}
 
 	/// Add subdirectory path if it's not possible to paste product to destination path

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -216,7 +216,9 @@ public struct BuildSettings {
 			pathComponent = "\(configuration)\(effectivePlatformName)"
 		}
 
-		let path = (basePath as NSString).appendingPathComponent(pathComponent)
+		// TODO: could use self["variant"] maybe, is SDK is passed with variant
+		let isUIKitForMac = (self.supportsUIKitForMac.value ?? false) && (self["SDK_NAME"].map { $0.contains("macos") }.value ?? false)
+		let path = (basePath as NSString).appendingPathComponent(isUIKitForMac ? "\(pathComponent)-uikitformac" : pathComponent)
 		return .success(path)
 	}
 

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -297,6 +297,11 @@ public struct BuildSettings {
 		return self["TARGET_BUILD_DIR"]
 	}
 
+	/// Attepts to determine if UIKit for Mac is supported
+	public var supportsUIKitForMac: Result<Bool, CarthageError> {
+		self["SUPPORTS_UIKITFORMAC"].map { $0 == "YES" }
+	}
+
 	/// Add subdirectory path if it's not possible to paste product to destination path
 	public func productDestinationPath(in destinationURL: URL) -> URL {
 		let directoryURL: URL

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -241,6 +241,11 @@ public struct BuildSettings {
 		return self["WRAPPER_NAME"]
 	}
 
+	/// Attempts to determine the name of the built product's wrapper bundle replacing "framework" with "xcframework".
+	public var xcFrameworkWrapperName: Result<String, CarthageError> {
+		return self["WRAPPER_NAME"].map { $0.spm_dropSuffix(".framework").appending(".xcframework") }
+	}
+
 	/// Attempts to determine the URL to the built product's wrapper, corresponding
 	/// to its xcodebuild action.
 	public var wrapperURL: Result<URL, CarthageError> {

--- a/Source/CarthageKit/FrameworkExtensions.swift
+++ b/Source/CarthageKit/FrameworkExtensions.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
+import XCDBLD
 
 extension String {
 	/// Returns a producer that will enumerate each line of the receiver, then
@@ -295,14 +296,50 @@ extension URL {
 
 	/// Returns the first `URL` to match `<self>/Headers/*-Swift.h`. Otherwise `nil`.
 	internal func swiftHeaderURL() -> URL? {
-		let headersURL = self.appendingPathComponent("Headers", isDirectory: true).resolvingSymlinksInPath()
+
+		var libraryIdentifier: String = ""
+		var libraryPath: String = ""
+		if self.pathExtension == "xcframework" {
+			let xcFrameworkInfo = Bundle(url: self)?
+				.infoDictionary
+				.flatMap(XCFrameworkInfo.init)
+			let firstLibrary =  xcFrameworkInfo?
+				.availableLibraries
+				.first
+			libraryIdentifier = firstLibrary?
+				.identifier ?? ""
+			libraryPath = firstLibrary?.path ?? ""
+		}
+
+		let headersURL = self.appendingPathComponent(libraryIdentifier)
+			.appendingPathComponent(libraryPath)
+			.appendingPathComponent("Headers", isDirectory: true)
+			.resolvingSymlinksInPath()
 		let dirContents = try? FileManager.default.contentsOfDirectory(at: headersURL, includingPropertiesForKeys: [], options: [])
 		return dirContents?.first { $0.absoluteString.contains("-Swift.h") }
 	}
 
 	/// Returns the first `URL` to match `<self>/Modules/*.swiftmodule`. Otherwise `nil`.
 	internal func swiftmoduleURL() -> URL? {
-		let headersURL = self.appendingPathComponent("Modules", isDirectory: true).resolvingSymlinksInPath()
+
+		var libraryIdentifier: String = ""
+		var libraryPath: String = ""
+		if self.pathExtension == "xcframework" {
+			let xcFrameworkInfo = Bundle(url: self)?
+				.infoDictionary
+				.flatMap(XCFrameworkInfo.init)
+			let firstLibrary =  xcFrameworkInfo?
+				.availableLibraries
+				.first
+			libraryIdentifier = firstLibrary?
+				.identifier ?? ""
+			libraryPath = firstLibrary?.path ?? ""
+		}
+
+		let headersURL = self.appendingPathComponent(libraryIdentifier)
+			.appendingPathComponent(libraryPath)
+			.appendingPathComponent("Modules", isDirectory: true)
+			.resolvingSymlinksInPath()
 		let dirContents = try? FileManager.default.contentsOfDirectory(at: headersURL, includingPropertiesForKeys: [], options: [])
 		return dirContents?.first { $0.absoluteString.contains("swiftmodule") }
 	}

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -3,6 +3,7 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import XCDBLD
+import CommonCrypto
 
 struct CachedFramework: Codable {
 	enum CodingKeys: String, CodingKey {
@@ -417,12 +418,52 @@ public func createVersionFileForCommitish(
 				return frameworkSwiftVersionIfIsSwiftFramework(url)
 					.mapError { swiftVersionError -> CarthageError in .unknownFrameworkSwiftVersion(swiftVersionError.description) }
 					.flatMap(.merge) { frameworkSwiftVersion -> SignalProducer<(String, FrameworkDetail), CarthageError> in
-					let frameworkDetail: FrameworkDetail = .init(platformName: platformName,
+						let frameworkDetail: FrameworkDetail = .init(platformName: platformName,
 										     frameworkName: frameworkName,
 										     frameworkSwiftVersion: frameworkSwiftVersion)
-					let details = SignalProducer<FrameworkDetail, CarthageError>(value: frameworkDetail)
-					let binaryURL = url.appendingPathComponent(frameworkName, isDirectory: false)
-					return SignalProducer.zip(hashForFileAtURL(binaryURL), details)
+						let details = SignalProducer<FrameworkDetail, CarthageError>(value: frameworkDetail)
+
+						guard let bundle = Bundle(url: url),
+							let packageType = bundle.packageType else {
+							return SignalProducer<(String, FrameworkDetail), CarthageError>(error: .internalError(description: "\(url) is not a valid bundle."))
+						}
+						switch packageType {
+
+						case .framework, .bundle:
+							let binaryURL = bundle.executableURL!
+							return SignalProducer.zip(hashForFileAtURL(binaryURL), details)
+						case .xcFramework:
+							guard let xcFrameworkInfo = bundle.infoDictionary.flatMap(XCFrameworkInfo.init) else {
+								return SignalProducer<(String, FrameworkDetail), CarthageError>(error: .internalError(description: "\(url) cannot parse xcframework Info.plist"))
+							}
+
+							let sha256Context = UnsafeMutablePointer<CC_SHA256_CTX>.allocate(capacity: 1)
+							CC_SHA256_Init(sha256Context)
+
+							let cumulativeHashProducer = SignalProducer<XCFrameworkLibrary, CarthageError>(xcFrameworkInfo.availableLibraries)
+								.map { ($0.identifier as NSString).appendingPathComponent($0.path) as String }
+								.map { bundle.bundleURL.appendingPathComponent($0) }
+								.map { Bundle(url: $0)!.executableURL! }
+								.flatMap(.merge, hashForFileAtURL)
+								.map { $0.data(using: .utf8)! }
+								.reduce(into: sha256Context) { sha256Context, data in
+									var mutableData = data
+									CC_SHA256_Update(sha256Context, &mutableData, UInt32(mutableData.count)) }
+								.map { ctx -> String in
+									let sha56hash = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(CC_SHA256_DIGEST_LENGTH))
+									CC_SHA256_Final(sha56hash, ctx)
+									let data = Data(bytes: sha56hash, count: Int(CC_SHA256_DIGEST_LENGTH))
+									sha56hash.deallocate()
+									sha256Context.deallocate()
+
+									return data.reduce("") {$0 + String(format: "%02x", $1)}
+
+								}
+
+							return SignalProducer.zip(cumulativeHashProducer, details)
+						default:
+							 return SignalProducer<(String, FrameworkDetail), CarthageError>(error: .internalError(description: "\(url) is not a supported bundle."))
+						}
 				}
 			}
 			.reduce(into: platformCaches) { (platformCaches: inout [String: [CachedFramework]], values: (String, FrameworkDetail)) in

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -704,18 +704,18 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 						}
 					}
 					.flatMapTaskEvents(.concat) { deviceSettings, simulatorSettings in
-
 						if options.useXCFrameworks {
+							let frameworkURLs = (deviceSettings.wrapperURL.fanout(simulatorSettings.wrapperURL))
+								.map { [ $0, $1 ] }
+							let outputURL = deviceSettings
+								.xcFrameworkWrapperName
+								.map(folderURL.appendingPathComponent)
 
-							let r = folderURL.appendingPathComponent(deviceSettings.wrapperName.value!.spm_dropSuffix("framework")+"xcframework")
-							let rP = SignalProducer<URL, CarthageError>(value: r)
-							return createXCFramework(
-								[deviceSettings.wrapperURL.value!, simulatorSettings.wrapperURL.value!],
-								r
-							).then(rP)
+							return SignalProducer(result: frameworkURLs.fanout(outputURL))
+								.flatMap(.merge, createXCFramework)
+								.then(SignalProducer(result: outputURL))
 						}
 						else {
-
 							return mergeBuildProducts(
 								deviceBuildSettings: deviceSettings,
 								simulatorBuildSettings: simulatorSettings,

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -297,6 +297,9 @@ internal enum PackageType: String {
 
 	/// A .dSYM package.
 	case dSYM = "dSYM"
+
+	/// A .xcframework
+	case xcFramework = "XFWK"
 }
 
 /// Finds the built product for the given settings, then copies it (preserving

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -658,6 +658,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 				sdksByPlatform[platform] = [sdk]
 			}
 		}
+		/*
 		.flatMap(.concat) { sdksByPlatform -> SignalProducer<(Platform, [SDK]), CarthageError> in
 			if sdksByPlatform.isEmpty {
 				fatalError("No SDKs found for scheme \(scheme)")
@@ -889,6 +890,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 				}
 				.then(SignalProducer<URL, CarthageError>(value: builtProductURL))
 		}
+		*/
 }
 
 /// Fixes problem when more than one xcode target has the same Product name for same Deployment target and configuration by deleting TARGET_BUILD_DIR.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -921,6 +921,16 @@ private func build(sdk: SDK,
 	var argsForLoading = buildArgs
 	argsForLoading.sdk = sdk
 
+	var buildFolderName = sdk.platform.rawValue
+
+	if buildFolderName == "Mac" && isUIKitForMac {
+		buildFolderName = "UIKitForMac"
+	} else if sdk.isSimulator {
+		buildFolderName += "Simulator"
+	}
+
+	argsForLoading.buildFolderName = buildFolderName
+
 	var argsForBuilding = argsForLoading
 	argsForBuilding.onlyActiveArchitecture = false
 

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -106,9 +106,9 @@ public struct BuildArguments {
 			// Since we wouldn't be trying to build this target unless it were
 			// for macOS already, just let xcodebuild figure out the SDK on its
 			// own.
-			if sdk != .macOSX {
+//			if sdk != .macOSX {
 				args += [ "-sdk", sdk.rawValue ]
-			}
+//			}
 		}
 
 		if let toolchain = toolchain {

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -74,6 +74,30 @@ public struct BuildArguments {
 
 	/// The `xcodebuild` invocation corresponding to the receiver.
 	public var arguments: [String] {
+
+		var args = rawArguments
+
+		if let sdk = sdk {
+			// Passing in -sdk macosx appears to break implicit dependency
+			// resolution (see Carthage/Carthage#347).
+			//
+			// Since we wouldn't be trying to build this target unless it were
+			// for macOS already, just let xcodebuild figure out the SDK on its
+			// own.
+			if sdk == .macOSX, let sdkIndex = args.firstIndex(where: { $0 == "-sdk"} ) {
+
+				if sdkIndex + 1 < args.count {
+					args.remove(at: sdkIndex) // remove -skd
+					args.remove(at: sdkIndex) // remove paramter
+				}
+			}
+		}
+
+		return args
+	}
+
+	public var rawArguments: [String] {
+
 		var args = [ "xcodebuild" ]
 
 		switch project {
@@ -100,15 +124,7 @@ public struct BuildArguments {
 		}
 
 		if let sdk = sdk {
-			// Passing in -sdk macosx appears to break implicit dependency
-			// resolution (see Carthage/Carthage#347).
-			//
-			// Since we wouldn't be trying to build this target unless it were
-			// for macOS already, just let xcodebuild figure out the SDK on its
-			// own.
-//			if sdk != .macOSX {
-				args += [ "-sdk", sdk.rawValue ]
-//			}
+			args += [ "-sdk", sdk.rawValue ]
 		}
 
 		if let toolchain = toolchain {

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -37,6 +37,9 @@ public struct BuildArguments {
 	/// The path to the derived data.
 	public var derivedDataPath: String?
 
+	/// The name of the temporary folder used to build for a platform.
+	public var buildFolderName: String?
+
 	/// The platform SDK to build for.
 	public var sdk: SDK?
 
@@ -117,9 +120,13 @@ public struct BuildArguments {
 		}
 
 		if let derivedDataPath = derivedDataPath {
-			let standarizedPath = URL(fileURLWithPath: (derivedDataPath as NSString).expandingTildeInPath).standardizedFileURL.path
-			if !derivedDataPath.isEmpty && !standarizedPath.isEmpty {
-				args += [ "-derivedDataPath", standarizedPath ]
+			var standardizedPath = URL(fileURLWithPath: (derivedDataPath as NSString).expandingTildeInPath).standardizedFileURL.path
+			if !derivedDataPath.isEmpty && !standardizedPath.isEmpty {
+				if let buildFolderName = buildFolderName {
+					standardizedPath = (standardizedPath as NSString).appendingPathComponent(buildFolderName)
+				}
+
+				args += [ "-derivedDataPath", standardizedPath ]
 			}
 		}
 
@@ -152,6 +159,10 @@ public struct BuildArguments {
 		args += [ "CODE_SIGNING_REQUIRED=NO", "CODE_SIGN_IDENTITY=" ]
 
 		args += [ "CARTHAGE=YES" ]
+
+		if let buildFolderName = buildFolderName {
+			args += [ "BUILD_FOLDER_NAME=\(buildFolderName)" ]
+		}
 
 		return args
 	}

--- a/Source/XCDBLD/XCFrameworkInfo.swift
+++ b/Source/XCDBLD/XCFrameworkInfo.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public enum XCFrameworkPlatformVariant: String {
+	case simulator
+}
+
+public struct XCFrameworkLibrary {
+
+	public let identifier: String
+	public let path: String
+	public let supportedArchitectures: [String]
+	public let supportedPlatform: Platform
+	public let supportedSDK: SDK
+
+	public init?(_ dictionary: [String: Any]) {
+
+		guard let identifier = dictionary["LibraryIdentifier"] as? String,
+			let path = dictionary["LibraryPath"] as? String,
+			let supportedArchs = dictionary["SupportedArchitectures"] as? [String],
+			let supportPlatform = dictionary["SupportedPlatform"] as? String else {
+				return nil
+		}
+
+		let supportedPlatformVariant = dictionary["SupportedPlatformVariant"] as? XCFrameworkPlatformVariant
+		guard let supportedPlatform = Platform(platform: supportPlatform),
+			let sdk = SDK(platform: supportedPlatform, variant: supportedPlatformVariant) else {
+				return nil
+		}
+
+		self.identifier = identifier
+		self.path = path
+		self.supportedArchitectures = supportedArchs
+		self.supportedPlatform = supportedPlatform
+		self.supportedSDK = sdk
+	}
+}
+
+fileprivate extension Platform {
+
+	static var aliases: [String : Platform] {
+		["ios" : .iOS,
+		 "macos" : .macOS,
+		 "watchos" : .watchOS,
+		 "tvos" : .tvOS
+		]
+	}
+
+	init?(platform: String) {
+
+		guard let vanillaPlatform = Platform(rawValue: platform) else {
+			guard let aliasedPlatfrom = Platform.aliases[platform] else {
+				return nil
+			}
+			self = aliasedPlatfrom
+			return
+		}
+		self = vanillaPlatform
+	}
+}
+
+fileprivate extension SDK {
+
+	init?(platform: Platform, variant: XCFrameworkPlatformVariant?) {
+
+		let isSimulatorVariant = variant != nil && variant! == .simulator
+
+		switch platform {
+			case .iOS:
+				self = isSimulatorVariant ? .iPhoneSimulator : .iPhoneOS
+			case .macOS:
+				guard !isSimulatorVariant else { return nil }
+				self = .macOSX
+			case .tvOS:
+				self = isSimulatorVariant ? .tvSimulator : .tvOS
+			case .watchOS:
+				self = isSimulatorVariant ? .watchSimulator : .watchOS
+		}
+	}
+}
+
+/// Represents the information parsed from the Info.plist of an .xcframework bundle
+public struct XCFrameworkInfo {
+
+	public let formatVersion: String
+	public let packageTypeString: String
+	public let availableLibraries: [XCFrameworkLibrary]
+
+	public init?(_ dictionary: [String: Any]) {
+
+		guard let formatVersion = dictionary["XCFrameworkFormatVersion"] as? String,
+			let packageType = dictionary["CFBundlePackageType"] as? String,
+			let avalableLibraries = (dictionary["AvailableLibraries"] as? [[String : Any]])
+				.flatMap({ libDicts in libDicts.compactMap(XCFrameworkLibrary.init) }) else {
+				return nil
+		}
+
+		self.formatVersion = formatVersion
+		self.packageTypeString = packageType
+		self.availableLibraries = avalableLibraries
+	}
+}

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -65,7 +65,7 @@ public struct ArchiveCommand: CommandProtocol {
 					if let wrapperName = settings.wrapperName.value,
 						let xcFrameworkWrapperName = settings.xcFrameworkWrapperName.value,
 						settings.productType.value == .framework {
-						return .init(value: options.createXCFramework ?xcFrameworkWrapperName : wrapperName)
+						return .init(value: options.createXCFramework ? xcFrameworkWrapperName : wrapperName)
 					} else {
 						return .empty
 					}

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -86,7 +86,12 @@ public struct ArchiveCommand: CommandProtocol {
 					}
 				}
 				.map { relativePath -> (relativePath: String, absolutePath: String) in
-					let absolutePath = (options.directoryPath as NSString).appendingPathComponent(relativePath)
+					var absolutePath = options.directoryPath
+
+					if false {
+						absolutePath = (absolutePath as NSString).appendingPathComponent(relativePath)
+					}
+
 					return (relativePath, absolutePath)
 				}
 				.filter { filePath in FileManager.default.fileExists(atPath: filePath.absolutePath) }

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -78,6 +78,10 @@ public struct ArchiveCommand: CommandProtocol {
 			return SignalProducer<Platform, CarthageError>(Platform.supportedPlatforms)
 				.flatMap(.merge) { platform -> SignalProducer<String, CarthageError> in
 					return SignalProducer(frameworks).map { framework in
+						if true {
+							return framework
+						}
+
 						return (platform.relativePath as NSString).appendingPathComponent(framework)
 					}
 				}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -45,7 +45,11 @@ public struct BuildCommand: CommandProtocol {
 		/// Otherwise, this producer will be empty.
 		public var archiveProducer: SignalProducer<(), CarthageError> {
 			if archive {
-				let options = ArchiveCommand.Options(outputPath: nil, directoryPath: directoryPath, colorOptions: colorOptions, frameworkNames: [])
+				let options = ArchiveCommand.Options(outputPath: nil,
+													 directoryPath: directoryPath,
+													 colorOptions: colorOptions,
+													 createXCFramework: buildOptions.useXCFrameworks,
+													 frameworkNames: [])
 				return ArchiveCommand().archiveWithOptions(options)
 			} else {
 				return .empty

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -23,6 +23,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option<String?>(key: "derived-data", defaultValue: nil, usage: "path to the custom derived data folder")
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
+			<*> mode <| Option(key: "create-xcframework", defaultValue: false, usage: "create an .xcframework instead of a fat binary")
 	}
 }
 

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -65,15 +65,18 @@ public struct UpdateCommand: CommandProtocol {
 			let buildDescription = "skip the building of dependencies after updating\n(ignored if --no-checkout option is present)"
 
 			let dependenciesUsage = "the dependency names to update, checkout and build"
+			let defaultValue: String? = nil
 
-			return curry(Options.init)
-				<*> mode <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
-				<*> mode <| Option(key: "build", defaultValue: true, usage: buildDescription)
-				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
-				<*> mode <| Option(key: "log-path", defaultValue: nil, usage: "path to the xcode build output. A temporary file is used by default")
-				<*> mode <| Option(key: "new-resolver", defaultValue: false, usage: "use the new resolver codeline when calculating dependencies. Default is false")
-				<*> BuildOptions.evaluate(mode, addendum: "\n(ignored if --no-build option is present)")
-				<*> CheckoutCommand.Options.evaluate(mode, dependenciesUsage: dependenciesUsage)
+			let options: Result<Options, CommandantError<CarthageError>> = curry(Options.init)
+							<*> mode <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
+							<*> mode <| Option(key: "build", defaultValue: true, usage: buildDescription)
+							<*> mode <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
+							<*> mode <| Option(key: "log-path", defaultValue: defaultValue, usage: "path to the xcode build output. A temporary file is used by default")
+							<*> mode <| Option(key: "new-resolver", defaultValue: false, usage: "use the new resolver codeline when calculating dependencies. Default is false")
+							<*> BuildOptions.evaluate(mode, addendum: "\n(ignored if --no-build option is present)")
+							<*> CheckoutCommand.Options.evaluate(mode, dependenciesUsage: dependenciesUsage)
+
+			return options
 		}
 
 		/// Attempts to load the project referenced by the options, and configure it

--- a/Tests/CarthageKitTests/ArchiveSpec.swift
+++ b/Tests/CarthageKitTests/ArchiveSpec.swift
@@ -7,6 +7,7 @@ import ReactiveSwift
 class ArchiveSpec: QuickSpec {
 	override func spec() {
 		describe("unzipping") {
+			print(Bundle(for: type(of: self)))
 			let archiveURL = Bundle(for: type(of: self)).url(forResource: "CartfilePrivateOnly", withExtension: "zip")!
 
 			it("should unzip archive to a temporary directory") {


### PR DESCRIPTION
This is based upon @blender's PR for adding support for XCFrameworks #2801 

Current known issues that need to be fixed:

- [ ] Current implementation only builds a single XCFramework with all combined platforms and does not currently support building frameworks split by platform
- [ ] Current implementation must have a derived data directory set in order to avoid issues with builds locking files on each other

I made a design decision to output the combined XCFramework to the `Carthage/Build` folder and would appreciate input on that decision.