### PR TITLE
Failed to build on Xcode 12 and macOS 11.0

### DIFF
--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -77,7 +77,7 @@ public struct SDK: Hashable {
 	///            hardcoded `simulatorHeuristic` · all keyed by lowercased `name`.
 	/// - Note: The aliases are intended to be matched case-insensitevly.
 	private static let knownIn2019YearDictionary: [String: (String, [String], String)] =
-		KeyValuePairs.reduce([
+		[
 			"MacOSX": (["macOS", "Mac", "OSX"], "macOS"),
 			"iPhoneOS": (["iOS Device", "iOS"], "iOS"),
 			"iPhoneSimulator": (["iOS Simulator"], "Simulator - iOS"),
@@ -85,9 +85,9 @@ public struct SDK: Hashable {
 			"WatchSimulator": (["watchOS Simulator", "watchsimulator"], "Simulator - watchOS"),
 			"AppleTVOS": (["tvOS"], "tvOS"),
 			"AppleTVSimulator": (["tvOS Simulator", "appletvsimulator", "tvsimulator"], "Simulator - tvOS"),
-		])(into: [:]) {
-			$0[$1.0.lowercased()] = ($1.0, $1.1.0, $1.1.1)
-		}
+        ].reduce(into: [:]) {
+            $0[$1.0.lowercased()] = ($1.0, $1.1.0, $1.1.1)
+        }
 
 	public static let knownIn2019YearSDKs: Set<SDK> =
 		Set(

--- a/Source/XCDBLD/SDK.swift
+++ b/Source/XCDBLD/SDK.swift
@@ -77,7 +77,7 @@ public struct SDK: Hashable {
 	///            hardcoded `simulatorHeuristic` · all keyed by lowercased `name`.
 	/// - Note: The aliases are intended to be matched case-insensitevly.
 	private static let knownIn2019YearDictionary: [String: (String, [String], String)] =
-		[
+		([
 			"MacOSX": (["macOS", "Mac", "OSX"], "macOS"),
 			"iPhoneOS": (["iOS Device", "iOS"], "iOS"),
 			"iPhoneSimulator": (["iOS Simulator"], "Simulator - iOS"),
@@ -85,9 +85,9 @@ public struct SDK: Hashable {
 			"WatchSimulator": (["watchOS Simulator", "watchsimulator"], "Simulator - watchOS"),
 			"AppleTVOS": (["tvOS"], "tvOS"),
 			"AppleTVSimulator": (["tvOS Simulator", "appletvsimulator", "tvsimulator"], "Simulator - tvOS"),
-        ].reduce(into: [:]) {
-            $0[$1.0.lowercased()] = ($1.0, $1.1.0, $1.1.1)
-        }
+		] as KeyValuePair).reduce(into: [:]) {
+			$0[$1.0.lowercased()] = ($1.0, $1.1.0, $1.1.1)
+		}
 
 	public static let knownIn2019YearSDKs: Set<SDK> =
 		Set(


### PR DESCRIPTION
The project failed to build on Xcode 12 and macOS 11.0 due to following error:

```
/Users/eofs/Projects/Xcode/Carthage/Source/XCDBLD/SDK.swift:80:3: error: call can throw, but errors cannot be thrown out of a global variable initializer
                KeyValuePairs.reduce([
                ^
```

This prevented installing latest Carthage release using `brew`.

Calling `reduce()` on the collection itself instead allowed the project to build successfully.
