### PR TITLE
Built product info file - Proof of concept

### DIFF
--- a/Source/CarthageKit/BuiltProductInfo.swift
+++ b/Source/CarthageKit/BuiltProductInfo.swift
@@ -11,6 +11,18 @@ public struct BuiltProductInfo {
     var commitish: String?
     var fileNames: [String] = []
     
+    #if swift(>=5.0)
+    #else
+    init(swiftToolchainVersion: String,
+         productUrl: URL,
+         platform: Platform)
+    {
+        self.swiftToolchainVersion = swiftToolchainVersion
+        self.productUrl = productUrl
+        self.platform = platform
+    }
+    #endif
+    
     private var destinationDirectoryURL: URL {
         return productUrl.deletingLastPathComponent().deletingLastPathComponent()
     }

--- a/Source/CarthageKit/BuiltProductInfo.swift
+++ b/Source/CarthageKit/BuiltProductInfo.swift
@@ -1,16 +1,18 @@
 import Foundation
 import ReactiveSwift
 import Result
+import XCDBLD
 
 public struct BuiltProductInfo {
     
     var swiftToolchainVersion: String
     var productUrl: URL
+    var platform: Platform
     var commitish: String?
     var fileNames: [String] = []
     
     private var destinationDirectoryURL: URL {
-        return productUrl.deletingLastPathComponent()
+        return productUrl.deletingLastPathComponent().deletingLastPathComponent()
     }
     private var productFileName: String {
         return productUrl.lastPathComponent
@@ -31,6 +33,7 @@ public struct BuiltProductInfo {
     var asFile: BuiltProductInfoFile {
         return BuiltProductInfoFile(swiftToolchainVersion: swiftToolchainVersion,
                                     productFileName: productFileName,
+                                    platform: platform,
                                     commitish: commitish,
                                     fileNames: fileNames.sorted())
     }
@@ -38,7 +41,7 @@ public struct BuiltProductInfo {
     func writeJSONFile() -> Result<(), CarthageError> {
         return Result(at: destinationDirectoryURL, attempt: {
             let metadataFileURL = $0
-                .appendingPathComponent(".\(productFileName)")
+                .appendingPathComponent(".\(productFileName)-\(platform)")
                 .appendingPathExtension("builtProductInfo")
             let encoder = JSONEncoder()
             if #available(OSX 10.13, *) {
@@ -55,6 +58,7 @@ public struct BuiltProductInfo {
 public struct BuiltProductInfoFile: Codable {
     var swiftToolchainVersion: String?
     var productFileName: String?
+    var platform: Platform
     var commitish: String?
     var fileNames: [String] = []
 }
@@ -74,3 +78,5 @@ public func addCommitish(commitish: String, to builtProductInfos: [BuiltProductI
         })
     }
 }
+
+extension Platform : Codable {}

--- a/Source/CarthageKit/BuiltProductInfo.swift
+++ b/Source/CarthageKit/BuiltProductInfo.swift
@@ -42,7 +42,10 @@ public struct BuiltProductInfo {
         return copy
     }
     
-    var asFile: BuiltProductInfoFile {
+    func asFile() throws -> BuiltProductInfoFile {
+        guard let commitish = commitish else {
+            throw CarthageError.internalError(description: "BuiltProductInfo commitish is nil")
+        }
         return BuiltProductInfoFile(swiftToolchainVersion: swiftToolchainVersion,
                                     productFileName: productFileName,
                                     platform: platform,
@@ -61,18 +64,18 @@ public struct BuiltProductInfo {
             } else {
                 encoder.outputFormatting = [.prettyPrinted]
             }
-            let jsonData = try encoder.encode(self.asFile)
+            let jsonData = try encoder.encode(try self.asFile())
             try jsonData.write(to: metadataFileURL, options: .atomic)
         })
     }
 }
 
 public struct BuiltProductInfoFile: Codable {
-    var swiftToolchainVersion: String?
-    var productFileName: String?
+    var swiftToolchainVersion: String
+    var productFileName: String
     var platform: Platform
-    var commitish: String?
-    var fileNames: [String] = []
+    var commitish: String
+    var fileNames: [String]
 }
 
 public func writeBuiltProductInfoJSONFile(builtProductInfo: BuiltProductInfo) -> SignalProducer<(), CarthageError> {

--- a/Source/CarthageKit/BuiltProductInfo.swift
+++ b/Source/CarthageKit/BuiltProductInfo.swift
@@ -1,0 +1,76 @@
+import Foundation
+import ReactiveSwift
+import Result
+
+public struct BuiltProductInfo {
+    
+    var swiftToolchainVersion: String
+    var productUrl: URL
+    var commitish: String?
+    var fileNames: [String] = []
+    
+    private var destinationDirectoryURL: URL {
+        return productUrl.deletingLastPathComponent()
+    }
+    private var productFileName: String {
+        return productUrl.lastPathComponent
+    }
+    
+    func withCommitish(_ commitish: String) -> BuiltProductInfo {
+        var copy = self
+        copy.commitish = commitish
+        return copy
+    }
+    
+    func addingFile(_ fileUrl: URL) -> BuiltProductInfo {
+        var copy = self
+        copy.fileNames.append(fileUrl.lastPathComponent)
+        return copy
+    }
+    
+    var asFile: BuiltProductInfoFile {
+        return BuiltProductInfoFile(swiftToolchainVersion: swiftToolchainVersion,
+                                    productFileName: productFileName,
+                                    commitish: commitish,
+                                    fileNames: fileNames.sorted())
+    }
+    
+    func writeJSONFile() -> Result<(), CarthageError> {
+        return Result(at: destinationDirectoryURL, attempt: {
+            let metadataFileURL = $0
+                .appendingPathComponent(".\(productFileName)")
+                .appendingPathExtension("builtProductInfo")
+            let encoder = JSONEncoder()
+            if #available(OSX 10.13, *) {
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            } else {
+                encoder.outputFormatting = [.prettyPrinted]
+            }
+            let jsonData = try encoder.encode(self.asFile)
+            try jsonData.write(to: metadataFileURL, options: .atomic)
+        })
+    }
+}
+
+public struct BuiltProductInfoFile: Codable {
+    var swiftToolchainVersion: String?
+    var productFileName: String?
+    var commitish: String?
+    var fileNames: [String] = []
+}
+
+public func writeBuiltProductInfoJSONFile(builtProductInfo: BuiltProductInfo) -> SignalProducer<(), CarthageError> {
+    return SignalProducer<(), CarthageError> { () -> Result<(), CarthageError> in
+        return builtProductInfo.writeJSONFile()
+    }
+}
+
+public func addCommitish(commitish: String, to builtProductInfos: [BuiltProductInfo]) -> SignalProducer<[BuiltProductInfo], CarthageError> {
+    return SignalProducer<[BuiltProductInfo], CarthageError> { () -> Result<[BuiltProductInfo], CarthageError> in
+        return Result(catching: {
+            return builtProductInfos.map {
+                return $0.withCommitish(commitish)
+            }
+        })
+    }
+}

--- a/Source/CarthageKit/FrameworkInfo.swift
+++ b/Source/CarthageKit/FrameworkInfo.swift
@@ -1,0 +1,67 @@
+import Foundation
+import ReactiveSwift
+import Result
+import XCDBLD
+
+public struct FrameworkInfo: Equatable, Hashable {
+    
+    var sourceURL: URL
+    var destinationURL: URL
+    var platform: Platform
+}
+
+extension Array where Element == FrameworkInfo {
+
+    // Returns the unique pairs in the input array
+    // or the duplicate keys by .destinationURL
+    func uniqueSourceDestinationPairs() -> Result<[FrameworkInfo], CarthageError> {
+        let destinationMap = reduce(into: [FrameworkInfo : [URL]]()) { result, frameworkInfo in
+            result[frameworkInfo] = (result[frameworkInfo] ?? []) + [frameworkInfo.sourceURL]
+        }
+        let dupes = destinationMap.filter { $0.value.count > 1 }
+        guard dupes.count == 0 else {
+            //TODO: transform dupes to duplicatesInArchive dictionary
+            return .failure(CarthageError.duplicatesInArchive(duplicates: CarthageError.DuplicatesInArchive(dictionary: [:])))
+        }
+        let uniquePairs = destinationMap
+            .filter { $0.value.count == 1 }
+            .map { $0.key }
+        return .success(uniquePairs)
+    }
+}
+
+extension SignalProducer where Value == Platform, Error == CarthageError {
+    
+    public func frameworkInfo(sourceURL: URL, directoryURL: URL) -> SignalProducer<FrameworkInfo, CarthageError> {
+        /// Constructs the file:// URL at which a given .framework
+        /// will be found. Depends on the location of the current project.
+        func frameworkURLInCarthageBuildFolder(
+            forPlatform platform: Platform,
+            frameworkNameAndExtension: String,
+            directoryURL: URL
+        ) -> Result<URL, CarthageError> {
+            guard let lastComponent = URL(string: frameworkNameAndExtension)?.pathExtension,
+                lastComponent == "framework" else {
+                    return .failure(.internalError(description: "\(frameworkNameAndExtension) is not a valid framework identifier"))
+            }
+
+            guard let destinationURLInWorkingDir = platform
+                .relativeURL?
+                .appendingPathComponent(frameworkNameAndExtension, isDirectory: true) else {
+                    return .failure(.internalError(description: "failed to construct framework destination url from \(platform) and \(frameworkNameAndExtension)"))
+            }
+
+            return .success(directoryURL
+                .appendingPathComponent(destinationURLInWorkingDir.path, isDirectory: true)
+                .standardizedFileURL)
+        }
+        
+        return producer.flatMap(.merge) { platform -> SignalProducer<FrameworkInfo, CarthageError> in
+            return frameworkURLInCarthageBuildFolder(forPlatform: platform,
+                                                     frameworkNameAndExtension: sourceURL.lastPathComponent,
+                                                     directoryURL: directoryURL)
+                .producer
+                .attemptMap { .success(FrameworkInfo(sourceURL: sourceURL, destinationURL: $0, platform: platform)) }
+        }
+    }
+}


### PR DESCRIPTION
## Background
I was researching solutions for caching Carthage artifacts, specifically to speed up CI builds. I came across Rome and was curious to see how it worked under the hood. But without enough experience in Haskell, and a time constraint, I decided how I might go about writing my own caching solution in Rust (...just kidding Swift obvs).

## Idea proposal
On building or unpacking prebuilt binary packages, create a new metadata file per built product that contains all the input information required for a caching solution.

Example `Build` directory tree for a single Cartfile.resolved line `github "realm/realm-cocoa" "v4.4.1"`:

```
/Users/vagrant/git/Carthage/
└── Build
    ├── .Realm.framework-iOS.builtProductInfo [NEW]
    ├── .Realm.framework-macOS.builtProductInfo [NEW]
    ├── .Realm.framework-tvOS.builtProductInfo [NEW]
    ├── .Realm.framework-watchOS.builtProductInfo [NEW]
    ├── .RealmSwift.framework-iOS.builtProductInfo [NEW]
    ├── .RealmSwift.framework-macOS.builtProductInfo [NEW]
    ├── .RealmSwift.framework-tvOS.builtProductInfo [NEW]
    ├── .RealmSwift.framework-watchOS.builtProductInfo [NEW]
    ├── .realm-cocoa.version
    ├── iOS
    │   ├── 0EAE362D-1B54-3BE2-B56B-4F369DE049B3.bcsymbolmap
    │   ├── 44C7B2AE-F465-397B-945B-7FAC25FA34D3.bcsymbolmap
    │   ├── 728FB08E-CDD2-31FA-9965-E1F382FF8E35.bcsymbolmap
    │   ├── BA1F73B8-7DF6-33E2-BF63-3B3A783B2092.bcsymbolmap
    │   ├── Realm.framework
    │   ├── Realm.framework.dSYM
    │   ├── RealmSwift.framework
    │   └── RealmSwift.framework.dSYM
    ├── Mac
    │   └── ... (hidden for brevity)
    ├── tvOS
    │   └── ... (hidden for brevity)
    └── watchOS
        └── ... (hidden for brevity)
```

Structure of proposed `.builtProductInfo` JSON file, example `.Realm.framework-iOS.builtProductInfo`:
```json
{
  "commitish" : "v4.4.1",
  "fileNames" : [
    "44C7B2AE-F465-397B-945B-7FAC25FA34D3.bcsymbolmap",
    "728FB08E-CDD2-31FA-9965-E1F382FF8E35.bcsymbolmap",
    "Realm.framework.dSYM"
  ],
  "platform" : "iOS",
  "productFileName" : "Realm.framework",
  "swiftToolchainVersion" : "5.2.2 (swiftlang-1103.0.32.6 clang-1103.0.32.51)"
}
```
## Bonus
Easy path to implement the cleanup command https://github.com/Carthage/Carthage/issues/902 by adding the dependency name as another field in the built product info file, the rest is elementary.

## Obstacles
*Bad timing*: might be a pain to address merge conflicts now that [PR 2981](https://github.com/Carthage/Carthage/pull/2981) has been merged.

*2 test failures*: I haven't been able to find the root cause yet. 🕵️‍♂️
```
CarthageKitTests/ProjectSpec.swift:263: error: -[CarthageKitTests.ProjectSpec buildCheckedOutDependenciesWithOptions__createAndCheckVersionFiles__should_rebuild_a_framework_for_all_platforms_even_a_cached_framework_is_invalid_for_only_a_single_platform] : failed - expected to equal <[TestFramework1_Mac]>, got <[]>
```
```
CarthageKitTests/ProjectSpec.swift:264: error: -[CarthageKitTests.ProjectSpec buildCheckedOutDependenciesWithOptions__createAndCheckVersionFiles__should_rebuild_a_framework_for_all_platforms_even_a_cached_framework_is_invalid_for_only_a_single_platform] : failed - expected to equal <[TestFramework1_iOS]>, got <[]>
```

**So before I invest any more time in this, I'd appreciate any feedback please.** 🙏

If you're interested to run the proof of concept, clone my fork and read the [Get Started](https://github.com/Carthage/Carthage/blob/master/CONTRIBUTING.md#get-started) section to install or run from Xcode.
