### PR TITLE
Don't filter workspaces that have valid schemes

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -276,8 +276,8 @@ public func schemesInProjects(_ projects: [(ProjectLocator, [Scheme])]) -> Signa
 			switch project {
 			case .projectFile where !schemes.isEmpty:
 				return true
-            case .workspace where !schemes.isEmpty:
-                return true
+ 			case .workspace where !schemes.isEmpty:
+				return true
 			default:
 				return false
 			}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -276,7 +276,8 @@ public func schemesInProjects(_ projects: [(ProjectLocator, [Scheme])]) -> Signa
 			switch project {
 			case .projectFile where !schemes.isEmpty:
 				return true
-
+            case .workspace where !schemes.isEmpty:
+                return true
 			default:
 				return false
 			}


### PR DESCRIPTION
Presently with Carthage if you scheme is located inside the workspace, Carthage is unable to find a valid scheme and errors out.

See the following example of Alamofire where I moved the scheme into the workspace container, and out of the project:

https://github.com/Alamofire/Alamofire/commit/c32797bbaeec605c8ce647a6443718aa1794498d

Now when I try to build, I get the following:

```
2.4.4 ExampleCarthagePull
 ➲  carthage update
*** Fetching Alamofire
*** Checking out Alamofire at "93cc83453ffee1c6e9aee7bde60bb3732b15b858"
*** xcodebuild output can be found in /var/folders/td/0lcyjgbx5cz4tj2tgmckz8mc0000gn/T/carthage-xcodebuild.LXYoZ1.log
*** Skipped building Alamofire due to the error:
Dependency "Alamofire" has no shared framework schemes

If you believe this to be an error, please file an issue with the maintainers at https://github.com/MikeSilvis/Alamofire/issues/new
```
