### PR TITLE
Avoid unnecessary rebuilds when using --no-skip-current with --cache-builds

### DIFF
--- a/IntegrationTests/Utilities/TestFramework.bash
+++ b/IntegrationTests/Utilities/TestFramework.bash
@@ -6,6 +6,10 @@ extract-test-frameworks-one-and-two() {
 	unzip ${BATS_TEST_DIRNAME:?}/../Tests/CarthageKitTests/fixtures/DependencyTest.zip 'DependencyTest/SourceRepos/TestFramework[12]/*' -d "${BATS_TMPDIR:?}"
 }
 
+extract-workspace-with-dependency() {
+	unzip -o ${BATS_TEST_DIRNAME:?}/../Tests/CarthageKitTests/fixtures/WorkspaceWithDependency.zip -d "${BATS_TMPDIR:?}"
+}
+
 branch-test-frameworks-one-and-two() {
 	directory_to_return_into="${PWD:?}"
 	branch="${1:?}" # parameter 1: branch name used in git repositories for both `TestFramework`s.

--- a/IntegrationTests/build.bats
+++ b/IntegrationTests/build.bats
@@ -24,12 +24,13 @@ EOF
     extract-workspace-with-dependency
     cd "${BATS_TMPDIR:?}/WorkspaceWithDependency"
     git init && git-commit 'Initialize project.'
+    git remote add origin "git@example.com:TestFramework1.git"
 
     run carthage build --no-skip-current --platform mac --cache-builds
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = "*** Invalid cache found for _Current, rebuilding with all downstream dependencies" ]
+    [ "${lines[1]}" = "*** Invalid cache found for TestFramework1, rebuilding with all downstream dependencies" ]
 
     run carthage build --no-skip-current --platform mac --cache-builds
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = "*** Valid cache found for _Current, skipping build" ]
+    [ "${lines[1]}" = "*** Valid cache found for TestFramework1, skipping build" ]
 }

--- a/IntegrationTests/build.bats
+++ b/IntegrationTests/build.bats
@@ -28,9 +28,9 @@ EOF
 
     run carthage build --no-skip-current --platform mac --cache-builds
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = "*** Invalid cache found for TestFramework1, rebuilding with all downstream dependencies" ]
+    [[ "$output" =~ "*** Invalid cache found for TestFramework1, rebuilding with all downstream dependencies" ]]
 
     run carthage build --no-skip-current --platform mac --cache-builds
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = "*** Valid cache found for TestFramework1, skipping build" ]
+    [[ "$output" =~ "*** Valid cache found for TestFramework1, skipping build" ]]
 }

--- a/IntegrationTests/build.bats
+++ b/IntegrationTests/build.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+load "Utilities/TestFramework"
+
 setup() {
     cd $BATS_TMPDIR
 }
@@ -16,4 +18,18 @@ EOF
     run carthage bootstrap --platform ios
     [ "$status" -eq 0 ]
     [ -e Carthage/Build/iOS/MMMarkdown.framework ]
+}
+
+@test "carthage build --no-skip-current caches the current project" {
+    extract-workspace-with-dependency
+    cd "${BATS_TMPDIR:?}/WorkspaceWithDependency"
+    git init && git-commit 'Initialize project.'
+
+    run carthage build --no-skip-current --platform mac --cache-builds
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "*** Invalid cache found for _Current, rebuilding with all downstream dependencies" ]
+
+    run carthage build --no-skip-current --platform mac --cache-builds
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "*** Valid cache found for _Current, skipping build" ]
 }

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -708,7 +708,7 @@ public func projectName(for repositoryFileURL: URL? = nil) -> SignalProducer<Str
 				}
 				.first?.value.remoteNameAndURL.url
 
-				// If the reposiroty is not pushed to any remote
+				// If the repository is not pushed to any remote
 				// the list of remotes is empty, so call the current project... "_Current"
 				return urlOfMostPopularRemote.flatMap { Dependency.git(GitURL($0)).name } ?? "_Current"
 			}

