### PR TITLE
Support no_proxy/NO_PROXY environment variables

### DIFF
--- a/Source/CarthageKit/GitHub.swift
+++ b/Source/CarthageKit/GitHub.swift
@@ -161,12 +161,3 @@ extension Client {
 		}
 	}
 }
-
-extension URLSession {
-	public static var proxiedSession: URLSession {
-		let configuration = URLSessionConfiguration.default
-		configuration.connectionProxyDictionary = Proxy.default.connectionProxyDictionary
-
-		return URLSession(configuration: configuration)
-	}
-}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -242,7 +242,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 					self._projectEventsObserver.send(value: .downloadingBinaryFrameworkDefinition(.binary(binary), binary.url))
 					
 					let request = self.buildURLRequest(for: binary.url, useNetrc: self.useNetrc)
-					return URLSession.shared.reactive.data(with: request)
+					return URLSession.proxiedSession.reactive.data(with: request)
 						.mapError { CarthageError.readFailed(binary.url, $0 as NSError) }
 						.attemptMap { data, _ in
 							return BinaryProject.from(jsonData: data).mapError { error in
@@ -1162,7 +1162,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 			return SignalProducer(value: fileURL)
 		} else {
 			let request = self.buildURLRequest(for: url, useNetrc: self.useNetrc)
-			return URLSession.shared.reactive.download(with: request)
+			return URLSession.proxiedSession.reactive.download(with: request)
 				.on(started: {
 					self._projectEventsObserver.send(value: .downloadingBinaries(dependency, version.description))
 				})

--- a/Source/CarthageKit/Proxy.swift
+++ b/Source/CarthageKit/Proxy.swift
@@ -6,8 +6,9 @@ struct Proxy {
 	init(environment: [String: String]) {
 		let http = Proxy.makeHTTPDictionary(environment)
 		let https = Proxy.makeHTTPSDictionary(environment)
+        let noProxy = Proxy.makeNoProxyDictionary(environment)
 
-		let combined = http.merging(https) { _, property in property }
+        let combined = http.merging(https) { _, property in property }.merging(noProxy) { _, property in property }
 
 		// the proxy dictionary on URLSessionConfiguration must be nil so that it can default to the system proxy.
 		connectionProxyDictionary = combined.isEmpty ? nil : combined
@@ -46,8 +47,38 @@ struct Proxy {
 
 		return dictionary
 	}
+    
+    private static func makeNoProxyDictionary(_ environment: [String: String]) -> [AnyHashable: Any] {
+        #if os(OSX)
+        
+        let vars = ["no_proxy", "NO_PROXY"]
+        guard
+            let noProxyList: [String] = (vars.compactMap { environment[$0] }.first)?.split(separator: ",").compactMap({ String($0) }),
+            !noProxyList.isEmpty
+            else { return [:] }
+        
+        let dictionary: [AnyHashable: Any] = [
+            kCFNetworkProxiesExceptionsList: noProxyList
+        ]
+        
+        return dictionary
+        
+        #else
+        return [:]
+        #endif
+    }
+
 }
 
 extension Proxy {
 	static let `default`: Proxy = Proxy(environment: ProcessInfo.processInfo.environment)
+}
+
+extension URLSession {
+    public static var proxiedSession: URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.connectionProxyDictionary = Proxy.default.connectionProxyDictionary
+
+        return URLSession(configuration: configuration)
+    }
 }

--- a/Tests/CarthageKitTests/ProxyTests.swift
+++ b/Tests/CarthageKitTests/ProxyTests.swift
@@ -5,7 +5,7 @@ import Quick
 
 class ProxySpec: QuickSpec {
 	override func spec() {
-		describe("createProxyWithNoProxyValues") {
+		describe("createProxyWithoutProxyValues") {
 			let proxy = Proxy(environment: [:])
 
 			it("should have nil dictionary") {
@@ -36,6 +36,12 @@ class ProxySpec: QuickSpec {
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSProxy]).to(beNil())
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSPort]).to(beNil())
 			}
+            
+            #if os(OSX)
+            it("should not set the proxy exceptions") {
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesExceptionsList]).to(beNil())
+            }
+            #endif
 		}
 
 		describe("createProxyWithHTTPSValues") {
@@ -53,7 +59,36 @@ class ProxySpec: QuickSpec {
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPProxy]).to(beNil())
 				expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPPort]).to(beNil())
 			}
+            
+            #if os(OSX)
+            it("should not set the proxy exceptions") {
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesExceptionsList]).to(beNil())
+            }
+            #endif
 		}
+        
+        #if os(OSX)
+        describe("createNoProxy") {
+            let proxy = Proxy(environment: ["no_proxy": "example.com,.github.com", "NO_PROXY": "example.com,.github.com"])
+
+            it("should set the proxy exceptions") {
+                expect(proxy.connectionProxyDictionary).toNot(beNil())
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesExceptionsList] as? [String]) == ["example.com", ".github.com"]
+            }
+
+            it("should not set the http properties") {
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPEnable]).to(beNil())
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPProxy]).to(beNil())
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPPort]).to(beNil())
+            }
+            
+            it("should not set the https properties") {
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSEnable]).to(beNil())
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSProxy]).to(beNil())
+                expect(proxy.connectionProxyDictionary![kCFNetworkProxiesHTTPSPort]).to(beNil())
+            }
+        }
+        #endif
 
 		describe("createProxyWithHTTPAndHTTPSValues") {
 			let proxy = Proxy(environment: [


### PR DESCRIPTION
* As support for http_proxy/https_proxy environment already exists, there was also a need to support the no_proxy/NO_PROXY override.
* `kCFNetworkProxiesExceptionsList` is available only on macOS, hence the conditional statements.
* Made sure that downloaded binaries also use proxied environment, which was not the case.
* Moved `URLSession.proxiedSession` into Proxy.swift where it seems to belong a bit more.