### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ MKDIR=mkdir -p
 SUDO=sudo
 CP=cp
 
+ifdef DISABLE_SUDO
+override SUDO:=
+endif
+
 .PHONY: all clean install package test uninstall xcconfig xcodeproj
 
 all: installables

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INTERNAL_PACKAGE=CarthageApp.pkg
 OUTPUT_PACKAGE=Carthage.pkg
 
 CARTHAGE_EXECUTABLE=./.build/release/carthage
-BINARIES_FOLDER=/usr/local/bin
+BINARIES_FOLDER=$(PREFIX)/bin
 
 SWIFT_BUILD_FLAGS=--configuration release -Xswiftc -suppress-warnings
 
@@ -68,8 +68,8 @@ package: installables
 	   	"$(OUTPUT_PACKAGE)"
 
 prefix_install: installables
-	$(MKDIR) "$(PREFIX)/bin"
-	$(CP) -f "$(CARTHAGE_EXECUTABLE)" "$(PREFIX)/bin/"
+	$(MKDIR) "$(BINARIES_FOLDER)"
+	$(CP) -f "$(CARTHAGE_EXECUTABLE)" "$(BINARIES_FOLDER)/"
 
 install: installables
 	if [ ! -d "$(BINARIES_FOLDER)" ]; then $(SUDO) $(MKDIR) "$(BINARIES_FOLDER)"; fi


### PR DESCRIPTION
This patch fixes the usage of ``PREFIX`` and ``BINARIES_FOLDER`` environments in the Makefile.
Furthermore it removes ``sudo`` from the Makefile to allow unprivileged installs and avoid hidden
usage of sudo. For privileged installs simply call:

```bash
$ sudo make install
```