--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -652,3 +652,77 @@ public func cloneOrFetch(
 			.take(last: 1)
 	}
 }
+
+public func projectName(for repositoryFileURL: URL? = nil) -> SignalProducer<String, CarthageError> {
+
+	/*
+	List all remotes known for this repository
+	and keep only the "fetch" urls by which the current repository
+	would be known for the purpose of fetching anyways.
+
+	Example of well-formed output:
+
+		$ git remote -v
+		origin   https://github.com/blender/Carthage.git (fetch)
+		origin   https://github.com/blender/Carthage.git (push)
+		upstream https://github.com/Carthage/Carthage.git (fetch)
+		upstream https://github.com/Carthage/Carthage.git (push)
+
+	Example of ill-formed output where upstream does not have a url:
+
+		$ git remote -v
+		origin   https://github.com/blender/Carthage.git (fetch)
+		origin   https://github.com/blender/Carthage.git (push)
+		upstream
+	*/
+	let allRemoteURLs = launchGitTask(["remote", "-v"], repositoryFileURL: repositoryFileURL)
+		.flatMap(.concat) { $0.linesProducer }
+		.map { $0.components(separatedBy: .whitespacesAndNewlines) }
+		.filter { $0.count >= 3 && $0.last == "(fetch)" } // Discard ill-formed output as of example
+		.map { ($0[0], $0[1]) }
+		.collect()
+
+	return allRemoteURLs
+		// Assess the popularity of each remote url
+		.map { $0.reduce([String: (popularity: Int, remoteNameAndURL: (name: String, url: String))]()) { remoteURLPopularityMap, remoteNameAndURL in
+			let (remoteName, remoteUrl) = remoteNameAndURL
+			var remoteURLPopularityMap = remoteURLPopularityMap
+			if let existingEntry = remoteURLPopularityMap[remoteName] {
+				remoteURLPopularityMap[remoteName] = (existingEntry.popularity + 1, existingEntry.remoteNameAndURL)
+			} else {
+				remoteURLPopularityMap[remoteName] = (0, (remoteName, remoteUrl))
+			}
+			return remoteURLPopularityMap
+			}
+		}
+		// Pick "origin" if it exists,
+		// otherwise sort remotes by popularity
+		// or alphabetically in case of a draw
+		.map { (remotePopularityMap: [String: (popularity: Int, remoteNameAndURL: (name: String, url: String))]) -> String in
+			guard let origin = remotePopularityMap["origin"] else {
+				let urlOfMostPopularRemote = remotePopularityMap.sorted { lhs, rhs in
+					if lhs.value.popularity == rhs.value.popularity {
+						return lhs.key < rhs.key
+					}
+					return lhs.value.popularity > rhs.value.popularity
+				}
+				.first?.value.remoteNameAndURL.url
+
+				// If the reposiroty is not pushed to any remote
+				// the list of remotes is empty, so call the current project... "_Current"
+				return urlOfMostPopularRemote.flatMap { Dependency.git(GitURL($0)).name } ?? "_Current"
+			}
+
+			return Dependency.git(GitURL(origin.remoteNameAndURL.url)).name
+		}
+}
+
+public func describeTagOrCommitish(_ commitish: String, in repositoryFileURL: URL? = nil) -> SignalProducer<String, CarthageError> {
+	return launchGitTask(["rev-parse", commitish], repositoryFileURL: repositoryFileURL)
+	.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+	.flatMap(.merge) { headCommitish in
+		launchGitTask(["describe", "--tags", "--exact-match", headCommitish], repositoryFileURL: repositoryFileURL)
+			.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+			.flatMapError { _  in SignalProducer(value: headCommitish) }
+	}
+}

--- a/Source/CarthageKit/GitURL.swift
+++ b/Source/CarthageKit/GitURL.swift
@@ -56,7 +56,7 @@ public struct GitURL {
 		} else {
 			absoluteURLString = urlString
 		}
