### PR TITLE
Prevent directory traversal

### DIFF
--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -47,7 +47,16 @@ public struct GitURL {
 
 	/// The name of the repository, if it can be inferred from the URL.
 	public var name: String? {
-		let components = urlString.split(omittingEmptySubsequences: true) { $0 == "/" }
+        let absoluteURLString: String
+        if urlString.hasPrefix(".") {
+            absoluteURLString = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(urlString)
+                .standardizedFileURL
+                .absoluteString
+        } else {
+            absoluteURLString = urlString
+        }
+		let components = absoluteURLString.split(omittingEmptySubsequences: true) { $0 == "/" }
 
 		return components
 			.last

--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -47,15 +47,15 @@ public struct GitURL {
 
 	/// The name of the repository, if it can be inferred from the URL.
 	public var name: String? {
-        let absoluteURLString: String
-        if urlString.hasPrefix(".") {
-            absoluteURLString = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-                .appendingPathComponent(urlString)
-                .standardizedFileURL
-                .absoluteString
-        } else {
-            absoluteURLString = urlString
-        }
+		let absoluteURLString: String
+		if urlString.hasPrefix(".") {
+			absoluteURLString = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+				.appendingPathComponent(urlString)
+				.standardizedFileURL
+				.absoluteString
+		} else {
+			absoluteURLString = urlString
+		}
 		let components = absoluteURLString.split(omittingEmptySubsequences: true) { $0 == "/" }
 
 		return components

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -85,15 +85,44 @@ class DependencySpec: QuickSpec {
 					expect(dependency.name) == "whatisthisurleven"
 				}
 
-				it("should be the directory name if the given URL is relative local path") {
+				context("when a relative local path with dots is given") {
 					let fileManager = FileManager.default
-					let startingDirectory = fileManager.currentDirectoryPath
-					defer { fileManager.changeCurrentDirectoryPath(startingDirectory) }
-					let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
-					fileManager.changeCurrentDirectoryPath(temporaryDirectoryURL.path)
-					let dependency = Dependency.git(GitURL(".."))
+					var startingDirectory: String!
+					var temporaryDirectoryURL: URL!
 
-					expect(dependency.name) == temporaryDirectoryURL.deletingLastPathComponent().lastPathComponent
+					beforeEach {
+						startingDirectory = fileManager.currentDirectoryPath
+						temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
+						fileManager.changeCurrentDirectoryPath(temporaryDirectoryURL.path)
+					}
+
+					afterEach {
+						fileManager.changeCurrentDirectoryPath(startingDirectory)
+					}
+
+					it("should be the directory name if the given URL string is '.'") {
+						let dependency = Dependency.git(GitURL("."))
+
+						expect(dependency.name) == temporaryDirectoryURL.lastPathComponent
+					}
+
+					it ("should be the directory name if the given URL string is prefixed by './'") {
+						let dependency = Dependency.git(GitURL("./myproject"))
+
+						expect(dependency.name) == "myproject"
+					}
+
+					it("should be the directory name if the given URL string is '..'") {
+						let dependency = Dependency.git(GitURL(".."))
+
+						expect(dependency.name) == temporaryDirectoryURL.deletingLastPathComponent().lastPathComponent
+					}
+
+					it ("should be the directory name if the given URL string is prefixed by '../'") {
+						let dependency = Dependency.git(GitURL("../myproject"))
+
+						expect(dependency.name) == "myproject"
+					}
 				}
 			}
 

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -84,6 +84,17 @@ class DependencySpec: QuickSpec {
 
 					expect(dependency.name) == "whatisthisurleven"
 				}
+
+                it("should be the directory name if the given URL is relative local path") {
+                    let fileManager = FileManager.default
+                    let previousDirectory = fileManager.currentDirectoryPath
+                    defer { fileManager.changeCurrentDirectoryPath(previousDirectory) }
+                    let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                    fileManager.changeCurrentDirectoryPath(temporaryDirectoryURL.path)
+                    let dependency = Dependency.git(GitURL(".."))
+
+                    expect(dependency.name) == temporaryDirectoryURL.deletingLastPathComponent().lastPathComponent
+                }
 			}
 
 			context("binary") {

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -87,8 +87,8 @@ class DependencySpec: QuickSpec {
 
 				it("should be the directory name if the given URL is relative local path") {
 					let fileManager = FileManager.default
-					let previousDirectory = fileManager.currentDirectoryPath
-					defer { fileManager.changeCurrentDirectoryPath(previousDirectory) }
+					let startingDirectory = fileManager.currentDirectoryPath
+					defer { fileManager.changeCurrentDirectoryPath(startingDirectory) }
 					let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
 					fileManager.changeCurrentDirectoryPath(temporaryDirectoryURL.path)
 					let dependency = Dependency.git(GitURL(".."))

--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -85,16 +85,16 @@ class DependencySpec: QuickSpec {
 					expect(dependency.name) == "whatisthisurleven"
 				}
 
-                it("should be the directory name if the given URL is relative local path") {
-                    let fileManager = FileManager.default
-                    let previousDirectory = fileManager.currentDirectoryPath
-                    defer { fileManager.changeCurrentDirectoryPath(previousDirectory) }
-                    let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
-                    fileManager.changeCurrentDirectoryPath(temporaryDirectoryURL.path)
-                    let dependency = Dependency.git(GitURL(".."))
+				it("should be the directory name if the given URL is relative local path") {
+					let fileManager = FileManager.default
+					let previousDirectory = fileManager.currentDirectoryPath
+					defer { fileManager.changeCurrentDirectoryPath(previousDirectory) }
+					let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
+					fileManager.changeCurrentDirectoryPath(temporaryDirectoryURL.path)
+					let dependency = Dependency.git(GitURL(".."))
 
-                    expect(dependency.name) == temporaryDirectoryURL.deletingLastPathComponent().lastPathComponent
-                }
+					expect(dependency.name) == temporaryDirectoryURL.deletingLastPathComponent().lastPathComponent
+				}
 			}
 
 			context("binary") {


### PR DESCRIPTION
## Problem

When Cartfile contains a local dependency of which path ends with `..`, Carthage clones the repo into the wrong place.

I created the repository to reproduce the behavior: https://github.com/manicmaniac/CarthageDirectoryTraversal

## Cause

`GitURL.name` doesn't check if the own path is relative or absolute but just returns the last path component.

So the name could be `..` and later it will be used as the destination path where the dependency should be copied.

## Solution

I added some code to `GitURL` to convert a relative path to the absolute path before getting the name.