### PR TITLE
Remove pipe in carthage outdated step

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can add a Run Script phase to automatically warn you when one of your depend
 1. On your application targets’ `Build Phases` settings tab, click the `+` icon and choose `New Run Script Phase`. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
 ```sh
-/usr/local/bin/carthage outdated --xcode-warnings | 2>/dev/null
+/usr/local/bin/carthage outdated --xcode-warnings 2>/dev/null
 ```
 
 ##### Swift binary framework download compatibility


### PR DESCRIPTION
The snippet in **README.md** to add to the build phase is wrong by one pipe (`|`)

I'm not sure what a pipe does in this scenario, but it is not the right thing. Bash seems to take `echo "foo" | 2>/dev/null` and alias 2 to be a `cd` command. If one wants to redirect `stderr` to **/dev/null**, one only needs `2>/dev/null`. Before this change. all the output from the outdated dependencies step is swallowed and nothing gets added to Xcode. After, the warnings will show up in the console, but no network connection doesn't cause build failures (https://github.com/Carthage/Carthage/commit/70f5b2c51c78fb5440155346063f792347c893d9#diff-04c6e90faac2675aa89e2176d2eec7d8)
