### PR TITLE
Add workaround for Swift 5.1 compiler crash

### DIFF
--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -66,11 +66,11 @@ public struct UpdateCommand: CommandProtocol {
 
 			let dependenciesUsage = "the dependency names to update, checkout and build"
 
-      // Swift 5.1 workaround
-      // Carthage Issue: https://github.com/Carthage/Carthage/issues/2831
-      // Swift Compiler Bug: https://bugs.swift.org/browse/SR-11423
-      let defaultLogPath: String? = nil
-      
+			// Swift 5.1 workaround
+			// Carthage Issue: https://github.com/Carthage/Carthage/issues/2831
+			// Swift Compiler Bug: https://bugs.swift.org/browse/SR-11423
+			let defaultLogPath: String? = nil
+
 			return curry(Options.init)
 				<*> mode <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
 				<*> mode <| Option(key: "build", defaultValue: true, usage: buildDescription)

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -66,11 +66,16 @@ public struct UpdateCommand: CommandProtocol {
 
 			let dependenciesUsage = "the dependency names to update, checkout and build"
 
+      // Swift 5.1 workaround
+      // Carthage Issue: https://github.com/Carthage/Carthage/issues/2831
+      // Swift Compiler Bug: https://bugs.swift.org/browse/SR-11423
+      let defaultLogPath: String? = nil
+      
 			return curry(Options.init)
 				<*> mode <| Option(key: "checkout", defaultValue: true, usage: "skip the checking out of dependencies after updating")
 				<*> mode <| Option(key: "build", defaultValue: true, usage: buildDescription)
 				<*> mode <| Option(key: "verbose", defaultValue: false, usage: "print xcodebuild output inline (ignored if --no-build option is present)")
-				<*> mode <| Option(key: "log-path", defaultValue: nil, usage: "path to the xcode build output. A temporary file is used by default")
+				<*> mode <| Option(key: "log-path", defaultValue: defaultLogPath, usage: "path to the xcode build output. A temporary file is used by default")
 				<*> mode <| Option(key: "new-resolver", defaultValue: false, usage: "use the new resolver codeline when calculating dependencies. Default is false")
 				<*> BuildOptions.evaluate(mode, addendum: "\n(ignored if --no-build option is present)")
 				<*> CheckoutCommand.Options.evaluate(mode, dependenciesUsage: dependenciesUsage)


### PR DESCRIPTION
Workaround for #2831.

I've created a [Swift bug](https://bugs.swift.org/browse/SR-11423) for this crash, but I figure it probably won't be fixed in time for Xcode 11 GM.