### PR TITLE
Swift 5.2 migration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "2cd0210f897fe46c6ce42f52ccfa72b3bbb621a0",
-          "version": "0.16.0"
+          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
+          "version": "0.17.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
-          "version": "8.0.2"
+          "revision": "7fd118ec8795888bcbbebc1a41f6984454c4cd6f",
+          "version": "8.0.7"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
-          "version": "2.1.0"
+          "revision": "33682c2f6230c60614861dfc61df267e11a1602f",
+          "version": "2.2.0"
         }
       },
       {
@@ -51,35 +51,26 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
         "state": {
           "branch": null,
-          "revision": "c37950dc5020544c58d4bf47c0d028893686b9e6",
-          "version": "5.0.1"
+          "revision": "e27ccdbf4ec36f154b60b91a0d7e0110c4e882cb",
+          "version": "6.2.1"
         }
       },
       {
         "package": "ReactiveTask",
         "repositoryURL": "https://github.com/Carthage/ReactiveTask.git",
         "state": {
-          "branch": null,
-          "revision": "df1bf7625684180b9377a8ba3c076db08d98757e",
-          "version": "0.16.0"
-        }
-      },
-      {
-        "package": "Result",
-        "repositoryURL": "https://github.com/antitypical/Result.git",
-        "state": {
-          "branch": null,
-          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
-          "version": "4.1.0"
+          "branch": "master",
+          "revision": "e1396a56055812234e97aeda78731d7228e0bbc7",
+          "version": null
         }
       },
       {
         "package": "Tentacle",
-        "repositoryURL": "https://github.com/mdiep/Tentacle.git",
+        "repositoryURL": "https://github.com/olejnjak/Tentacle.git",
         "state": {
-          "branch": null,
-          "revision": "578edd088b03bc749c49253b15ae2d5aaa9aa7df",
-          "version": "0.13.1"
+          "branch": "swift5.2",
+          "revision": "6681c015a2ab5d5fb6c07ca4ada07c7a649c76a5",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -44,5 +44,5 @@ let package = Package(
             exclude: ["swift-is-crashy.c"]
         ),
     ],
-    swiftLanguageVersions: [.v4_2]
+    swiftLanguageVersions: [.version("5.2")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,13 @@ let package = Package(
         .executable(name: "carthage", targets: ["carthage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/antitypical/Result.git", from: "4.1.0"),
-        .package(url: "https://github.com/Carthage/ReactiveTask.git", from: "0.16.0"),
+//        .package(url: "https://github.com/Carthage/ReactiveTask.git", from: "0.16.0"),
+        .package(url: "https://github.com/Carthage/ReactiveTask.git", .branch("master")),
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.16.0"),
         .package(url: "https://github.com/jdhealy/PrettyColors.git", from: "5.0.2"),
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0"),
-        .package(url: "https://github.com/mdiep/Tentacle.git", from: "0.13.1"),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.2.0"),
+//        .package(url: "https://github.com/mdiep/Tentacle.git", from: "0.13.1"),
+        .package(url: "https://github.com/olejnjak/Tentacle.git", .branch("swift5.2")),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.2"),
         .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
@@ -22,7 +23,7 @@ let package = Package(
     targets: [
         .target(
             name: "XCDBLD",
-            dependencies: ["Result", "ReactiveSwift", "ReactiveTask"]
+            dependencies: ["ReactiveSwift", "ReactiveTask"]
         ),
         .testTarget(
             name: "XCDBLDTests",

--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import ReactiveSwift
 import ReactiveTask
 

--- a/Source/CarthageKit/Availability.swift
+++ b/Source/CarthageKit/Availability.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ReactiveSwift
-import Result
 import XCDBLD
 
 // swiftlint:disable missing_docs fatal_error_message

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// Represents a binary dependency 
 public struct BinaryProject: Equatable {
@@ -8,8 +7,8 @@ public struct BinaryProject: Equatable {
 	public var versions: [PinnedVersion: URL]
 
 	public static func from(jsonData: Data) -> Result<BinaryProject, BinaryJSONError> {
-		return Result<[String: String], AnyError>(attempt: { try jsonDecoder.decode([String: String].self, from: jsonData) })
-			.mapError { .invalidJSON($0.error) }
+		return Result<[String: String], Error> { try jsonDecoder.decode([String: String].self, from: jsonData) }
+			.mapError { .invalidJSON($0) }
 			.flatMap { json -> Result<BinaryProject, BinaryJSONError> in
 				var versions = [PinnedVersion: URL]()
 

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import ReactiveSwift
 import XCDBLD
 

--- a/Source/CarthageKit/Cartfile.swift
+++ b/Source/CarthageKit/Cartfile.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// Represents a Cartfile, which is a specification of a project's dependencies
 /// and any other settings Carthage needs to build it.
@@ -94,7 +93,7 @@ public struct Cartfile {
 	/// Attempts to parse a Cartfile from a file at a given URL.
 	public static func from(file cartfileURL: URL) -> Result<Cartfile, CarthageError> {
 		return Result(catching: { try String(contentsOf: cartfileURL, encoding: .utf8) })
-			.mapError { .readFailed(cartfileURL, $0) }
+			.mapError { .readFailed(cartfileURL, $0 as NSError) }
 			.flatMap(Cartfile.from(string:))
 			.mapError { error in
 				guard case let .duplicateDependencies(dupes) = error else { return error }

--- a/Source/CarthageKit/CompatibilityInfo.swift
+++ b/Source/CarthageKit/CompatibilityInfo.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// Identifies a dependency, its pinned version, and its compatible and incompatible requirements
 public struct CompatibilityInfo: Equatable {
@@ -40,14 +39,14 @@ public struct CompatibilityInfo: Equatable {
 				var requirements = invertedRequirements[requiredDependency] ?? [:]
 
 				if requirements[dependency] != nil {
-					return .init(error: .duplicateDependencies([DuplicateDependency(dependency: dependency, locations: [])]))
+					return .failure(.duplicateDependencies([DuplicateDependency(dependency: dependency, locations: [])]))
 				}
 
 				requirements[dependency] = requiredVersion
 				invertedRequirements[requiredDependency] = requirements
 			}
 		}
-		return .init(invertedRequirements)
+		return .success(invertedRequirements)
 	}
 
 	/// Constructs CompatibilityInfo objects for dependencies with incompatibilities

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// A struct including all constants.
 public struct Constants {
@@ -31,7 +30,7 @@ public struct Constants {
 	private static let userCachesURL: URL = {
 		let fileManager = FileManager.default
 
-		let urlResult: Result<URL, NSError> = Result(catching: {
+		let urlResult: Result<URL, Error> = Result(catching: {
 			try fileManager.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
 		}).flatMap { cachesURL in
 			let dependenciesURL = cachesURL.appendingPathComponent(Constants.bundleIdentifier, isDirectory: true)
@@ -39,10 +38,10 @@ public struct Constants {
 
 			if fileManager.fileExists(atPath: dependenciesPath, isDirectory: nil) {
 				if fileManager.isWritableFile(atPath: dependenciesPath) {
-					return Result(value: dependenciesURL)
+                    return .success(dependenciesURL)
 				} else {
 					let error = NSError(domain: Constants.bundleIdentifier, code: 0, userInfo: nil)
-					return Result(error: error)
+                    return .failure(error)
 				}
 			} else {
 				return Result(catching: {

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import Tentacle
 
 /// Uniquely identifies a Binary Spec's resolved URL and its description

--- a/Source/CarthageKit/Dependency.swift
+++ b/Source/CarthageKit/Dependency.swift
@@ -71,7 +71,8 @@ extension Dependency {
 				let ownerAndNameSubstring = String(urlString[urlString.index(urlString.startIndex, offsetBy: startOfOwnerAndNameSubstring)..<urlString.endIndex])
 
 				switch Repository.fromIdentifier(ownerAndNameSubstring as String) {
-				case .success(let server, let repository):
+				case .success(let success):
+                    let (server, repository) = success
 					self = Dependency.gitHub(server, repository)
 
 				default:

--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import ReactiveSwift
 import Tentacle
 

--- a/Source/CarthageKit/MachHeader.swift
+++ b/Source/CarthageKit/MachHeader.swift
@@ -79,7 +79,7 @@ extension MachHeader {
 			.filter { !$0.isEmpty }
 			.flatMap(.merge) { (output: String) -> SignalProducer<(String, String), Never> in
 				output.linesProducer.combinePrevious()
-			}.filterMap { previousLine, currentLine -> MachHeader? in
+			}.compactMap { previousLine, currentLine -> MachHeader? in
 
 				let previousLineComponents = previousLine
 					.components(separatedBy: CharacterSet.whitespaces)

--- a/Source/CarthageKit/MachHeader.swift
+++ b/Source/CarthageKit/MachHeader.swift
@@ -2,7 +2,6 @@ import Foundation
 import MachO.loader
 import ReactiveTask
 import ReactiveSwift
-import Result
 
 /// Represents a Mach header
 ///
@@ -78,7 +77,7 @@ extension MachHeader {
 			.ignoreTaskData()
 			.map { String(data: $0, encoding: .utf8) ?? "" }
 			.filter { !$0.isEmpty }
-			.flatMap(.merge) { (output: String) -> SignalProducer<(String, String), NoError> in
+			.flatMap(.merge) { (output: String) -> SignalProducer<(String, String), Never> in
 				output.linesProducer.combinePrevious()
 			}.filterMap { previousLine, currentLine -> MachHeader? in
 

--- a/Source/CarthageKit/Netrc.swift
+++ b/Source/CarthageKit/Netrc.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 struct NetrcMachine {
 	let name: String
@@ -15,6 +14,7 @@ struct Netrc {
 		case machineNotFound
 		case missingToken(String)
 		case missingValueForToken(String)
+        case unknown(Error)
 	}
 	
 	public let machines: [NetrcMachine]
@@ -36,6 +36,7 @@ struct Netrc {
 		guard FileManager.default.isReadableFile(atPath: fileURL.path) else { return .failure(NetrcError.unreadableFile(fileURL)) }
 		
 		return Result(catching: { try String(contentsOf: fileURL, encoding: .utf8) })
+            .mapError { .unknown($0) }
 			.flatMap { Netrc.from($0) }
 	}
 	

--- a/Source/CarthageKit/NewResolver.swift
+++ b/Source/CarthageKit/NewResolver.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import ReactiveSwift
 
 /// Responsible for resolving acyclic dependency graphs.

--- a/Source/CarthageKit/ProductType.swift
+++ b/Source/CarthageKit/ProductType.swift
@@ -1,4 +1,3 @@
-import Result
 
 /// Describes the type of product built by an Xcode target.
 public enum ProductType: String {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1305,7 +1305,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 								return .empty
 							}
 							return self.installBinaries(for: dependency, pinnedVersion: version, toolchain: options.toolchain)
-								.filterMap { installed -> (Dependency, PinnedVersion)? in
+								.compactMap { installed -> (Dependency, PinnedVersion)? in
 									return installed ? (dependency, version) : nil
 								}
 						case let .binary(binary):

--- a/Source/CarthageKit/RemoteVersion.swift
+++ b/Source/CarthageKit/RemoteVersion.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ReactiveSwift
 import ReactiveTask
-import Result
 import Tentacle
 
 /// Synchronously returns the semantic version of the newest release,

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -68,7 +68,7 @@ public struct Resolver: ResolverProtocol {
 				}
 
 				// When target dependencies are specified
-				return orderedNodesProducer.filterMap { node -> (Dependency, PinnedVersion)? in
+				return orderedNodesProducer.compactMap { node -> (Dependency, PinnedVersion)? in
 					// A dependency included in the targets should be affected.
 					if dependenciesToUpdate.contains(node.dependency.name) {
 						return node.pinnedDependency

--- a/Source/CarthageKit/Resolver.swift
+++ b/Source/CarthageKit/Resolver.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import ReactiveSwift
 
 /// Protocol for resolving acyclic dependency graphs.
@@ -167,7 +166,7 @@ public struct Resolver: ResolverProtocol {
 		basedOnGraph inputGraph: DependencyGraph
 	) -> SignalProducer<DependencyGraph, CarthageError> {
 		return nodePermutations(for: dependencies)
-			.flatMap(.concat) { (nodes: [DependencyNode]) -> SignalProducer<Signal<DependencyGraph, CarthageError>.Event, NoError> in
+			.flatMap(.concat) { (nodes: [DependencyNode]) -> SignalProducer<Signal<DependencyGraph, CarthageError>.Event, Never> in
 				return self
 					.graphs(for: nodes, dependencyOf: dependencyOf, basedOnGraph: inputGraph)
 					.materialize()
@@ -203,7 +202,7 @@ public struct Resolver: ResolverProtocol {
 					.map { node in self.graphsForDependenciesOfNode(node, basedOnGraph: graph) }
 					.observe(on: scheduler)
 					.permute()
-					.flatMap(.concat) { graphs -> SignalProducer<Signal<DependencyGraph, CarthageError>.Event, NoError> in
+					.flatMap(.concat) { graphs -> SignalProducer<Signal<DependencyGraph, CarthageError>.Event, Never> in
 						return SignalProducer<DependencyGraph, CarthageError> {
 								mergeGraphs([ inputGraph ] + graphs)
 							}
@@ -365,11 +364,11 @@ private struct DependencyGraph {
 				newNodes.append(newNode)
 
 			case let .failure(error):
-				return Result(error: error)
+                return .failure(error)
 			}
 		}
 
-		return Result(value: newNodes)
+            return .success(newNodes)
 	}
 
 	/// Whether the given node is included or not in the nested dependencies of

--- a/Source/CarthageKit/Scannable.swift
+++ b/Source/CarthageKit/Scannable.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// Anything that can be parsed from a Scanner.
 public protocol Scannable {

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable file_length
 
 import Foundation
-import Result
 import ReactiveSwift
 
 /// A semantic version.

--- a/Source/CarthageKit/Version.swift
+++ b/Source/CarthageKit/Version.swift
@@ -50,10 +50,10 @@ public struct SemanticVersion: Hashable {
 		self.preRelease = preRelease
 		self.buildMetadata = buildMetadata
 	}
-
-	public var hashValue: Int {
-		return components.reduce(0) { $0 ^ $1.hashValue }
-	}
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(components)
+    }
 }
 
 extension SemanticVersion {

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ReactiveSwift
 import ReactiveTask
-import Result
 import XCDBLD
 
 /// A representation of the cached frameworks

--- a/Source/CarthageKit/XCDBLDExtensions.swift
+++ b/Source/CarthageKit/XCDBLDExtensions.swift
@@ -45,7 +45,7 @@ extension ProjectLocator {
 						return !directoriesToSkip.contains { $0.hasSubdirectory(url) }
 					}
 			}
-			.filterMap { url -> ProjectLocator? in
+			.compactMap { url -> ProjectLocator? in
 				if let uti = url.typeIdentifier.value {
 					if UTTypeConformsTo(uti as CFString, "com.apple.dt.document.workspace" as CFString) {
 						return .workspace(url)

--- a/Source/CarthageKit/XCDBLDExtensions.swift
+++ b/Source/CarthageKit/XCDBLDExtensions.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ReactiveSwift
 import ReactiveTask
-import Result
 import XCDBLD
 
 extension MachOType {

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -904,8 +904,8 @@ public func build(
 			case let (_, .noSharedFrameworkSchemes(_, platforms)):
 				return .noSharedFrameworkSchemes(dependency, platforms)
 
-			case let (.gitHub(repo), .noSharedSchemes(project, _)):
-				return .noSharedSchemes(project, repo)
+			case let (.gitHub(server, repository), .noSharedSchemes(project, _)):
+				return .noSharedSchemes(project, (server, repository))
 
 			default:
 				return error

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable file_length
 
 import Foundation
-import Result
 import ReactiveSwift
 import ReactiveTask
 import XCDBLD
@@ -100,7 +99,7 @@ private func dSYMSwiftVersion(_ dSYMURL: URL) -> SignalProducer<String, SwiftVer
 		.ignoreTaskData()
 		.map { String(data: $0, encoding: .utf8) ?? "" }
 		.filter { !$0.isEmpty }
-		.flatMap(.merge) { (output: String) -> SignalProducer<String, NoError> in
+		.flatMap(.merge) { (output: String) -> SignalProducer<String, Never> in
 			output.linesProducer
 		}
 		.filter { $0.contains("AT_producer") }

--- a/Source/XCDBLD/MachOType.swift
+++ b/Source/XCDBLD/MachOType.swift
@@ -1,4 +1,3 @@
-import Result
 
 /// Describes the type of Mach-O files.
 /// See https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW73.

--- a/Source/XCDBLD/ResultExtensions.swift
+++ b/Source/XCDBLD/ResultExtensions.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public extension Result {
+    /// Returns value for `.success`, `nil` for `failure`
+    var value: Success? { try? get() }
+    
+    /// Returns erro value for `.failure`, `nil` for `success`
+    var error: Failure? {
+        switch self {
+        case .success: return nil
+        case .failure(let error): return error
+        }
+    }
+    
+    /// Returns a Result with a tuple of the receiver and `other` values if both
+    /// are `Success`es, or re-wrapping the error of the earlier `Failure`.
+    func fanout<U>(_ other: @autoclosure () -> Result<U, Error>) -> Result<(Value, U), Error> {
+        return self.flatMap { left in other().map { right in (left, right) } }
+    }
+    
+    /// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
+    func flatMap<U>(_ transform: (Value) -> Result<U, Error>) -> Result<U, Error> {
+        switch self {
+        case let .success(value): return transform(value)
+        case let .failure(error): return .failure(error)
+        }
+    }
+    
+    /// Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`
+    func recover(_ value: @autoclosure () -> Value) -> Value {
+        return self.value ?? value()
+    }
+
+    /// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`
+    func recover(with result: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error> {
+        switch self {
+        case .success: return self
+        case .failure: return result()
+        }
+    }
+    
+    /// Case analysis for Result.
+    ///
+    /// Returns the value produced by applying `ifFailure` to `failure` Results, or `ifSuccess` to `success` Results.
+    func analysis<Result>(ifSuccess: (Value) -> Result, ifFailure: (Error) -> Result) -> Result {
+        switch self {
+        case let .success(value):
+            return ifSuccess(value)
+        case let .failure(value):
+            return ifFailure(value)
+        }
+    }
+    
+    /// The domain for errors constructed by Result.
+    static var errorDomain: String { return "com.antitypical.Result" }
+
+    /// The userInfo key for source functions in errors constructed by Result.
+    static var functionKey: String { return "\(errorDomain).function" }
+
+    /// The userInfo key for source file paths in errors constructed by Result.
+    static var fileKey: String { return "\(errorDomain).file" }
+
+    /// The userInfo key for source file line numbers in errors constructed by Result.
+    static var lineKey: String { return "\(errorDomain).line" }
+    
+    /// Constructs an error.
+    static func error(_ message: String? = nil, function: String = #function, file: String = #file, line: Int = #line) -> NSError {
+        var userInfo: [String: Any] = [
+            functionKey: function,
+            fileKey: file,
+            lineKey: line,
+        ]
+
+        if let message = message {
+            userInfo[NSLocalizedDescriptionKey] = message
+        }
+
+        return NSError(domain: errorDomain, code: 0, userInfo: userInfo)
+    }
+    
+    /// Constructs a result from an `Optional`, failing with `Error` if `nil`.
+    init(_ value: Value?, failWith: @autoclosure () -> Error) {
+        self = value.map(Result.success) ?? .failure(failWith())
+    }
+}

--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 
 /// Represents an SDK buildable by Xcode.
 public enum SDK: String {

--- a/Source/XCDBLD/XcodeVersion.swift
+++ b/Source/XCDBLD/XcodeVersion.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Result
 import ReactiveSwift
 import ReactiveTask
 

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 import XCDBLD
 import Curry

--- a/Source/carthage/Bootstrap.swift
+++ b/Source/carthage/Bootstrap.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 
 /// Type that encapsulates the configuration and evaluation of the `bootstrap` subcommand.

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 import ReactiveTask
 import XCDBLD

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -115,7 +115,9 @@ public struct BuildCommand: CommandProtocol {
 							case let .standardError(data):
 								stderrHandle.write(data)
 
-							case let .success(project, scheme):
+							case let .success(event):
+                                let (project, scheme) = event
+                                
 								carthage.println(formatting.bullets + "Building scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
 							}
 						}

--- a/Source/carthage/Checkout.swift
+++ b/Source/carthage/Checkout.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 import Curry
 

--- a/Source/carthage/Cleanup.swift
+++ b/Source/carthage/Cleanup.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import Curry
 
 /// Type that encapsulates the configuration and evaluation of the `cleanup` subcommand.

--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 
 /// Type that encapsulates the configuration and evaluation of the `copy-frameworks` subcommand.
@@ -202,7 +201,7 @@ private func scriptInputFileLists() -> SignalProducer<String, CarthageError> {
 				.attemptMap { getEnvironmentVariable("SCRIPT_INPUT_FILE_LIST_\($0)") }
 				.flatMap(.merge) { fileList -> SignalProducer<String, CarthageError> in
 					let fileListURL = URL(fileURLWithPath: fileList, isDirectory: true)
-					return SignalProducer<String, NSError>(result: Result(catching: { try String(contentsOfFile: fileList) }))
+                    return SignalProducer<String, NSError>(result: Result { try String(contentsOfFile: fileList) }.mapError { $0 as NSError })
 						.mapError { CarthageError.readFailed(fileListURL, $0) }
 				}
 				.map { $0.split(separator: "\n").map(String.init) }

--- a/Source/carthage/Environment.swift
+++ b/Source/carthage/Environment.swift
@@ -1,6 +1,5 @@
 import CarthageKit
 import Foundation
-import Result
 
 internal func getEnvironmentVariable(_ variable: String) -> Result<String, CarthageError> {
 	let environment = ProcessInfo.processInfo.environment

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -4,7 +4,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 import ReactiveTask
 

--- a/Source/carthage/Fetch.swift
+++ b/Source/carthage/Fetch.swift
@@ -1,6 +1,5 @@
 import CarthageKit
 import Commandant
-import Result
 import Foundation
 import ReactiveSwift
 import Curry

--- a/Source/carthage/Formatting.swift
+++ b/Source/carthage/Formatting.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import PrettyColors
 import Curry
 

--- a/Source/carthage/Outdated.swift
+++ b/Source/carthage/Outdated.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 import Curry
 

--- a/Source/carthage/RemoteVersion.swift
+++ b/Source/carthage/RemoteVersion.swift
@@ -9,7 +9,7 @@ public func remoteVersion() -> SemanticVersion? {
 	let remoteVersionProducer = Client(.dotCom, urlSession: URLSession.proxiedSession)
 		.execute(Repository(owner: "Carthage", name: "Carthage").releases, perPage: 2)
 		.mapError(CarthageError.gitHubAPIRequestFailed)
-		.filterMap { _, releases in
+		.compactMap { _, releases in
 			return releases.first { !$0.isDraft }
 		}
 	return remoteVersion(remoteVersionProducer)

--- a/Source/carthage/RemoteVersion.swift
+++ b/Source/carthage/RemoteVersion.swift
@@ -2,7 +2,6 @@ import Foundation
 import CarthageKit
 import ReactiveSwift
 import ReactiveTask
-import Result
 import Tentacle
 
 /// The latest version of Carthage as a `Version`.

--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 import ReactiveSwift
 import Curry
 

--- a/Source/carthage/Validate.swift
+++ b/Source/carthage/Validate.swift
@@ -2,7 +2,6 @@ import CarthageKit
 import Commandant
 import Foundation
 import ReactiveSwift
-import Result
 
 /// Type that encapsulates the configuration and evaluation of the `validate` subcommand.
 public struct ValidateCommand: CommandProtocol {

--- a/Source/carthage/Version.swift
+++ b/Source/carthage/Version.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import Commandant
 import Foundation
-import Result
 
 /// Type that encapsulates the configuration and evaluation of the `version` subcommand.
 public struct VersionCommand: CommandProtocol {

--- a/Source/carthage/main.swift
+++ b/Source/carthage/main.swift
@@ -3,7 +3,6 @@ import Commandant
 import Foundation
 import ReactiveSwift
 import ReactiveTask
-import Result
 
 setlinebuf(stdout)
 

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -1,6 +1,5 @@
 import CarthageKit
 import Foundation
-import Result
 import Tentacle
 import Nimble
 import Quick

--- a/Tests/CarthageKitTests/DB.swift
+++ b/Tests/CarthageKitTests/DB.swift
@@ -1,7 +1,6 @@
 import CarthageKit
 import ReactiveSwift
 import Foundation
-import Result
 import Tentacle
 
 // swiftlint:disable no_extension_access_modifier

--- a/Tests/CarthageKitTests/MachHeaderSpec.swift
+++ b/Tests/CarthageKitTests/MachHeaderSpec.swift
@@ -3,7 +3,6 @@ import Foundation
 import Nimble
 import Quick
 import ReactiveSwift
-import Result
 
 class MachHeaderSpec: QuickSpec {
 

--- a/Tests/CarthageKitTests/ResolverSpec.swift
+++ b/Tests/CarthageKitTests/ResolverSpec.swift
@@ -3,7 +3,6 @@ import Foundation
 import Nimble
 import Quick
 import ReactiveSwift
-import Result
 import Tentacle
 
 private func ==<A: Equatable, B: Equatable>(lhs: [(A, B)], rhs: [(A, B)]) -> Bool {

--- a/Tests/CarthageKitTests/ValidateSpec.swift
+++ b/Tests/CarthageKitTests/ValidateSpec.swift
@@ -3,7 +3,6 @@ import Foundation
 import Nimble
 import Quick
 import ReactiveSwift
-import Result
 import Tentacle
 
 private extension CarthageError {

--- a/Tests/CarthageKitTests/VersionFileSpec.swift
+++ b/Tests/CarthageKitTests/VersionFileSpec.swift
@@ -2,7 +2,6 @@ import Foundation
 import Quick
 import Nimble
 import ReactiveSwift
-import Result
 import XCDBLD
 @testable import CarthageKit
 

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -1,6 +1,5 @@
 @testable import CarthageKit
 import Foundation
-import Result
 import Nimble
 import Quick
 import ReactiveSwift
@@ -238,7 +237,7 @@ class XcodeSpec: QuickSpec {
 						.ignoreTaskData()
 						.mapError(CarthageError.taskError)
 						.map { String(data: $0, encoding: .utf8) ?? "" }
-						.flatMap(.merge) { output -> SignalProducer<Bool, NoError> in
+						.flatMap(.merge) { output -> SignalProducer<Bool, Never> in
 							return SignalProducer(value: output.contains("SO "))
 					}
 			}.single()


### PR DESCRIPTION
This PR demonstrates what changes would be necessary (or useful) to migrate Carthage to use Swift 5.2. TL;DR not much, just removing custom `Result` dependency would be fine. And for further development it would be very useful as in Swift 5 custom `Result` can be easily mistaken with the built-in type.