### PR TITLE
Update swift-package-manager dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a",
-          "revision": "916450f7e8a5aef13630edf9e6fc0b16ed9f5f65",
+          "branch": "swift-4.2-branch",
+          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.2"),
         .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("swift-4.2-branch")),
         .package(url: "https://github.com/apple/swift-llbuild.git", .revision("3aeecb428d202afe15633266dc862de27feab723")),
     ],
     targets: [
@@ -32,7 +32,7 @@ let package = Package(
         ),
         .target(
             name: "CarthageKit",
-            dependencies: ["XCDBLD", "Tentacle", "Curry", "SwiftPM-auto", "llbuildSwift"]
+            dependencies: ["XCDBLD", "Tentacle", "Curry", "SwiftPM", "llbuildSwift"]
         ),
         .testTarget(
             name: "CarthageKitTests",

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Result
-import struct SPMUtility.Version
+import struct Utility.Version
 
 /// Represents a binary dependency 
 public struct BinaryProject: Equatable {

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,4 +1,4 @@
-import SPMUtility
+import Utility
 
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Result
-import SPMUtility
+import Utility
 
 /// Identifies a dependency, its pinned version, and its compatible and incompatible requirements
 public struct CompatibilityInfo: Equatable {

--- a/Source/CarthageKit/NewResolver.swift
+++ b/Source/CarthageKit/NewResolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
-import SPMUtility
+import Utility
 
 /// Responsible for resolving acyclic dependency graphs.
 public struct NewResolver: ResolverProtocol {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -6,7 +6,7 @@ import ReactiveSwift
 import Tentacle
 import XCDBLD
 import ReactiveTask
-import struct SPMUtility.Version
+import struct Utility.Version
 
 /// Describes an event occurring to or with a project.
 public enum ProjectEvent {

--- a/Source/CarthageKit/RemoteVersion.swift
+++ b/Source/CarthageKit/RemoteVersion.swift
@@ -3,7 +3,7 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
-import SPMUtility
+import Utility
 
 /// Synchronously returns the semantic version of the newest release,
 /// if the given producer emits it within a reasonable timeframe.

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Result
 import ReactiveSwift
-import SPMUtility
+import Utility
 
 /// Protocol for resolving acyclic dependency graphs.
 public protocol ResolverProtocol {

--- a/Source/CarthageKit/Simulator.swift
+++ b/Source/CarthageKit/Simulator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SPMUtility
+import Utility
 import XCDBLD
 
 internal struct Simulator: Decodable {

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Result
 import ReactiveSwift
-import SPMUtility
+import Utility
 
 extension Version {
 	/// Attempts to parse a semantic version from a PinnedVersion.

--- a/Source/carthage/RemoteVersion.swift
+++ b/Source/carthage/RemoteVersion.swift
@@ -4,7 +4,7 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
-import SPMUtility
+import Utility
 
 /// The latest version of Carthage as a `Version`.
 public func remoteVersion() -> Version? {

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -4,7 +4,7 @@ import Result
 import Tentacle
 import Nimble
 import Quick
-import SPMUtility
+import Utility
 
 import struct Foundation.URL
 

--- a/Tests/CarthageKitTests/DB.swift
+++ b/Tests/CarthageKitTests/DB.swift
@@ -3,7 +3,7 @@ import ReactiveSwift
 import Foundation
 import Result
 import Tentacle
-import SPMUtility
+import Utility
 
 // swiftlint:disable no_extension_access_modifier
 let git1 = Dependency.git(GitURL("https://example.com/repo1"))

--- a/Tests/CarthageKitTests/RemoteVersionSpec.swift
+++ b/Tests/CarthageKitTests/RemoteVersionSpec.swift
@@ -3,7 +3,7 @@ import Nimble
 import Quick
 import ReactiveSwift
 import Tentacle
-import SPMUtility
+import Utility
 
 import struct Foundation.URL
 

--- a/Tests/CarthageKitTests/ValidateSpec.swift
+++ b/Tests/CarthageKitTests/ValidateSpec.swift
@@ -5,7 +5,7 @@ import Quick
 import ReactiveSwift
 import Result
 import Tentacle
-import SPMUtility
+import Utility
 
 import struct Foundation.URL
 

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -2,7 +2,7 @@ import CarthageKit
 import Foundation
 import Nimble
 import Quick
-import SPMUtility
+import Utility
 
 class VersionSpec: QuickSpec {
 	override func spec() {


### PR DESCRIPTION
I cloned the repository yesterday and had troubles initializing it for testing. 

`make` would not fetch dependencies properly.
As suggested by @tmspzz here https://github.com/Carthage/Carthage/issues/2834#issuecomment-516455570 at least the dependencies could be resolved.  
However, Xcode could not compile the project with the following error:

```
@_exported import llbuildSwift         <--- Missing required module 'llbuild'
```

This PR updates the dependency to the swift-4.2-branch which should be stable.
All other files are a mere rename `SPMUtility` -> `Utility` as it was changed in `swift-package-manager` repo at some point.