### PR TITLE
Refer to SWIFTPM_BOOTSTRAP in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If you can’t make the change yourself, please open an issue after making sure 
 After checkout, you can run the following command from the cloned directory, and then open the workspace in Xcode:
 
 ```bash
-make xcodeproj && \
+SWIFTPM_BOOTSTRAP=true make xcodeproj && \
   open Carthage.xcodeproj
 ```
 


### PR DESCRIPTION
I've just cloned Carthage repository and followed the instruction in CONTRIBUTING.md.
However, it couldn't be built .xcodeproj and the following error occurred.

```
make xcodeproj
swift package generate-xcodeproj --xcconfig-overrides .build/libSwiftPM.xcconfig
Updating https://github.com/apple/swift-package-manager.git
Updating https://github.com/Carthage/ReactiveTask.git
Updating https://github.com/mdiep/Tentacle.git
Updating https://github.com/apple/swift-llbuild.git
Updating https://github.com/jdhealy/PrettyColors.git
Updating https://github.com/ReactiveCocoa/ReactiveSwift.git
Updating https://github.com/antitypical/Result.git
Updating https://github.com/Quick/Quick.git
Updating https://github.com/thoughtbot/Curry.git
Updating https://github.com/Carthage/Commandant.git
Updating https://github.com/Quick/Nimble.git
error: dependency graph is unresolvable; found these conflicting requirements:

Dependencies:
    https://github.com/apple/swift-package-manager.git @ swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a
make: *** [xcodeproj] Error 1
```

I tried exporting `SWIFTPM_BOOTSTRAP=true` environment variable as .travis.yml says and it worked.
I think the current instruction lacks the reference to the environment variable so I added it in this PR.