### PR TITLE
Fix building with SPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       language: objective-c
       osx_image: xcode10.1
       script:
-        - make test
+        - make clean && SWIFTPM_BOOTSTRAP=true make test
       env: JOB=CI_TEST_10_1
     - os: osx
       language: objective-c
@@ -22,7 +22,7 @@ matrix:
       script:
         - brew uninstall carthage
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install bats
-        - make install
+        - make clean && SWIFTPM_BOOTSTRAP=true make install
         - bats IntegrationTests
       env:
         - JOB=CI_INTEGRATION_TESTS

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ OUTPUT_PACKAGE=Carthage.pkg
 CARTHAGE_EXECUTABLE=./.build/release/carthage
 BINARIES_FOLDER=/usr/local/bin
 
-SWIFT_BUILD_FLAGS=--configuration release -Xswiftc -suppress-warnings
+PWD := $(shell pwd)
+SWIFT_BUILD_FLAGS=--skip-update --configuration release -Xswiftc -suppress-warnings
 
 SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED:=$(shell test -n "$${HOMEBREW_SDKROOT}" && echo should_be_flagged)
 ifeq ($(SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED), should_be_flagged)
@@ -39,17 +40,20 @@ all: installables
 
 clean:
 	swift package clean
+	swift package reset
 
 test:
 	$(RM_SAFELY) ./.build/debug/CarthagePackageTests.xctest
-	swift build --build-tests -Xswiftc -suppress-warnings
+	swift package --skip-update resolve
+	swift build --skip-update --build-tests -Xswiftc -suppress-warnings -Xswiftc -Xcc -Xswiftc -fmodule-map-file=$(PWD)/`find .build/checkouts -name "swift-llbuild.git*"`/products/libllbuild/include/module.modulemap
 	$(CP) -R Tests/CarthageKitTests/Resources ./.build/debug/CarthagePackageTests.xctest/Contents
 	$(CP) Tests/CarthageKitTests/fixtures/CartfilePrivateOnly.zip ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
 	script/copy-fixtures ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
 	swift test --skip-build
 
 installables:
-	swift build $(SWIFT_BUILD_FLAGS)
+	swift package --skip-update resolve
+	swift build $(SWIFT_BUILD_FLAGS) -Xswiftc -Xcc -Xswiftc -fmodule-map-file=$(PWD)/`find .build/checkouts -name "swift-llbuild.git*"`/products/libllbuild/include/module.modulemap
 
 package: installables
 	$(MKDIR) "$(CARTHAGE_TEMPORARY_FOLDER)$(BINARIES_FOLDER)"

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {
@@ -77,7 +77,7 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "3aeecb428d202afe15633266dc862de27feab723",
           "version": null
         }

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
         .package(url: "https://github.com/apple/swift-package-manager.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a")),
+        .package(url: "https://github.com/apple/swift-llbuild.git", .revision("3aeecb428d202afe15633266dc862de27feab723")),
     ],
     targets: [
         .target(
@@ -31,7 +32,7 @@ let package = Package(
         ),
         .target(
             name: "CarthageKit",
-            dependencies: ["XCDBLD", "Tentacle", "Curry", "SwiftPM-auto"]
+            dependencies: ["XCDBLD", "Tentacle", "Curry", "SwiftPM-auto", "llbuildSwift"]
         ),
         .testTarget(
             name: "CarthageKitTests",


### PR DESCRIPTION
# What happened?
[swift-llbuild](https://github.com/apple/swift-llbuild.git)'s Package.swift was updated to Swift 5. This in combination with `swift build` __automatically updating dependencies__ prevents carthage from building with SwiftPM.

# Solution 

First, to stop SwiftPM from updating dependencies, it is necessary to add `--skip-update`.

Unfortunately however that's not enough for carthage to build. SwiftPM itself [adds a very nasty dependency to swift-llbuild master](https://github.com/apple/swift-package-manager/blob/916450f7e8a5aef13630edf9e6fc0b16ed9f5f65/Package.swift#L262)

To prevent that from happening it's enough to set `SWIFTPM_BOOTSTRAP` environment variable, however this completely removes swift-llbuild from the dependency graph.

To keep swift-llbuild in the dependency graph it's necessary to add it explicitly as a dependency.

However, that also is not enough as SwiftPM won't build anymore because of missing dependency on swift-llbuild. To prevent this, it is first necessary to ask SwiftPM to resolve the dependencies at the right version (without updating), then find the checkout directory of swift-llbuild and finally pass the location of it's modulemap to all swiftc commands.

#### Personal remarks

I would have not expected any of this to happen, since builds are supposed to be reproducible. I believe there are serious issue with how SwiftPM behaves, [some clarification is needed](https://forums.swift.org/t/about-reproducible-builds/26957).