### PR TITLE
Fix integration test that is failing on newer versions of Xcode

### DIFF
--- a/IntegrationTests/copy-frameworks.bats
+++ b/IntegrationTests/copy-frameworks.bats
@@ -15,7 +15,7 @@ teardown() {
     run carthage update --platform ios
     [ "$status" -eq 0 ]
 
-    run xcodebuild clean build-for-testing -scheme CarthageCopyFrameworksFixture -sdk iphonesimulator -destination "name=iPhone 6s"
+    run xcodebuild clean build-for-testing -scheme CarthageCopyFrameworksFixture -sdk iphonesimulator -destination "name=iPhone 8"
     [ "$status" -eq 0 ]
 
     ARCHIVE_APP_DIR=CarthageCopyFrameworksFixture.xcarchive/Products/Applications


### PR DESCRIPTION
Newer versions of Xcode don't have an iPhone 6s by default so this should be a good compromise that works on older and newer versions of Xcode.