### PR TITLE
Prevent directory traversal (in more piecemeal way) allowing «project-directory» flag to function.

### DIFF
--- a/Tests/CarthageKitTests/DependencySpec.swift
+++ b/Tests/CarthageKitTests/DependencySpec.swift
@@ -100,28 +100,59 @@ class DependencySpec: QuickSpec {
 						fileManager.changeCurrentDirectoryPath(startingDirectory)
 					}
 
-					it("should be the directory name if the given URL string is '.'") {
+					it("should sanitize even despite the given URL string being (pathologically) solely the nul character") {
+						// this project would not be able to be checked out
+					
+						let dependency = Dependency.git(GitURL("\u{0000}"))
+
+						expect(dependency.name) == "␀"
+					}
+
+					it("should sanitize even despite the given URL string being (pathologically) solely the nul character and path separators") {
+						// this project would not be able to be checked out
+					
+						let dependency = Dependency.git(GitURL("/\u{0000}/"))
+
+						expect(dependency.name) == "␀"
+					}
+
+					it("should sanitize even despite the given URL string containing (pathologically) the nul character") {
+						// this project would not be able to be checked out
+					
+						let dependency = Dependency.git(GitURL("./../../../../../\u{0000}myproject"))
+
+						expect(dependency.name) == "␀myproject"
+					}
+
+
+					it("should sanitize if the given URL string is (pathologically) «.»") {
 						let dependency = Dependency.git(GitURL("."))
 
-						expect(dependency.name) == temporaryDirectoryURL.lastPathComponent
+						expect(dependency.name) == "\u{FF0E}"
 					}
 
-					it ("should be the directory name if the given URL string is prefixed by './'") {
+					it ("should be the directory name if the given URL string is (pathologically) prefixed by «./»") {
 						let dependency = Dependency.git(GitURL("./myproject"))
 
-						expect(dependency.name) == "myproject"
+						expect(dependency.name) == "myproject"	
 					}
 
-					it("should be the directory name if the given URL string is '..'") {
+					it("should sanitize if the given URL string is (pathologically) «..»") {
 						let dependency = Dependency.git(GitURL(".."))
 
-						expect(dependency.name) == temporaryDirectoryURL.deletingLastPathComponent().lastPathComponent
+						expect(dependency.name) == "\u{FF0E}\u{FF0E}"
 					}
 
-					it ("should be the directory name if the given URL string is prefixed by '../'") {
+					it ("should be the directory name if the given URL string is (pathologically) prefixed by «../» with (pathologically) no URL scheme") {
 						let dependency = Dependency.git(GitURL("../myproject"))
 
 						expect(dependency.name) == "myproject"
+					}
+
+					it ("should sanitize if the given URL string is (pathologically) suffixed by «/..»") {
+						let dependency = Dependency.git(GitURL("../myproject/.."))
+
+						expect(dependency.name) == "\u{FF0E}\u{FF0E}"
 					}
 				}
 			}


### PR DESCRIPTION
Also, sanitize [nul characters](https://en.wikipedia.org/wiki/Null_character) in `GitURL`s (transposing them to «␀».)

The cases in the modified test are — given a URL is specified and provided is a string without URL scheme — pathological, and as such the result for them from `GitURL.name` are maybe unintuitive, but decidedly safe.

The flag «--project-directory» clashed with the formerly placed (but never shipped in a tagged Carthage release) invocation of `FileManager.currentDirectoryPath`.

To avoid the clash, we settle on a less intuitive, but most importantly safe change — _to be clear_ a *breaking change* for some pathological URL-scheme–less or nul-character–containing Cartfile lines and `GitURL`s.