### PR TITLE
Remove — as a library dependency — `SwiftPM` and `llbuild` and reinstate `struct Carthage.SemanticVersion`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean:
 test:
 	$(RM_SAFELY) ./.build/debug/CarthagePackageTests.xctest
 	swift package --skip-update resolve
-	swift build --skip-update --build-tests -Xswiftc -suppress-warnings -Xswiftc -Xcc -Xswiftc -fmodule-map-file=$(PWD)/`find .build/checkouts -name "swift-llbuild.git*"`/products/libllbuild/include/module.modulemap
+	swift build --skip-update --build-tests -Xswiftc -suppress-warnings
 	$(CP) -R Tests/CarthageKitTests/Resources ./.build/debug/CarthagePackageTests.xctest/Contents
 	$(CP) Tests/CarthageKitTests/fixtures/CartfilePrivateOnly.zip ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
 	script/copy-fixtures ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
@@ -53,7 +53,7 @@ test:
 
 installables:
 	swift package --skip-update resolve
-	swift build $(SWIFT_BUILD_FLAGS) -Xswiftc -Xcc -Xswiftc -fmodule-map-file=$(PWD)/`find .build/checkouts -name "swift-llbuild.git*"`/products/libllbuild/include/module.modulemap
+	swift build $(SWIFT_BUILD_FLAGS)
 
 package: installables
 	$(MKDIR) "$(CARTHAGE_TEMPORARY_FOLDER)$(BINARIES_FOLDER)"
@@ -81,12 +81,5 @@ install: installables
 uninstall:
 	$(RM) "$(BINARIES_FOLDER)/carthage"
 	
-.build/libSwiftPM.xcconfig:
-	mkdir -p .build
-	echo "OTHER_LDFLAGS = -lncurses -lsqlite3" > "$@"
-	echo "OTHER_CFLAGS = -DSWIFT_PACKAGE" >> "$@"
-
-xcconfig: .build/libSwiftPM.xcconfig
-
-xcodeproj: xcconfig
-	 swift package generate-xcodeproj --xcconfig-overrides .build/libSwiftPM.xcconfig
+xcodeproj:
+	 swift package generate-xcodeproj