-		let components = absoluteURLString.split(omittingEmptySubsequences: true) { $0 == "/" }
+		let components = absoluteURLString.split(omittingEmptySubsequences: true) { $0 == "/" || $0 == ":" }
 
 		return components
 			.last

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -107,14 +107,14 @@ public struct VersionFile: Codable {
 
 	/// Calculates the path of the version file corresponding with a dependency
 	/// - Parameters:
-	///   - dependency: the dependency
+	///   - dependencyName: the dependency's name
 	///   - rootDirectoryURL: the path to the root directory
-	public static func url(for dependency: Dependency, rootDirectoryURL: URL) -> URL {
+	public static func url(for dependencyName: String, rootDirectoryURL: URL) -> URL {
 		let rootBinariesURL = rootDirectoryURL
 			.appendingPathComponent(Constants.binariesFolderPath, isDirectory: true)
 			.resolvingSymlinksInPath()
 		return rootBinariesURL
-			.appendingPathComponent(".\(dependency.name).\(VersionFile.pathExtension)")
+			.appendingPathComponent(".\(dependencyName).\(VersionFile.pathExtension)")
 	}
 
 	/// Calculates the path of the framework corresponding with a version file
@@ -305,77 +305,7 @@ public func createVersionFileForCurrentProject(
 	buildProducts: [URL],
 	rootDirectoryURL: URL
 ) -> SignalProducer<(), CarthageError> {
-
-	/*
-	List all remotes known for this repository
-	and keep only the "fetch" urls by which the current repository
-	would be known for the purpose of fetching anyways.
-
-	Example of well-formed output:
-
-		$ git remote -v
-		origin   https://github.com/blender/Carthage.git (fetch)
-		origin   https://github.com/blender/Carthage.git (push)
-		upstream https://github.com/Carthage/Carthage.git (fetch)
-		upstream https://github.com/Carthage/Carthage.git (push)
-
-	Example of ill-formed output where upstream does not have a url:
-
-		$ git remote -v
-		origin   https://github.com/blender/Carthage.git (fetch)
-		origin   https://github.com/blender/Carthage.git (push)
-		upstream
-	*/
-	let allRemoteURLs = launchGitTask(["remote", "-v"])
-		.flatMap(.concat) { $0.linesProducer }
-		.map { $0.components(separatedBy: .whitespacesAndNewlines) }
-		.filter { $0.count >= 3 && $0.last == "(fetch)" } // Discard ill-formed output as of example
-		.map { ($0[0], $0[1]) }
-		.collect()
-
-	let currentProjectName = allRemoteURLs
-		// Assess the popularity of each remote url
-		.map { $0.reduce([String: (popularity: Int, remoteNameAndURL: (name: String, url: String))]()) { remoteURLPopularityMap, remoteNameAndURL in
-			let (remoteName, remoteUrl) = remoteNameAndURL
-			var remoteURLPopularityMap = remoteURLPopularityMap
-			if let existingEntry = remoteURLPopularityMap[remoteName] {
-				remoteURLPopularityMap[remoteName] = (existingEntry.popularity + 1, existingEntry.remoteNameAndURL)
-			} else {
-				remoteURLPopularityMap[remoteName] = (0, (remoteName, remoteUrl))
-			}
-			return remoteURLPopularityMap
-			}
-		}
-		// Pick "origin" if it exists,
-		// otherwise sort remotes by popularity
-		// or alphabetically in case of a draw
-		.map { (remotePopularityMap: [String: (popularity: Int, remoteNameAndURL: (name: String, url: String))]) -> String in
-			guard let origin = remotePopularityMap["origin"] else {
-				let urlOfMostPopularRemote = remotePopularityMap.sorted { lhs, rhs in
-					if lhs.value.popularity == rhs.value.popularity {
-						return lhs.key < rhs.key
-					}
-					return lhs.value.popularity > rhs.value.popularity
-				}
-				.first?.value.remoteNameAndURL.url
-
-				// If the reposiroty is not pushed to any remote
-				// the list of remotes is empty, so call the current project... "_Current"
-				return urlOfMostPopularRemote.flatMap { Dependency.git(GitURL($0)).name } ?? "_Current"
-			}
-
-			return Dependency.git(GitURL(origin.remoteNameAndURL.url)).name
-		}
-
-	let currentGitTagOrCommitish = launchGitTask(["rev-parse", "HEAD"])
-		.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-		.flatMap(.merge) { headCommitish in
-			launchGitTask(["describe", "--tags", "--exact-match", headCommitish])
-				.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-				.flatMapError { _  in SignalProducer(value: headCommitish) }
-		}
-
-	 return SignalProducer.zip(currentProjectName, currentGitTagOrCommitish)
+	return SignalProducer.zip(projectName(for: rootDirectoryURL), describeTagOrCommitish("HEAD", in: rootDirectoryURL))
 		.flatMap(.merge) { currentProjectNameString, version in
 			createVersionFileForCommitish(
 				version,
@@ -535,13 +465,13 @@ public func createVersionFileForCommitish(
 /// otherwise true if the version file matches and the build can be
 /// skipped or false if there is a mismatch of some kind.
 public func versionFileMatches(
-	_ dependency: Dependency,
+	_ dependencyName: String,
 	version: PinnedVersion,
 	platforms: Set<Platform>,
 	rootDirectoryURL: URL,
 	toolchain: String?
 ) -> SignalProducer<Bool?, CarthageError> {
-	let versionFileURL = VersionFile.url(for: dependency, rootDirectoryURL: rootDirectoryURL)
+	let versionFileURL = VersionFile.url(for: dependencyName, rootDirectoryURL: rootDirectoryURL)
 	guard let versionFile = VersionFile(url: versionFileURL) else {
 		return SignalProducer(value: nil)
 	}

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -113,15 +113,15 @@ internal struct ProjectEventSink {
 		case let .skippedBuilding(dependency, message):
 			carthage.println(formatting.bullets + "Skipped building " + formatting.projectName(dependency.name) + " due to the error:\n" + message)
 
-		case let .skippedBuildingCached(dependency):
-			carthage.println(formatting.bullets + "Valid cache found for " + formatting.projectName(dependency.name) + ", skipping build")
+		case let .skippedBuildingCached(dependencyName):
+			carthage.println(formatting.bullets + "Valid cache found for " + formatting.projectName(dependencyName) + ", skipping build")
 
-		case let .rebuildingCached(dependency):
-			carthage.println(formatting.bullets + "Invalid cache found for " + formatting.projectName(dependency.name)
+		case let .rebuildingCached(dependencyName):
+			carthage.println(formatting.bullets + "Invalid cache found for " + formatting.projectName(dependencyName)
 				+ ", rebuilding with all downstream dependencies")
 
-		case let .buildingUncached(dependency):
-			carthage.println(formatting.bullets + "No cache found for " + formatting.projectName(dependency.name)
+		case let .buildingUncached(dependencyName):
+			carthage.println(formatting.bullets + "No cache found for " + formatting.projectName(dependencyName)
 				+ ", building with all downstream dependencies")
 
 		case let .removingUnneededItem(url):


### PR DESCRIPTION
When building the local project with `carthage build --no-skip-current --cache-builds`, Carthage writes a version file (since #2636). However, this file is never checked, and invoking Carthage again will rebuild the project even though the version file is valid.

I've added logic to Build.swift that checks for a valid version file before sending the `currentProducers`, analogous to what Carthage does for dependencies in `buildCheckedOutDependenciesWithOptions`.

Some changes made to support this:
- The logic for determining a project name based on its git origins is extracted to its own function in Git.swift.
- Version file APIs and `ProjectEvent`s printed to the console take a `String` dependency name rather than a `Dependency`. This allow them to support the local project, which does not have a corresponding `Dependency`.
- `GitURL.name` correctly handles repos that are at the "top level" of their server (i.e. "git@example.com:MyRepo.git"). Repos like this won't exist on GitHub but are possible on other servers, and a test case I wrote exposed this.

As always, happy to tweak this or break it into multiple PRs if necessary :) 