### PR TITLE
Sort frameworks in version file

### DIFF
--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -431,12 +431,16 @@ private func createVersionFile(
 				.platformSimulatorlessFromHeuristic
 		}
 
+		let sortedFrameworks: ([CachedFramework]?) -> [CachedFramework]? = {
+			$0?.sorted { $0.name < $1.name }
+		}
+
 		let versionFile = VersionFile(
 			commitish: commitish,
-			macOS: platformCaches[knownIn2019YearSDK("mac")],
-			iOS: platformCaches[knownIn2019YearSDK("iphoneos")],
-			watchOS: platformCaches[knownIn2019YearSDK("watchos")],
-			tvOS: platformCaches[knownIn2019YearSDK("appletvos")])
+			macOS: sortedFrameworks(platformCaches[knownIn2019YearSDK("mac")]),
+			iOS: sortedFrameworks(platformCaches[knownIn2019YearSDK("iphoneos")]),
+			watchOS: sortedFrameworks(platformCaches[knownIn2019YearSDK("watchos")]),
+			tvOS: sortedFrameworks(platformCaches[knownIn2019YearSDK("appletvos")]))
 
 		return versionFile.write(to: versionFileURL)
 	}


### PR DESCRIPTION
This is enhancement as mentioned in #3013

Sort the frameworks by name in the version file
So we can easily identify which frameworks are altered when situations like running `--update` 