### PR TITLE
Swift Package Manager: Suppress `sandbox-exec` under Homebrew.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       language: objective-c
       osx_image: xcode10.1
       script:
-        - make clean && SWIFTPM_BOOTSTRAP=true make test
+        - make test
       env: JOB=CI_TEST_10_1
     - os: osx
       language: objective-c
@@ -22,7 +22,7 @@ matrix:
       script:
         - brew uninstall carthage
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install bats
-        - make clean && SWIFTPM_BOOTSTRAP=true make install
+        - make install
         - bats IntegrationTests
       env:
         - JOB=CI_INTEGRATION_TESTS

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ OUTPUT_PACKAGE=Carthage.pkg
 CARTHAGE_EXECUTABLE=./.build/release/carthage
 BINARIES_FOLDER=/usr/local/bin
 
-PWD := $(shell pwd)
-SWIFT_BUILD_FLAGS=--skip-update --configuration release -Xswiftc -suppress-warnings
+SWIFT_BUILD_FLAGS=--configuration release -Xswiftc -suppress-warnings
 
 SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED:=$(shell test -n "$${HOMEBREW_SDKROOT}" && echo should_be_flagged)
 ifeq ($(SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED), should_be_flagged)
@@ -40,19 +39,16 @@ all: installables
 
 clean:
 	swift package clean
-	swift package reset
 
 test:
 	$(RM_SAFELY) ./.build/debug/CarthagePackageTests.xctest
-	swift package --skip-update resolve
-	swift build --skip-update --build-tests -Xswiftc -suppress-warnings
+	swift build --build-tests -Xswiftc -suppress-warnings
 	$(CP) -R Tests/CarthageKitTests/Resources ./.build/debug/CarthagePackageTests.xctest/Contents
 	$(CP) Tests/CarthageKitTests/fixtures/CartfilePrivateOnly.zip ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
 	script/copy-fixtures ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
 	swift test --skip-build
 
 installables:
-	swift package --skip-update resolve
 	swift build $(SWIFT_BUILD_FLAGS)
 
 package: installables


### PR DESCRIPTION
Crucial to enable Homebrew installs: due to Homebrew's own use of sandboxing.

Travis: remove `make clean` and `SWIFTPM_BOOTSTRAP` (`var` for certain versions of SwiftPM-as-a-library) — no longer necessary as of Carthage/Carthage@9b009cb408afb08e3b32d234adb7a8ee5f1be627.

Restores previous behavior.

Partial revert of Carthage/Carthage@60aaf683dc4e5d446c2b64704e7c02b80de45ba3.