### PR TITLE
Publish version functions

### DIFF
--- a/Source/CarthageKit/SwiftVersionError.swift
+++ b/Source/CarthageKit/SwiftVersionError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal enum SwiftVersionError: Error, Equatable {
+public enum SwiftVersionError: Error, Equatable {
 	/// An error in determining the local Swift version
 	case unknownLocalSwiftVersion
 
@@ -13,7 +13,7 @@ internal enum SwiftVersionError: Error, Equatable {
 }
 
 extension SwiftVersionError: CustomStringConvertible {
-	var description: String {
+	public var description: String {
 		switch self {
 		case .unknownLocalSwiftVersion:
 			return "Unable to determine local Swift version."

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -7,7 +7,7 @@ import ReactiveTask
 import XCDBLD
 
 /// Emits the currect Swift version
-internal func swiftVersion(usingToolchain toolchain: String? = nil) -> SignalProducer<String, SwiftVersionError> {
+public func swiftVersion(usingToolchain toolchain: String? = nil) -> SignalProducer<String, SwiftVersionError> {
 	return determineSwiftVersion(usingToolchain: toolchain).replayLazily(upTo: 1)
 }
 

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -51,7 +51,7 @@ private func parseSwiftVersionCommand(output: String?) -> String? {
 }
 
 /// Determines the Swift version of a framework at a given `URL`.
-internal func frameworkSwiftVersionIfIsSwiftFramework(_ frameworkURL: URL) -> SignalProducer<String?, SwiftVersionError> {
+public func frameworkSwiftVersionIfIsSwiftFramework(_ frameworkURL: URL) -> SignalProducer<String?, SwiftVersionError> {
 	guard isSwiftFramework(frameworkURL) else {
 		return SignalProducer(value: nil)
 	}
@@ -59,7 +59,7 @@ internal func frameworkSwiftVersionIfIsSwiftFramework(_ frameworkURL: URL) -> Si
 }
 
 /// Determines the Swift version of a framework at a given `URL`.
-internal func frameworkSwiftVersion(_ frameworkURL: URL) -> SignalProducer<String, SwiftVersionError> {
+public func frameworkSwiftVersion(_ frameworkURL: URL) -> SignalProducer<String, SwiftVersionError> {
 	// Fall back to dSYM version parsing if header is not present
 	guard let swiftHeaderURL = frameworkURL.swiftHeaderURL() else {
 		return dSYMSwiftVersion(frameworkURL.appendingPathExtension("dSYM"))


### PR DESCRIPTION
Hi,

for a tool I am using, I would love to use version producers that also _CarthageKit_ uses, unluckily they are `internal`, is there an option to make them `public`? 🙂 

Thanks