### PR TITLE
Fix Segmentation Fault 11 while calling FetchCache.updateLastFetchTime

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -18,11 +18,16 @@ public struct FetchCache {
 
 	private static var lastFetchTimes: [GitURL: TimeInterval] = [:]
 
+	private static let lock = NSLock()
+
 	internal static func clearFetchTimes() {
 		lastFetchTimes.removeAll()
 	}
 
 	internal static func needsFetch(forURL url: GitURL) -> Bool {
+		lock.lock()
+		defer { lock.unlock() }
+
 		guard let lastFetch = lastFetchTimes[url] else {
 			return true
 		}
@@ -33,6 +38,9 @@ public struct FetchCache {
 	}
 
 	fileprivate static func updateLastFetchTime(forURL url: GitURL?) {
+		lock.lock()
+		defer { lock.unlock() }
+
 		if let url = url {
 			lastFetchTimes[url] = Date().timeIntervalSince1970
 		}

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -21,6 +21,9 @@ public struct FetchCache {
 	private static let lock = NSLock()
 
 	internal static func clearFetchTimes() {
+		lock.lock()
+		defer { lock.unlock() }
+
 		lastFetchTimes.removeAll()
 	}
 


### PR DESCRIPTION
## Problem

https://github.com/Carthage/Carthage/issues/2760#issuecomment-555964945

## Solution

Use NSLock to coordinates the operation of multiple threads of execution within the FetchCache.