### PR TITLE
Add alternative content type for zip archives

### DIFF
--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -102,6 +102,6 @@ public struct Constants {
 
 		/// MIME types allowed for GitHub Release assets, for them to be considered as
 		/// binary frameworks.
-		public static let binaryAssetContentTypes = ["application/zip", "application/octet-stream"]
+		public static let binaryAssetContentTypes = ["application/zip", "application/x-zip-compressed", "application/octet-stream"]
 	}
 }


### PR DESCRIPTION
Sometimes GitHub uses `application/x-zip-compressed` content type for zip archives. This type should be allowed as it's just a zip file.

PS: It was really tricky to figure out what was wrong with the release.