### PR TITLE
Use updated dependencies when building with Swift 5, but keep backwards-compatibility with Swift 4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "2cd0210f897fe46c6ce42f52ccfa72b3bbb621a0",
-          "version": "0.16.0"
+          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
+          "version": "0.17.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
-          "version": "8.0.2"
+          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
+          "version": "8.1.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
-          "version": "2.1.0"
+          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
+          "version": "2.2.1"
         }
       },
       {
@@ -51,17 +51,17 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
         "state": {
           "branch": null,
-          "revision": "c37950dc5020544c58d4bf47c0d028893686b9e6",
-          "version": "5.0.1"
+          "revision": "3f4351d04115fd8797802d9b2d17b812cd761602",
+          "version": "6.3.0"
         }
       },
       {
         "package": "ReactiveTask",
         "repositoryURL": "https://github.com/Carthage/ReactiveTask.git",
         "state": {
-          "branch": null,
-          "revision": "df1bf7625684180b9377a8ba3c076db08d98757e",
-          "version": "0.16.0"
+          "branch": "release-0.17.0",
+          "revision": "0f6162a44d56b3e2fc3e42d20e77b8b09bd5e00a",
+          "version": null
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
-          "version": "4.1.0"
+          "revision": "12920a5c2595926efab9274d6003e29f503dbb66",
+          "version": "5.0.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/mdiep/Tentacle.git",
         "state": {
           "branch": null,
-          "revision": "578edd088b03bc749c49253b15ae2d5aaa9aa7df",
-          "version": "0.13.1"
+          "revision": "fb9f20c3cc094103799e271dd664e1ee1b76211e",
+          "version": "0.14.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,23 @@
 // swift-tools-version:4.2
 import PackageDescription
 
+let compilerSpecificDependencies: [Package.Dependency]
+#if compiler(>=5)
+compilerSpecificDependencies = [
+    .package(url: "https://github.com/antitypical/Result.git", from: "5.0.0"),
+    .package(url: "https://github.com/Carthage/ReactiveTask.git", .branch("release-0.17.0")),
+    .package(url: "https://github.com/Carthage/Commandant.git", from: "0.17.0"),
+    .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.0.0"),
+]
+#else
+compilerSpecificDependencies = [
+    .package(url: "https://github.com/antitypical/Result.git", from: "4.1.0"),
+    .package(url: "https://github.com/Carthage/ReactiveTask.git", .upToNextMinor(from: "0.16.0")),
+    .package(url: "https://github.com/Carthage/Commandant.git", "0.16.0" ..< "0.17.0"),
+    .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0"),
+]
+#endif
+
 let package = Package(
     name: "Carthage",
     products: [
@@ -9,16 +26,12 @@ let package = Package(
         .executable(name: "carthage", targets: ["carthage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/antitypical/Result.git", from: "4.1.0"),
-        .package(url: "https://github.com/Carthage/ReactiveTask.git", from: "0.16.0"),
-        .package(url: "https://github.com/Carthage/Commandant.git", from: "0.16.0"),
         .package(url: "https://github.com/jdhealy/PrettyColors.git", from: "5.0.2"),
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0"),
         .package(url: "https://github.com/mdiep/Tentacle.git", from: "0.13.1"),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.2"),
         .package(url: "https://github.com/Quick/Quick.git", from: "2.1.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.1"),
-    ],
+    ] + compilerSpecificDependencies,
     targets: [
         .target(
             name: "XCDBLD",

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -108,9 +108,15 @@ public final class Project { // swiftlint:disable:this type_body_length
 	/// to download binary only frameworks.
 	public var useNetrc = false
 
+	#if compiler(>=5)
+	/// Sends each event that occurs to a project underneath the receiver (or
+	/// the receiver itself).
+	public let projectEvents: Signal<ProjectEvent, Never>
+	#else
 	/// Sends each event that occurs to a project underneath the receiver (or
 	/// the receiver itself).
 	public let projectEvents: Signal<ProjectEvent, NoError>
+	#endif
 	private let _projectEventsObserver: Signal<ProjectEvent, NoError>.Observer
 
 	public init(directoryURL: URL) {

--- a/Source/CarthageKit/Swift4Compatibility.swift
+++ b/Source/CarthageKit/Swift4Compatibility.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+#if compiler(>=5)
+/// Aliased to provide source-compatibility when building Carthage using Swift 4.2.
+/// Prior to Swift 5, Carthage and its dependencies used
+///
+///     SignalProducer<U, Result.NoError>
+///
+/// to represent a producer that could never send an error. In Swift 5, this changed to
+///
+///     SignalProducer<U, Swift.Never>
+typealias NoError = Never
+#endif

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -238,7 +238,7 @@ class XcodeSpec: QuickSpec {
 						.ignoreTaskData()
 						.mapError(CarthageError.taskError)
 						.map { String(data: $0, encoding: .utf8) ?? "" }
-						.flatMap(.merge) { output -> SignalProducer<Bool, NoError> in
+						.flatMap(.merge) { output in
 							return SignalProducer(value: output.contains("SO "))
 					}
 			}.single()


### PR DESCRIPTION
This is a complement to #2972, but doesn't make any breaking changes to CI / homebrew. It starts the work of upgrading to Swift 5.2 by using updated dependencies when Carthage is built with a 5.x compiler. These changes are helpful for users who depend on Carthage as a SwiftPM package [1], and should make it a little easier to drop support for Swift 4.x in the future.

[1]: Carthage doesn't build with Commandant >= 0.17.0, because that version drops support for antitypical/Result. You can manually pin Commandant to an older version, but then you can't depend on tools that have upgraded to the newer version of Commandant, like [SwiftLint](https://github.com/realm/SwiftLint/blob/bda1cd56e0bbcd4a68828394137e32d17c92963b/Package.swift#L17). So this PR helps keep users out of dependency hell when they're [using SwiftPM to version their build tools](https://artsy.github.io/blog/2019/01/05/its-time-to-use-spm/).