--- a/Package.resolved
+++ b/Package.resolved
@@ -74,24 +74,6 @@
         }
       },
       {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
-        "state": {
-          "branch": null,
-          "revision": "3aeecb428d202afe15633266dc862de27feab723",
-          "version": null
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
-        "state": {
-          "branch": "swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a",
-          "revision": "916450f7e8a5aef13630edf9e6fc0b16ed9f5f65",
-          "version": null
-        }
-      },
-      {
         "package": "Tentacle",
         "repositoryURL": "https://github.com/mdiep/Tentacle.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,6 @@ let package = Package(
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.2"),
         .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2019-03-04-a")),
-        .package(url: "https://github.com/apple/swift-llbuild.git", .revision("3aeecb428d202afe15633266dc862de27feab723")),
     ],
     targets: [
         .target(
@@ -31,8 +29,8 @@ let package = Package(
             dependencies: ["XCDBLD", "Quick", "Nimble"]
         ),
         .target(
-            name: "CarthageKit",
-            dependencies: ["XCDBLD", "Tentacle", "Curry", "SwiftPM-auto", "llbuildSwift"]
+            name: "CarthageKit", 
+            dependencies: ["XCDBLD", "Tentacle", "Curry"]
         ),
         .testTarget(
             name: "CarthageKitTests",

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Result
-import struct SPMUtility.Version
 
 /// Represents a binary dependency 
 public struct BinaryProject: Equatable {
@@ -16,7 +15,7 @@ public struct BinaryProject: Equatable {
 
 				for (key, value) in json {
 					let pinnedVersion: PinnedVersion
-					switch Version.from(Scanner(string: key)) {
+					switch SemanticVersion.from(Scanner(string: key)) {
 					case .success:
 						pinnedVersion = PinnedVersion(key)
 					case let .failure(error):

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -1,8 +1,8 @@
-import SPMUtility
+import Foundation
 
 /// Defines the current CarthageKit version.
 public struct CarthageKitVersion {
-	public let value: Version
+	public let value: SemanticVersion
 
-	public static let current = CarthageKitVersion(value: Version(0, 33, 0))
+	public static let current = CarthageKitVersion(value: SemanticVersion(0, 33, 0))
 }

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Result
-import SPMUtility
 
 /// Identifies a dependency, its pinned version, and its compatible and incompatible requirements
 public struct CompatibilityInfo: Equatable {
@@ -57,7 +56,7 @@ public struct CompatibilityInfo: Equatable {
 		return CompatibilityInfo.invert(requirements: requirements)
 			.map { invertedRequirements -> [CompatibilityInfo] in
 				return dependencies.compactMap { dependency, version in
-					if case .success = Version.from(version), let requirements = invertedRequirements[dependency] {
+					if case .success = SemanticVersion.from(version), let requirements = invertedRequirements[dependency] {
 						return CompatibilityInfo(dependency: dependency, pinnedVersion: version, requirements: requirements)
 					}
 					return nil

--- a/Source/CarthageKit/NewResolver.swift
+++ b/Source/CarthageKit/NewResolver.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Result
 import ReactiveSwift
-import SPMUtility
 
 /// Responsible for resolving acyclic dependency graphs.
 public struct NewResolver: ResolverProtocol {
@@ -475,9 +474,9 @@ private final class DependencyNode {
 
 extension DependencyNode: Comparable {
 	fileprivate static func < (_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
-		let leftSemantic = Version.from(lhs.proposedVersion).value ?? Version(0, 0, 0)
-		let rightSemantic = Version.from(rhs.proposedVersion).value ?? Version(0, 0, 0)
-
+		let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(0, 0, 0)
+		let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(0, 0, 0)
+		
 		// Try higher versions first.
 		return leftSemantic > rightSemantic
 	}
@@ -485,8 +484,8 @@ extension DependencyNode: Comparable {
 	fileprivate static func == (_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
 		guard lhs.dependency == rhs.dependency else { return false }
 
-		let leftSemantic = Version.from(lhs.proposedVersion).value ?? Version(0, 0, 0)
-		let rightSemantic = Version.from(rhs.proposedVersion).value ?? Version(0, 0, 0)
+		let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(0, 0, 0)
+		let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(0, 0, 0)
 		return leftSemantic == rightSemantic
 	}
 }

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -6,7 +6,6 @@ import ReactiveSwift
 import Tentacle
 import XCDBLD
 import ReactiveTask
-import struct SPMUtility.Version
 
 /// Describes an event occurring to or with a project.
 public enum ProjectEvent {
@@ -515,7 +514,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.map { currentDependencies, updatedDependencies, latestDependencies -> [OutdatedDependency] in
 				return updatedDependencies.compactMap { project, version -> OutdatedDependency? in
 					if let resolved = currentDependencies[project], let latest = latestDependencies[project], resolved != version || resolved != latest {
-						if Version.from(resolved).value == nil, version == resolved {
+						if SemanticVersion.from(resolved).value == nil, version == resolved {
 							// If resolved version is not a semantic version but a commit
 							// it is a false-positive if `version` and `resolved` are the same
 							return nil
@@ -667,7 +666,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 					.flatMap(.merge) { pair -> SignalProducer<SourceURLAndDestinationURL, CarthageError> in
 						return checkFrameworkCompatibility(pair.frameworkSourceURL, usingToolchain: toolchain)
 							.mapError { error in CarthageError.internalError(description: error.description) }
-							.then(SignalProducer<SourceURLAndDestinationURL, CarthageError>(value: pair))
+							.reduce(into: pair) { (_, _) = ($0.1, $1) }
 					}
 					// If the framework is compatible copy it over to the destination folder in Carthage/Build
 					.flatMap(.merge) { pair -> SignalProducer<URL, CarthageError> in
@@ -990,10 +989,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 		projectName: String,
 		toolchain: String?
 	) -> SignalProducer<(), CarthageError> {
-		return SignalProducer<Version, ScannableError>(result: Version.from(pinnedVersion))
+		return SignalProducer<SemanticVersion, ScannableError>(result: SemanticVersion.from(pinnedVersion))
 			.mapError { CarthageError(scannableError: $0) }
 			.combineLatest(with: self.downloadBinaryFrameworkDefinition(binary: binary))
-			.attemptMap { semanticVersion, binaryProject -> Result<(Version, URL), CarthageError> in
+			.attemptMap { semanticVersion, binaryProject -> Result<(SemanticVersion, URL), CarthageError> in
 				guard let frameworkURL = binaryProject.versions[pinnedVersion] else {
 					return .failure(CarthageError.requiredVersionNotFound(Dependency.binary(binary), VersionSpecifier.exactly(semanticVersion)))
 				}
@@ -1009,7 +1008,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 
 	/// Downloads the binary only framework file. Sends the URL to each downloaded zip, after it has been moved to a
 	/// less temporary location.
-	private func downloadBinary(dependency: Dependency, version: Version, url: URL) -> SignalProducer<URL, CarthageError> {
+	private func downloadBinary(dependency: Dependency, version: SemanticVersion, url: URL) -> SignalProducer<URL, CarthageError> {
 		let fileName = url.lastPathComponent
 		let fileURL = fileURLToCachedBinaryDependency(dependency, version, fileName)
 
@@ -1305,7 +1304,7 @@ private func fileURLToCachedBinary(_ dependency: Dependency, _ release: Release,
 }
 
 /// Constructs a file URL to where the binary only framework download should be cached
-private func fileURLToCachedBinaryDependency(_ dependency: Dependency, _ semanticVersion: Version, _ fileName: String) -> URL {
+private func fileURLToCachedBinaryDependency(_ dependency: Dependency, _ semanticVersion: SemanticVersion, _ fileName: String) -> URL {
 	// ~/Library/Caches/org.carthage.CarthageKit/binaries/MyBinaryProjectFramework/2.3.1/MyBinaryProject.framework.zip
 	return Constants.Dependency.assetsURL.appendingPathComponent("\(dependency.name)/\(semanticVersion)/\(fileName)")
 }

--- a/Source/CarthageKit/RemoteVersion.swift
+++ b/Source/CarthageKit/RemoteVersion.swift
@@ -3,15 +3,14 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
-import SPMUtility
 
 /// Synchronously returns the semantic version of the newest release,
 /// if the given producer emits it within a reasonable timeframe.
 ///
-public func remoteVersion(_ remoteVersionProducer: SignalProducer<Release, CarthageError>) -> Version? {
+public func remoteVersion(_ remoteVersionProducer: SignalProducer<Release, CarthageError>) -> SemanticVersion? {
 	let latestRemoteVersion = remoteVersionProducer
-		.attemptMap { release -> Result<Version, CarthageError> in
-			return Version.from(Scanner(string: release.tag)).mapError(CarthageError.init(scannableError:))
+		.attemptMap { release -> Result<SemanticVersion, CarthageError> in
+			return SemanticVersion.from(Scanner(string: release.tag)).mapError(CarthageError.init(scannableError:))
 		}
 		// Add timeout on different queue so that `first()` doesn't block timeout scheduling
 		.timeout(after: 0.5, raising: CarthageError.gitHubAPITimeout, on: QueueScheduler(qos: .default))

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Result
 import ReactiveSwift
-import SPMUtility
 
 /// Protocol for resolving acyclic dependency graphs.
 public protocol ResolverProtocol {
@@ -506,9 +505,9 @@ private final class DependencyNode {
 
 extension DependencyNode: Comparable {
 	fileprivate static func < (_ lhs: DependencyNode, _ rhs: DependencyNode) -> Bool {
-		let leftSemantic = Version.from(lhs.proposedVersion).value ?? Version(0, 0, 0)
-		let rightSemantic = Version.from(rhs.proposedVersion).value ?? Version(0, 0, 0)
-
+		let leftSemantic = SemanticVersion.from(lhs.proposedVersion).value ?? SemanticVersion(0, 0, 0)
+		let rightSemantic = SemanticVersion.from(rhs.proposedVersion).value ?? SemanticVersion(0, 0, 0)
+		
 		// Try higher versions first.
 		return leftSemantic > rightSemantic
 	}

--- a/Source/CarthageKit/Simulator.swift
+++ b/Source/CarthageKit/Simulator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SPMUtility
 import XCDBLD
 
 internal struct Simulator: Decodable {
@@ -53,8 +52,8 @@ internal func selectAvailableSimulator(of sdk: SDK, from data: Data) -> Simulato
 	let allTargetSimulators = devices.reduce(into: [:], reducePlatformNames)
 	func sortedByVersion(_ osNames: [String]) -> [String] {
 		return osNames.sorted { lhs, rhs in
-			guard let lhsVersion = Version.from(PinnedVersion(lhs)).value,
-				let rhsVersion = Version.from(PinnedVersion(rhs)).value else {
+			guard let lhsVersion = SemanticVersion.from(PinnedVersion(lhs)).value,
+				let rhsVersion = SemanticVersion.from(PinnedVersion(rhs)).value else {
 					return lhs < rhs
 			}
 			return lhsVersion < rhsVersion

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -3,11 +3,63 @@
 import Foundation
 import Result
 import ReactiveSwift
-import SPMUtility
 
-extension Version {
+/// A semantic version.
+/// - Note: See <http://semver.org/>
+public struct SemanticVersion: Hashable {
+	/// The major version.
+	///
+	/// Increments to this component represent incompatible API changes.
+	public let major: Int
+
+	/// The minor version.
+	///
+	/// Increments to this component represent backwards-compatible
+	/// enhancements.
+	public let minor: Int
+
+	/// The patch version.
+	///
+	/// Increments to this component represent backwards-compatible bug fixes.
+	public let patch: Int
+
+	/// The pre-release identifier
+	///
+	/// Indicates that the version is unstable
+	public let preRelease: String?
+
+	/// The build metadata
+	///
+	/// Build metadata is ignored when comparing versions
+	public let buildMetadata: String?
+
+	/// A list of the version components, in order from most significant to
+	/// least significant.
+	public var components: [Int] {
+		return [ major, minor, patch ]
+	}
+
+	/// Whether this is a prerelease version
+	public var isPreRelease: Bool {
+		return self.preRelease != nil
+	}
+
+	public init(_ major: Int, _ minor: Int, _ patch: Int, preRelease: String? = nil, buildMetadata: String? = nil) {
+		self.major = major
+		self.minor = minor
+		self.patch = patch
+		self.preRelease = preRelease
+		self.buildMetadata = buildMetadata
+	}
+
+	public var hashValue: Int {
+		return components.reduce(0) { $0 ^ $1.hashValue }
+	}
+}
+
+extension SemanticVersion {
 	/// Attempts to parse a semantic version from a PinnedVersion.
-	public static func from(_ pinnedVersion: PinnedVersion) -> Result<Version, ScannableError> {
+	public static func from(_ pinnedVersion: PinnedVersion) -> Result<SemanticVersion, ScannableError> {
 		let scanner = Scanner(string: pinnedVersion.commitish)
 
 		// Skip leading characters, like "v" or "version-" or anything like
@@ -23,6 +75,11 @@ extension Version {
 		}
 	}
 
+	/// The same SemanticVersion as self, except that the build metadata is discarded
+	public var discardingBuildMetadata: SemanticVersion {
+		return SemanticVersion(self.major, self.minor, self.patch, preRelease: self.preRelease)
+	}
+	
 	/// Set of valid digts for SemVer versions
 	/// - note: Please use this instead of `CharacterSet.decimalDigits`, as
 	/// `decimalDigits` include more characters that are not contemplated in
@@ -31,7 +88,7 @@ extension Version {
 
 	/// Set of valid characters for SemVer major.minor.patch section
 	fileprivate static let versionCharacterSet = CharacterSet(charactersIn: ".")
-		.union(Version.semVerDecimalDigits)
+		.union(SemanticVersion.semVerDecimalDigits)
 
 	fileprivate static let asciiAlphabeth = CharacterSet(
 		charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -39,7 +96,7 @@ extension Version {
 
 	/// Set of valid character for SemVer build metadata section
 	fileprivate static let invalidBuildMetadataCharacters = asciiAlphabeth
-		.union(Version.semVerDecimalDigits)
+		.union(SemanticVersion.semVerDecimalDigits)
 		.union(CharacterSet(charactersIn: "-"))
 		.inverted
 
@@ -47,10 +104,11 @@ extension Version {
 	fileprivate static let preReleaseComponentsSeparator = "."
 }
 
-extension Version: Scannable {
+extension SemanticVersion: Scannable {
 	/// Attempts to parse a semantic version from a human-readable string of the
 	/// form "a.b.c" from a string scanner.
-	public static func from(_ scanner: Scanner) -> Result<Version, ScannableError> {
+	public static func from(_ scanner: Scanner) -> Result<SemanticVersion, ScannableError> {
+
 		var versionBuffer: NSString?
 		guard scanner.scanCharacters(from: versionCharacterSet, into: &versionBuffer),
 			let version = versionBuffer as String? else {
@@ -92,14 +150,14 @@ extension Version: Scannable {
 
 		if
 			let buildMetadata = buildMetadata,
-			let error = Version.validateBuildMetadata(buildMetadata, fullVersion: version)
+			let error = SemanticVersion.validateBuildMetadata(buildMetadata, fullVersion: version)
 		{
 			return .failure(error)
 		}
 
 		if
 			let preRelease = preRelease,
-			let error = Version.validatePreRelease(preRelease, fullVersion: version)
+			let error = SemanticVersion.validatePreRelease(preRelease, fullVersion: version)
 		{
 			return .failure(error)
 		}
@@ -108,13 +166,7 @@ extension Version: Scannable {
 			return .failure(ScannableError(message: "can not have pre-release or build metadata without patch, in \"\(version)\""))
 		}
 
-		return .success(self.init(
-			major,
-			minor,
-			patch ?? 0,
-			prereleaseIdentifiers: preRelease?.split(separator: ".").map(String.init) ?? [],
-			buildMetadataIdentifiers: buildMetadata?.split(separator: ".").map(String.init) ?? []
-		))
+		return .success(self.init(major, minor, patch ?? 0, preRelease: preRelease, buildMetadata: buildMetadata))
 	}
 
 	/// Checks validity of a build metadata string and returns an error if not valid
@@ -145,7 +197,7 @@ extension Version: Scannable {
 
 		// swiftlint:disable:next first_where
 		guard components
-			.filter({ !$0.containsAny(Version.semVerDecimalDigits.inverted) && $0 != "0" })
+			.filter({ !$0.containsAny(SemanticVersion.semVerDecimalDigits.inverted) && $0 != "0" })
 			// MUST NOT include leading zeros
 			.first(where: { $0.hasPrefix("0") }) == nil else {
 				return ScannableError(message: "Pre-release contains leading zero component, in \"\(fullVersion)\"")
@@ -190,11 +242,83 @@ extension Scanner {
 	}
 }
 
+extension SemanticVersion: Comparable {
+	public static func < (_ lhs: SemanticVersion, _ rhs: SemanticVersion) -> Bool {
+		if lhs.components == rhs.components {
+			return lhs.isPreReleaseLesser(preRelease: rhs.preRelease)
+		}
+		return lhs.components.lexicographicallyPrecedes(rhs.components)
+	}
+}
+
+extension SemanticVersion: CustomStringConvertible {
+	public var description: String {
+		var description = components.map { $0.description }.joined(separator: ".")
+		if let preRelease = self.preRelease {
+			description += "-\(preRelease)"
+		}
+		if let buildMetadata = self.buildMetadata {
+			description += "+\(buildMetadata)"
+		}
+		return description
+	}
+}
+
+extension SemanticVersion {
+
+	/// Compares the pre-release component with the given pre-release
+	/// assuming that the other components (major, minor, patch) are the same
+	private func isPreReleaseLesser(preRelease: String?) -> Bool {
+
+		// a non-pre-release is not lesser
+		guard let selfPreRelease = self.preRelease else {
+			return false
+		}
+
+		// a pre-release version is lesser than a non-pre-release
+		guard let otherPreRelease = preRelease else {
+			return true
+		}
+
+		// same pre-release version has no precedence. Build metadata could differ,
+		// but there is no ordering defined on build metadata
+		guard selfPreRelease != otherPreRelease else {
+			return false // undefined ordering
+		}
+
+		// Compare dot separated components one by one
+		// From http://semver.org/:
+		// "Precedence for two pre-release versions with the same major, minor, and patch
+		// version MUST be determined by comparing each dot separated identifier from left
+		// to right until a difference is found [...]. A larger set of pre-release fields
+		// has a higher precedence than a smaller set, if all of the preceding
+		// identifiers are equal."
+
+		let selfComponents = selfPreRelease.components(separatedBy: ".")
+		let otherComponents = otherPreRelease.components(separatedBy: ".")
+		let nonEqualComponents = zip(selfComponents, otherComponents)
+			.filter { $0.0 != $0.1 }
+
+		for (selfComponent, otherComponent) in nonEqualComponents {
+			return selfComponent.lesserThanPreReleaseVersionComponent(other: otherComponent)
+		}
+
+		// if I got here, the two pre-release are not the same, but there are not non-equal
+		// components, so one must have move pre-components than the other
+		return selfComponents.count < otherComponents.count
+	}
+
+	/// Returns whether a version has the same numeric components (major, minor, patch)
+	func hasSameNumericComponents(version: SemanticVersion) -> Bool {
+		return self.components == version.components
+	}
+}
+
 extension String {
 
 	/// Returns the Int value of the string, if the string is only composed of digits
 	private var numericValue: Int? {
-		if !self.isEmpty && self.rangeOfCharacter(from: Version.semVerDecimalDigits.inverted) == nil {
+		if !self.isEmpty && self.rangeOfCharacter(from: SemanticVersion.semVerDecimalDigits.inverted) == nil {
 			return Int(self)
 		}
 		return nil
@@ -262,35 +386,19 @@ extension PinnedVersion: CustomStringConvertible {
 	}
 }
 
-extension Version {
-	fileprivate var isPreRelease: Bool {
-		return !prereleaseIdentifiers.isEmpty
-	}
-
-	fileprivate var discardingBuildMetadata: Version {
-		return Version(major, minor, patch, prereleaseIdentifiers: prereleaseIdentifiers)
-	}
-
-	fileprivate func hasSameNumericComponents(version: Version) -> Bool {
-		return major == version.major
-			&& minor == version.minor
-			&& patch == version.patch
-	}
-}
-
 /// Describes which versions are acceptable for satisfying a dependency
 /// requirement.
 public enum VersionSpecifier: Hashable {
 	case any
-	case atLeast(Version)
-	case compatibleWith(Version)
-	case exactly(Version)
+	case atLeast(SemanticVersion)
+	case compatibleWith(SemanticVersion)
+	case exactly(SemanticVersion)
 	case gitReference(String)
 
 	/// Determines whether the given version satisfies this version specifier.
 	public func isSatisfied(by version: PinnedVersion) -> Bool {
-		func withVersion(_ predicate: (Version) -> Bool) -> Bool {
-			if let semanticVersion = Version.from(version).value {
+		func withSemanticVersion(_ predicate: (SemanticVersion) -> Bool) -> Bool {
+			if let semanticVersion = SemanticVersion.from(version).value {
 				return predicate(semanticVersion)
 			} else {
 				// Consider non-semantic versions (e.g., branches) to meet every
@@ -301,14 +409,14 @@ public enum VersionSpecifier: Hashable {
 
 		switch self {
 		case .any:
-			return withVersion { !$0.isPreRelease }
+			return withSemanticVersion { !$0.isPreRelease }
 		case .gitReference:
 			return true
 		case let .exactly(requirement):
-			return withVersion { $0 == requirement }
+			return withSemanticVersion { $0 == requirement }
 
 		case let .atLeast(requirement):
-			return withVersion { version in
+			return withSemanticVersion { version in
 				let versionIsNewer = version >= requirement
 
 				// Only pick a pre-release version if the requirement is also
@@ -318,7 +426,7 @@ public enum VersionSpecifier: Hashable {
 				return notPreReleaseOrSameComponents && versionIsNewer
 			}
 		case let .compatibleWith(requirement):
-			return withVersion { version in
+			return withSemanticVersion { version in
 
 				let versionIsNewer = version >= requirement
 				let notPreReleaseOrSameComponents =	!version.isPreRelease
@@ -349,11 +457,11 @@ extension VersionSpecifier: Scannable {
 	/// Attempts to parse a VersionSpecifier.
 	public static func from(_ scanner: Scanner) -> Result<VersionSpecifier, ScannableError> {
 		if scanner.scanString("==", into: nil) {
-			return Version.from(scanner).map { .exactly($0) }
+			return SemanticVersion.from(scanner).map { .exactly($0) }
 		} else if scanner.scanString(">=", into: nil) {
-			return Version.from(scanner).map { .atLeast($0) }
+			return SemanticVersion.from(scanner).map { .atLeast($0) }
 		} else if scanner.scanString("~>", into: nil) {
-			return Version.from(scanner).map { .compatibleWith($0) }
+			return SemanticVersion.from(scanner).map { .compatibleWith($0) }
 		} else if scanner.scanString("\"", into: nil) {
 			var refName: NSString?
 			if !scanner.scanUpTo("\"", into: &refName) || refName == nil {
@@ -392,7 +500,7 @@ extension VersionSpecifier: CustomStringConvertible {
 	}
 }
 
-private func intersection(atLeast: Version, compatibleWith: Version) -> VersionSpecifier? {
+private func intersection(atLeast: SemanticVersion, compatibleWith: SemanticVersion) -> VersionSpecifier? {
 	if atLeast.major > compatibleWith.major {
 		return nil
 	} else if atLeast.major < compatibleWith.major {
@@ -402,7 +510,7 @@ private func intersection(atLeast: Version, compatibleWith: Version) -> VersionS
 	}
 }
 
-private func intersection(atLeast: Version, exactly: Version) -> VersionSpecifier? {
+private func intersection(atLeast: SemanticVersion, exactly: SemanticVersion) -> VersionSpecifier? {
 	if atLeast > exactly {
 		return nil
 	}
@@ -410,7 +518,7 @@ private func intersection(atLeast: Version, exactly: Version) -> VersionSpecifie
 	return .exactly(exactly)
 }
 
-private func intersection(compatibleWith: Version, exactly: Version) -> VersionSpecifier? {
+private func intersection(compatibleWith: SemanticVersion, exactly: SemanticVersion) -> VersionSpecifier? {
 	if exactly.major != compatibleWith.major || compatibleWith > exactly {
 		return nil
 	}

--- a/Source/carthage/RemoteVersion.swift
+++ b/Source/carthage/RemoteVersion.swift
@@ -4,10 +4,9 @@ import ReactiveSwift
 import ReactiveTask
 import Result
 import Tentacle
-import SPMUtility
 
 /// The latest version of Carthage as a `Version`.
-public func remoteVersion() -> Version? {
+public func remoteVersion() -> SemanticVersion? {
 	let remoteVersionProducer = Client(.dotCom, urlSession: URLSession.proxiedSession)
 		.execute(Repository(owner: "Carthage", name: "Carthage").releases, perPage: 2)
 		.mapError(CarthageError.gitHubAPIRequestFailed)

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -4,9 +4,6 @@ import Result
 import Tentacle
 import Nimble
 import Quick
-import SPMUtility
-
-import struct Foundation.URL
 
 // swiftlint:disable:this force_try
 
@@ -36,16 +33,16 @@ class CartfileSpec: QuickSpec {
 			let example4 = Dependency.gitHub(.dotCom, Repository(owner: "ExampleOrg", name: "ExamplePrj4"))
 			
 			expect(cartfile.dependencies) == [
-				reactiveCocoa: .atLeast(Version(2, 3, 1)),
-				mantle: .compatibleWith(Version(1, 0, 0)),
-				libextobjc: .exactly(Version(0, 4, 1)),
+				reactiveCocoa: .atLeast(SemanticVersion(2, 3, 1)),
+				mantle: .compatibleWith(SemanticVersion(1, 0, 0)),
+				libextobjc: .exactly(SemanticVersion(0, 4, 1)),
 				xcconfigs: .any,
 				iosCharts: .any,
 				errorTranslations: .any,
 				errorTranslations2: .gitReference("development"),
-				example1: .atLeast(Version(3, 0, 2, prereleaseIdentifiers: ["pre"])),
-				example2: .exactly(Version(3, 0, 2, buildMetadataIdentifiers: ["build"])),
-				example3: .exactly(Version(3, 0, 2)),
+				example1: .atLeast(SemanticVersion(3, 0, 2, preRelease: "pre")),
+				example2: .exactly(SemanticVersion(3, 0, 2, preRelease: nil, buildMetadata: "build")),
+				example3: .exactly(SemanticVersion(3, 0, 2)),
 				example4: .gitReference("release#2")
 			]
 		}

--- a/Tests/CarthageKitTests/DB.swift
+++ b/Tests/CarthageKitTests/DB.swift
@@ -3,7 +3,6 @@ import ReactiveSwift
 import Foundation
 import Result
 import Tentacle
-import SPMUtility
 
 // swiftlint:disable no_extension_access_modifier
 let git1 = Dependency.git(GitURL("https://example.com/repo1"))
@@ -27,14 +26,14 @@ extension PinnedVersion {
 	static let v3_0_0 = PinnedVersion("v3.0.0")
 }
 
-extension Version {
-	static let v0_1_0 = Version(0, 1, 0)
-	static let v1_0_0 = Version(1, 0, 0)
-	static let v1_1_0 = Version(1, 1, 0)
-	static let v1_2_0 = Version(1, 2, 0)
-	static let v2_0_0 = Version(2, 0, 0)
-	static let v2_0_1 = Version(2, 0, 1)
-	static let v3_0_0 = Version(3, 0, 0)
+extension SemanticVersion {
+	static let v0_1_0 = SemanticVersion(0, 1, 0)
+	static let v1_0_0 = SemanticVersion(1, 0, 0)
+	static let v1_1_0 = SemanticVersion(1, 1, 0)
+	static let v1_2_0 = SemanticVersion(1, 2, 0)
+	static let v2_0_0 = SemanticVersion(2, 0, 0)
+	static let v2_0_1 = SemanticVersion(2, 0, 1)
+	static let v3_0_0 = SemanticVersion(3, 0, 0)
 }
 // swiftlint:enable no_extension_access_modifier
 

--- a/Tests/CarthageKitTests/RemoteVersionSpec.swift
+++ b/Tests/CarthageKitTests/RemoteVersionSpec.swift
@@ -3,7 +3,6 @@ import Nimble
 import Quick
 import ReactiveSwift
 import Tentacle
-import SPMUtility
 
 import struct Foundation.URL
 
@@ -20,7 +19,7 @@ class RemoteVersionSpec: QuickSpec {
 
 		describe("remoteVersion") {
 			it("should time out") {
-				var version: Version? = Version(0, 0, 0)
+				var version: SemanticVersion? = SemanticVersion(0, 0, 0)
 				DispatchQueue.main.async {
 					version = remoteVersion(SignalProducer.never)
 				}
@@ -31,7 +30,7 @@ class RemoteVersionSpec: QuickSpec {
 			it("should return version") {
 				let release = Release(id: 0, tag: "0.1.0", url: URL(string: "about:blank")!, assets: [])
 				let producer = SignalProducer<Release, CarthageError>(value: release)
-				expect(remoteVersion(producer)) == Version(0, 1, 0)
+				expect(remoteVersion(producer)) == SemanticVersion(0, 1, 0)
 			}
 		}
 	}

--- a/Tests/CarthageKitTests/ValidateSpec.swift
+++ b/Tests/CarthageKitTests/ValidateSpec.swift
@@ -5,9 +5,6 @@ import Quick
 import ReactiveSwift
 import Result
 import Tentacle
-import SPMUtility
-
-import struct Foundation.URL
 
 private extension CarthageError {
 	var compatibilityInfos: [CompatibilityInfo] {
@@ -50,9 +47,9 @@ class ValidateSpec: QuickSpec {
 
 		// These tuples represent the desired version of a dependency, paired with its parent dependency;
 		// moya_3_1_0 indicates that Moya expects a version compatible with 3.1.0 of *another* dependency
-		let moya_3_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(Version(3, 1, 0)))
-		let moya_4_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(Version(4, 1, 0)))
-		let reactiveSwift_3_2_1 = (reactiveSwiftDependency, VersionSpecifier.compatibleWith(Version(3, 2, 1)))
+		let moya_3_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(SemanticVersion(3, 1, 0)))
+		let moya_4_1_0 = (moyaDependency, VersionSpecifier.compatibleWith(SemanticVersion(4, 1, 0)))
+		let reactiveSwift_3_2_1 = (reactiveSwiftDependency, VersionSpecifier.compatibleWith(SemanticVersion(3, 2, 1)))
 
 		describe("requirementsByDependency") {
 			it("should group dependencies by parent dependency") {
@@ -80,10 +77,10 @@ class ValidateSpec: QuickSpec {
 				let d = Dependency.gitHub(.dotCom, Repository(owner: "d", name: "d"))
 				let e = Dependency.gitHub(.dotCom, Repository(owner: "e", name: "e"))
 
-				let v1 = VersionSpecifier.compatibleWith(Version(1, 0, 0))
-				let v2 = VersionSpecifier.compatibleWith(Version(2, 0, 0))
-				let v3 = VersionSpecifier.compatibleWith(Version(3, 0, 0))
-				let v4 = VersionSpecifier.compatibleWith(Version(4, 0, 0))
+				let v1 = VersionSpecifier.compatibleWith(SemanticVersion(1, 0, 0))
+				let v2 = VersionSpecifier.compatibleWith(SemanticVersion(2, 0, 0))
+				let v3 = VersionSpecifier.compatibleWith(SemanticVersion(3, 0, 0))
+				let v4 = VersionSpecifier.compatibleWith(SemanticVersion(4, 0, 0))
 
 				let requirements = [a: [b: v1, c: v2], d: [c: v3, e: v4]]
 				let invertedRequirements = CompatibilityInfo.invert(requirements: requirements).value!
@@ -96,11 +93,11 @@ class ValidateSpec: QuickSpec {
 		describe("incompatibilities") {
 			it("should identify incompatible dependencies") {
 				let commitish = VersionSpecifier.gitReference("commitish")
-				let v4_0_0 = VersionSpecifier.compatibleWith(Version(4, 0, 0))
-				let v2_0_0 = VersionSpecifier.compatibleWith(Version(2, 0, 0))
-				let v4_1_0 = VersionSpecifier.compatibleWith(Version(4, 1, 0))
-				let v3_1_0 = VersionSpecifier.compatibleWith(Version(3, 1, 0))
-				let v3_2_1 = VersionSpecifier.compatibleWith(Version(3, 2, 1))
+				let v4_0_0 = VersionSpecifier.compatibleWith(SemanticVersion(4, 0, 0))
+				let v2_0_0 = VersionSpecifier.compatibleWith(SemanticVersion(2, 0, 0))
+				let v4_1_0 = VersionSpecifier.compatibleWith(SemanticVersion(4, 1, 0))
+				let v3_1_0 = VersionSpecifier.compatibleWith(SemanticVersion(3, 1, 0))
+				let v3_2_1 = VersionSpecifier.compatibleWith(SemanticVersion(3, 2, 1))
 
 				let dependencies = [rxSwiftDependency: PinnedVersion("4.1.2"),
 									moyaDependency: PinnedVersion("10.0.2"),

--- a/Tests/CarthageKitTests/VersionSpec.swift
+++ b/Tests/CarthageKitTests/VersionSpec.swift
@@ -2,42 +2,41 @@ import CarthageKit
 import Foundation
 import Nimble
 import Quick
-import SPMUtility
 
 class VersionSpec: QuickSpec {
 	override func spec() {
 		it("should parse semantic versions") {
-			expect(Version.from(PinnedVersion("1.4")).value) == Version(1, 4, 0)
-			expect(Version.from(PinnedVersion("v2.8.9")).value) == Version(2, 8, 9)
-			expect(Version.from(PinnedVersion("2.8.2-alpha")).value) == Version(2, 8, 2, prereleaseIdentifiers: ["alpha"])
-			expect(Version.from(PinnedVersion("2.8.2-alpha+build234")).value) == Version(2, 8, 2, prereleaseIdentifiers: ["alpha"], buildMetadataIdentifiers: ["build234"])
-			expect(Version.from(PinnedVersion("2.8.2+build234")).value) == Version(2, 8, 2, buildMetadataIdentifiers: ["build234"])
-			expect(Version.from(PinnedVersion("2.8.2-alpha.2.1.0")).value) == Version(2, 8, 2, prereleaseIdentifiers: ["alpha", "2", "1", "0"])
+			expect(SemanticVersion.from(PinnedVersion("1.4")).value) == SemanticVersion(1, 4, 0)
+			expect(SemanticVersion.from(PinnedVersion("v2.8.9")).value) == SemanticVersion(2, 8, 9)
+			expect(SemanticVersion.from(PinnedVersion("2.8.2-alpha")).value) == SemanticVersion(2, 8, 2, preRelease: "alpha")
+			expect(SemanticVersion.from(PinnedVersion("2.8.2-alpha+build234")).value) == SemanticVersion(2, 8, 2, preRelease: "alpha", buildMetadata: "build234")
+			expect(SemanticVersion.from(PinnedVersion("2.8.2+build234")).value) == SemanticVersion(2, 8, 2, buildMetadata: "build234")
+			expect(SemanticVersion.from(PinnedVersion("2.8.2-alpha.2.1.0")).value) == SemanticVersion(2, 8, 2, preRelease: "alpha.2.1.0")
 		}
 
 		it("should fail on invalid semantic versions") {
-			expect(Version.from(PinnedVersion("release#2")).value).to(beNil()) // not a valid SemVer
-			expect(Version.from(PinnedVersion("v1")).value).to(beNil())
-			expect(Version.from(PinnedVersion("v2.8-alpha")).value).to(beNil()) // pre-release should be after patch
-			expect(Version.from(PinnedVersion("v2.8+build345")).value).to(beNil()) // build should be after patch
-			expect(Version.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
-			expect(Version.from(PinnedVersion("1.4.5+")).value).to(beNil()) // missing build metadata after '+'
-			expect(Version.from(PinnedVersion("1.4.5-alpha+")).value).to(beNil()) // missing build metadata after '+'
-			expect(Version.from(PinnedVersion("1.4.5-alpha#2")).value).to(beNil()) // non alphanumeric are  not allowed in pre-release
-			expect(Version.from(PinnedVersion("1.4.5-alpha.2.01.0")).value).to(beNil()) // numeric identifiers in pre-release
+			expect(SemanticVersion.from(PinnedVersion("release#2")).value).to(beNil()) // not a valid SemVer
+			expect(SemanticVersion.from(PinnedVersion("v1")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("v2.8-alpha")).value).to(beNil()) // pre-release should be after patch
+			expect(SemanticVersion.from(PinnedVersion("v2.8+build345")).value).to(beNil()) // build should be after patch
+			expect(SemanticVersion.from(PinnedVersion("null-string-beta-2")).value).to(beNil())
+			expect(SemanticVersion.from(PinnedVersion("1.4.5+")).value).to(beNil()) // missing build metadata after '+'
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha+")).value).to(beNil()) // missing build metadata after '+'
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha#2")).value).to(beNil()) // non alphanumeric are not allowed in pre-release
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha.2.01.0")).value).to(beNil()) // numeric identifiers in pre-release
 																								//version must not include leading zeros
-			expect(Version.from(PinnedVersion("1.4.5-alpha.2..0")).value).to(beNil()) // empty pre-release component
-			expect(Version.from(PinnedVersion("1.4.5+build@2")).value).to(beNil()) // non alphanumeric are not allowed in build metadata
-			expect(Version.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
-			expect(Version.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
-			expect(Version.from(PinnedVersion("1.４.5")).value).to(beNil()) // Note that the `４` in this string is
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-alpha.2..0")).value).to(beNil()) // empty pre-release component
+			expect(SemanticVersion.from(PinnedVersion("1.4.5+build@2")).value).to(beNil()) // non alphanumeric are not allowed in build metadata
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-")).value).to(beNil()) // missing pre-release after '-'
+			expect(SemanticVersion.from(PinnedVersion("1.4.5-+build43")).value).to(beNil()) // missing pre-release after '-'
+			expect(SemanticVersion.from(PinnedVersion("1.４.5")).value).to(beNil()) // Note that the `４` in this string is
 																					// a fullwidth character, not a halfwidth `4`
-			expect(Version.from(PinnedVersion("1.8.0.1")).value).to(beNil()) // not a valid SemVer, too many dots
-			expect(Version.from(PinnedVersion("1.8..1")).value).to(beNil()) // not a valid SemVer, double dots
-			expect(Version.from(PinnedVersion("1.8.1.")).value).to(beNil()) // not a valid SemVer, ends with dot
-			expect(Version.from(PinnedVersion("1.8.")).value).to(beNil()) // not a valid SemVer, ends with dot
-			expect(Version.from(PinnedVersion("1.")).value).to(beNil()) // not a valid SemVer, ends with dot
-			expect(Version.from(PinnedVersion("1.8.0.alpha")).value).to(beNil()) // not a valid SemVer, pre-release is dot-separated
+			expect(SemanticVersion.from(PinnedVersion("1.8.0.1")).value).to(beNil()) // not a valid SemVer, too many dots
+			expect(SemanticVersion.from(PinnedVersion("1.8..1")).value).to(beNil()) // not a valid SemVer, double dots
+			expect(SemanticVersion.from(PinnedVersion("1.8.1.")).value).to(beNil()) // not a valid SemVer, ends with dot
+			expect(SemanticVersion.from(PinnedVersion("1.8.")).value).to(beNil()) // not a valid SemVer, ends with dot
+			expect(SemanticVersion.from(PinnedVersion("1.")).value).to(beNil()) // not a valid SemVer, ends with dot
+			expect(SemanticVersion.from(PinnedVersion("1.8.0.alpha")).value).to(beNil()) // not a valid SemVer, pre-release is dot-separated
 
 		}
 	}
@@ -94,7 +93,7 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 
 			it("should allow greater or equal versions for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == true
@@ -103,47 +102,47 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 			
 			it("should allow a non-semantic version for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow for a pre-release of the same non-pre-release version for .atLeast")
 			{
-				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 			
 			it("should allow for a build version of the same version for .atLeast")
 			{
-				let specifier = VersionSpecifier.atLeast(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
 			}
 			
 			it("should not allow for a build version of a different version for .atLeast")
 			{
-				let specifier = VersionSpecifier.atLeast(Version.from(v3_0_0).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v3_0_0).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
 			it("should allow for a build version of the same version for .compatibleWith")
 			{
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == true
 			}
 			
 			it("should not allow for a build version of a different version for .compatibleWith")
 			{
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v1_3_2).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v1_3_2).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
 			it("should not allow for a greater pre-release version for .atLeast") {
-				let specifier = VersionSpecifier.atLeast(Version.from(v2_0_2).value!)
+				let specifier = VersionSpecifier.atLeast(SemanticVersion.from(v2_0_2).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 			it("should allow greater or equal minor and patch versions for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == true
@@ -152,18 +151,18 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 			
 			it("should allow a non-semantic version for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow equal minor and patch pre-release version for .compatibleWith") {
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_alpha)) == false
 			}
 
 
 			it("should only allow exact versions for .exactly") {
-				let specifier = VersionSpecifier.exactly(Version.from(v2_2_0).value!)
+				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_2_0).value!)
 				expect(specifier.isSatisfied(by: v1_3_2)) == false
 				expect(specifier.isSatisfied(by: v2_0_2)) == false
 				expect(specifier.isSatisfied(by: v2_1_1)) == false
@@ -172,32 +171,32 @@ class VersionSpecifierSpec: QuickSpec {
 			}
 			
 			it("should not allow a build version of a different version for .exactly") {
-				let specifier = VersionSpecifier.exactly(Version.from(v1_3_2).value!)
+				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v1_3_2).value!)
 				expect(specifier.isSatisfied(by: v0_1_0_build123)) == false
 			}
 			
 			it("should not allow a build version of the same version for .exactly") {
-				let specifier = VersionSpecifier.exactly(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: v2_1_1_build3345)) == false
 			}
 			
 			it("should allow for a non-semantic version for .exactly") {
-				let specifier = VersionSpecifier.exactly(Version.from(v2_1_1).value!)
+				let specifier = VersionSpecifier.exactly(SemanticVersion.from(v2_1_1).value!)
 				expect(specifier.isSatisfied(by: nonSemantic)) == true
 			}
 			
 			it("should not allow any pre-release versions to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_1_0_pre23)) == false
 			}
 			
 			it("should not allow a pre-release versions of a different version to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_2_0_candidate)) == false
 			}
 
 			it("should allow only greater patch versions to satisfy 0.x") {
-				let specifier = VersionSpecifier.compatibleWith(Version.from(v0_1_0).value!)
+				let specifier = VersionSpecifier.compatibleWith(SemanticVersion.from(v0_1_0).value!)
 				expect(specifier.isSatisfied(by: v0_1_0)) == true
 				expect(specifier.isSatisfied(by: v0_1_1)) == true
 				expect(specifier.isSatisfied(by: v0_2_0)) == false
@@ -205,14 +204,14 @@ class VersionSpecifierSpec: QuickSpec {
 		}
 
 		describe("intersection") {
-			let v0_1_0 = Version(0, 1, 0)
-			let v0_1_1 = Version(0, 1, 1)
-			let v0_2_0 = Version(0, 2, 0)
-			let v1_3_2 = Version(1, 3, 2)
-			let v2_1_1 = Version(2, 1, 1)
-			let v2_2_0 = Version(2, 2, 0)
-			let v2_2_0_b421 = Version(2, 2, 0, buildMetadataIdentifiers: ["b421"])
-			let v2_2_0_alpha = Version(2, 2, 0, prereleaseIdentifiers: ["alpha"])
+			let v0_1_0 = SemanticVersion(0, 1, 0)
+			let v0_1_1 = SemanticVersion(0, 1, 1)
+			let v0_2_0 = SemanticVersion(0, 2, 0)
+			let v1_3_2 = SemanticVersion(1, 3, 2)
+			let v2_1_1 = SemanticVersion(2, 1, 1)
+			let v2_2_0 = SemanticVersion(2, 2, 0)
+			let v2_2_0_b421 = SemanticVersion(2, 2, 0, buildMetadata: "b421")
+			let v2_2_0_alpha = SemanticVersion(2, 2, 0, preRelease: "alpha")
 
 			it("should return the tighter specifier when one is .any") {
 				testIntersection(.any, .any, expected: .any)


### PR DESCRIPTION
A [bug in the-tool-SwiftPM's package resolution](https://github.com/apple/swift-package-manager/pull/2197) resulted in disregard for the (crucial) ‘resolved file’ when resolving branch-based dependencies.

Which would put us in the position of needing any commit of `apple/swift-package-manager` that didn't specify its dependency on `apple/swift-llbuild` in the branch-based style.

Also criteria for the above, [working Swift 4.2.X manifests and compilation](https://forums.swift.org/t/about-reproducible-builds/26957/10) _and_ working Swift 5.X manifests and compilation.

No such commit of `apple/swift-package-manager` could be found.

In addition, some confusion around [`llbuild`'s `sqlite3` linkage](https://github.com/apple/swift-llbuild/commit/f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb#diff-37ca2dd15ca0f6b1b49e78db084ef5b9L5-L10) made criteria even more confusing.

#### Notes:

- Some initializers and methods on `struct Carthage.SemanticVersion` have differences from the previous incarnation found in v0.33.0.
- Reinstate `struct Carthage.SemanticVersion` in all callsites in codebase and tests, removing `SPMUtility.Version`.
- No longer necessary to `import struct Foundation.URL` with the removed import of SPMUtility.
- Makefile removes complications which previously supported `llbuild`'s `sqlite3` linkage.
- Working Swift 4.2.X compilation is necessary to support building for [macOS High Sierra](https://en.wikipedia.org/wiki/MacOS_High_Sierra) on [Homebrew bottling infrastructure](https://github.com/Homebrew/brew/blob/7dd0466/Library/Homebrew/os/mac/xcode.rb#L18).
