### PR TITLE
Attempt to remove invalid archs by intersecting VALID_ARCHS and ARCHS

### DIFF
--- a/Source/carthage/CopyFrameworks.swift
+++ b/Source/carthage/CopyFrameworks.swift
@@ -165,9 +165,23 @@ private func frameworksFolder() -> Result<URL, CarthageError> {
 }
 
 private func validArchitectures() -> Result<[String], CarthageError> {
-	return getEnvironmentVariable("VALID_ARCHS").map { architectures -> [String] in
-		return architectures.components(separatedBy: " ")
-	}
+    let validArchs = getEnvironmentVariable("VALID_ARCHS").map { architectures -> [String] in
+        return architectures.components(separatedBy: " ")
+    }
+
+    if validArchs.error != nil {
+        return validArchs
+    }
+
+    let archs = getEnvironmentVariable("ARCHS").map { architectures -> [String] in
+        return architectures.components(separatedBy: " ")
+    }
+
+    if archs.error != nil {
+        return archs
+    }
+
+    return .success(validArchs.value!.filter(archs.value!.contains))
 }
 
 private func buildActionIsArchiveOrInstall() -> Bool {


### PR DESCRIPTION
This PR should fix #2956 
I'm not a Swift developer so I'm not sure this is the proper way to write this code. 

This PR makes sure that we intersect VALID_ARCHS and ARCHS so we only keep the ARCHS that we are actually building. 