### PR TITLE
For users named «travis» (case-insensitively), return early in `RemoteVersionSpec` rather than expose tests to the flakey interference currently seen

### DIFF
--- a/test.json
+++ b/test.json
@@ -1,0 +1,1 @@
+{"1.0":"https://xxxx.com/attachments/2018/zip/a507f6ba-bf30-4e64-9cad-7ab06d4671c5.zip"}


### PR DESCRIPTION
Our exemption here is somewhat heuristic — but, it applies broadly in Xcode environments, and Swift Package Manager environments, and others.
