### PR TITLE
FIX: Colon cause the build to fail #2879

### DIFF
--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -47,7 +47,7 @@ public struct GitURL {
 
 	/// The name of the repository, if it can be inferred from the URL.
 	public var name: String? {
-		let components = urlString.split(omittingEmptySubsequences: true) { $0 == "/" }
+        let components = urlString.split(omittingEmptySubsequences: true) { $0 == "/" || $0 == ":"}
 
 		return components
 			.last

--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -47,7 +47,7 @@ public struct GitURL {
 
 	/// The name of the repository, if it can be inferred from the URL.
 	public var name: String? {
-        let components = urlString.split(omittingEmptySubsequences: true) { $0 == "/" || $0 == ":"}
+        let components = urlString.split(omittingEmptySubsequences: true) { ["/", ":"].contains($0)  }
 
 		return components
 			.last

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -72,6 +72,12 @@ class DependencySpec: QuickSpec {
 
 					expect(dependency.name) == "myproject"
 				}
+                
+                it("should be the last component of the URL") {
+                    let dependency = Dependency.git(GitURL("git@server.com:myproject"))
+
+                    expect(dependency.name) == "myproject"
+                }
 
 				it("should not include the trailing git suffix") {
 					let dependency = Dependency.git(GitURL("ssh://server.com/myproject.git"))


### PR DESCRIPTION
When extracting the name from the repository url beside "/" treat ":" as separator
Added test for this specific case i.e. 
Cartfile:
git "git@192.168.1.2:myFramework" == 1.0.0

Expected result:
name == "myFramework"