### PR TITLE
Makefile - Check for and create binaries directory in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ prefix_install: installables
 	$(CP) -f "$(CARTHAGE_EXECUTABLE)" "$(PREFIX)/bin/"
 
 install: installables
+	if [ ! -d "$(BINARIES_FOLDER)" ]; then $(SUDO) $(MKDIR) "$(BINARIES_FOLDER)"; fi
 	$(SUDO) $(CP) -f "$(CARTHAGE_EXECUTABLE)" "$(BINARIES_FOLDER)"
 
 uninstall:


### PR DESCRIPTION
Addresses Carthage/Carthage#2941

Modified the `install` make target so that the `BINARIES` directory is check for existence and create if not.