### PR TITLE
Fix fetching race condition

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -836,53 +836,56 @@ public final class Project { // swiftlint:disable:this type_body_length
 
 	/// Checks out the given dependency into its intended working directory,
 	/// cloning it first if need be.
-	private func checkoutOrCloneDependency(
+	private func checkoutDependency(
 		_ dependency: Dependency,
 		version: PinnedVersion,
 		submodulesByPath: [String: Submodule]
 	) -> SignalProducer<(), CarthageError> {
 		let revision = version.commitish
-		return cloneOrFetchDependency(dependency, commitish: revision)
-			.flatMap(.merge) { repositoryURL -> SignalProducer<(), CarthageError> in
-				let workingDirectoryURL = self.directoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
+		let repositoryURL = repositoryFileURL(for: dependency)
 
-				/// The submodule for an already existing submodule at dependency project’s path
-				/// or the submodule to be added at this path given the `--use-submodules` flag.
-				let submodule: Submodule?
+		let producer = { () -> SignalProducer<(), CarthageError> in
+			let workingDirectoryURL = self.directoryURL.appendingPathComponent(dependency.relativePath, isDirectory: true)
 
-				if var foundSubmodule = submodulesByPath[dependency.relativePath] {
-					foundSubmodule.url = dependency.gitURL(preferHTTPS: self.preferHTTPS)!
-					foundSubmodule.sha = revision
-					submodule = foundSubmodule
-				} else if self.useSubmodules {
-					submodule = Submodule(name: dependency.relativePath, path: dependency.relativePath, url: dependency.gitURL(preferHTTPS: self.preferHTTPS)!, sha: revision)
-				} else {
-					submodule = nil
-				}
+			/// The submodule for an already existing submodule at dependency project’s path
+			/// or the submodule to be added at this path given the `--use-submodules` flag.
+			let submodule: Submodule?
 
-				let symlinkCheckoutPaths = self.symlinkCheckoutPaths(for: dependency, version: version, withRepository: repositoryURL, atRootDirectory: self.directoryURL)
-
-				if let submodule = submodule {
-					// In the presence of `submodule` for `dependency` — before symlinking, (not after) — add submodule and its submodules:
-					// `dependency`, subdependencies that are submodules, and non-Carthage-housed submodules.
-					return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path))
-						.startOnQueue(self.gitOperationQueue)
-						.then(symlinkCheckoutPaths)
-				} else {
-					return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, force: true, revision: revision)
-						// For checkouts of “ideally bare” repositories of `dependency`, we add its submodules by cloning ourselves, after symlinking.
-						.then(symlinkCheckoutPaths)
-						.then(
-							submodulesInRepository(repositoryURL, revision: revision)
-								.flatMap(.merge) {
-									return cloneSubmoduleInWorkingDirectory($0, workingDirectoryURL, cacheURLMap: { (gitURL: GitURL) in
-										let dependency = Dependency.git(gitURL)
-										return repositoryFileURL(for: dependency)
-									})
-								}
-						)
-				}
+			if var foundSubmodule = submodulesByPath[dependency.relativePath] {
+				foundSubmodule.url = dependency.gitURL(preferHTTPS: self.preferHTTPS)!
+				foundSubmodule.sha = revision
+				submodule = foundSubmodule
+			} else if self.useSubmodules {
+				submodule = Submodule(name: dependency.relativePath, path: dependency.relativePath, url: dependency.gitURL(preferHTTPS: self.preferHTTPS)!, sha: revision)
+			} else {
+				submodule = nil
 			}
+
+			let symlinkCheckoutPaths = self.symlinkCheckoutPaths(for: dependency, version: version, withRepository: repositoryURL, atRootDirectory: self.directoryURL)
+
+			if let submodule = submodule {
+				// In the presence of `submodule` for `dependency` — before symlinking, (not after) — add submodule and its submodules:
+				// `dependency`, subdependencies that are submodules, and non-Carthage-housed submodules.
+				return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path))
+					.startOnQueue(self.gitOperationQueue)
+					.then(symlinkCheckoutPaths)
+			} else {
+				return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, force: true, revision: revision)
+					// For checkouts of “ideally bare” repositories of `dependency`, we add its submodules by cloning ourselves, after symlinking.
+					.then(symlinkCheckoutPaths)
+					.then(
+						submodulesInRepository(repositoryURL, revision: revision)
+							.flatMap(.concat) { (submodule) in
+								return cloneSubmoduleInWorkingDirectory(submodule, workingDirectoryURL, cacheURLMap: { (gitURL: GitURL) in
+									let dependency = Dependency.git(gitURL)
+									return repositoryFileURL(for: dependency)
+								})
+							}
+					)
+			}
+		}
+
+		return producer()
 			.on(started: {
 				self._projectEventsObserver.send(value: .checkingOut(dependency, revision))
 			})
@@ -959,11 +962,24 @@ public final class Project { // swiftlint:disable:this type_body_length
 					.flatMap(.concurrent(limit: 4)) { dependency, version -> SignalProducer<(), CarthageError> in
 						switch dependency {
 						case .git, .gitHub:
-							return self.checkoutOrCloneDependency(dependency, version: version, submodulesByPath: submodulesByPath)
+							return self.cloneOrFetchDependency(dependency, commitish: version.commitish)
+								.then(SignalProducer<(), CarthageError>.empty)
 						case .binary:
 							return .empty
 						}
 					}
+					// The checkoutDependency operation may clone or fetch submodules that are the same as some dependencies,
+					// so it should run after cloneOrFetchDependency to prevent conflict.
+					.then(SignalProducer<(Dependency, PinnedVersion), CarthageError>(dependencies)
+						.flatMap(.concat) { (dependency, version) -> SignalProducer<(), CarthageError> in
+							switch dependency {
+							case .git, .gitHub:
+								return self.checkoutDependency(dependency, version: version, submodulesByPath: submodulesByPath)
+							case .binary:
+								return .empty
+							}
+						}
+					)
 			}
 			.then(SignalProducer<(), CarthageError>.empty)
 	}


### PR DESCRIPTION
This problem is introduced by #2795.
 
Cartfile to reproduce the problem:

```github "ReactiveCocoa/ReactiveSwift" == 5.0.0```

First, run a `carthage update --no-build` to make sure cache repositories are cloned. Then remove `~/Library/Caches/org.carthage.CarthageKit/dependencies/Result`, and run a `carthage checkout`. It will get an error when cloning `Result`.

The reason is that carthage will `checkoutOrCloneDependency` for all dependencies concurrently meaning it will checkout ReactiveSwift and clone Result at the same time. After ReactiveSwift is checked out, carthage will fetch the Result submodule of ReactiveSwift conflicting with the cloning of Result dependency.

The solution is to delay the checkout after all dependencies are fetched, and submodules should be dealt serially.

Most part of the `checkoutOrCloneDependency` function is not changed, only the `cloneOrFetchDependency` step is removed.
