### PR TITLE
Improve submodule performance when --use-submodule

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -634,6 +634,8 @@ public func cloneOrFetch(
 	if let cacheURL = cacheURL {
 		return cloneOrFetch(remoteURL: remoteURL, to: cacheURL, isBare: isCacheBare, commitish: commitish)
 			.then(cloneOrFetch(remoteURL: GitURL(cacheURL.path), to: destinationURL, isBare: isDestinationBare, commitish: commitish))
+			// Set the origin remote back to the actual remote URL
+			.then(launchGitTask([ "remote", "set-url", "origin", remoteURL.urlString ], repositoryFileURL: destinationURL))
 			.map { _ in () }
 			.take(last: 1)
 	} else {

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -578,9 +578,10 @@ public func cloneOrFetch(
 						return SignalProducer(value: nil)
 					}
 
+					let refspec = isBare ? "+refs/heads/*:refs/heads/*" : "+refs/heads/*:refs/remotes/origin/*"
 					return SignalProducer(value: CloneOrFetch.fetching)
 						.concat(
-							fetchRepository(repositoryURL, remoteURL: remoteURL, refspec: "+refs/heads/*:refs/heads/*")
+							fetchRepository(repositoryURL, remoteURL: remoteURL, refspec: refspec)
 								.then(SignalProducer<CloneOrFetch?, CarthageError>.empty)
 						)
 				}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -866,7 +866,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 			if let submodule = submodule {
 				// In the presence of `submodule` for `dependency` — before symlinking, (not after) — add submodule and its submodules:
 				// `dependency`, subdependencies that are submodules, and non-Carthage-housed submodules.
-				return addSubmoduleToRepository(self.directoryURL, submodule, GitURL(repositoryURL.path))
+				return addSubmoduleToRepository(self.directoryURL, submodule, cacheURLMap: { (gitURL: GitURL) in
+						let dependency = Dependency.git(gitURL)
+						return repositoryFileURL(for: dependency)
+					})
 					.startOnQueue(self.gitOperationQueue)
 					.then(symlinkCheckoutPaths)
 			} else {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -832,8 +832,6 @@ public final class Project { // swiftlint:disable:this type_body_length
 		return createVersionFileForCommitish(commitish, dependencyName: projectName, buildProducts: frameworkURLs, rootDirectoryURL: self.directoryURL)
 	}
 
-	private let gitOperationQueue = SerialProducerQueue(name: "org.carthage.Constants.Project.gitOperationQueue")
-
 	/// Checks out the given dependency into its intended working directory,
 	/// cloning it first if need be.
 	private func checkoutDependency(
@@ -870,7 +868,6 @@ public final class Project { // swiftlint:disable:this type_body_length
 						let dependency = Dependency.git(gitURL)
 						return repositoryFileURL(for: dependency)
 					})
-					.startOnQueue(self.gitOperationQueue)
 					.then(symlinkCheckoutPaths)
 			} else {
 				return checkoutRepositoryToDirectory(repositoryURL, workingDirectoryURL, force: true, revision: revision)


### PR DESCRIPTION
Try to clone or fetch submodules from the Carthage cache, instead of simply running a `git submodule update --init --recursive`.

A `git submodule init` operation seems unnecessary when there is a `git submodule add` before it, so I removed it.