### PR TITLE
Remove the cache if unarchiving was failed

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1011,7 +1011,12 @@ public final class Project { // swiftlint:disable:this type_body_length
 			.flatMap(.concat) { semanticVersion, frameworkURL in
 				return self.downloadBinary(dependency: Dependency.binary(binary), version: semanticVersion, url: frameworkURL)
 			}
-			.flatMap(.concat) { self.unarchiveAndCopyBinaryFrameworks(zipFile: $0, projectName: projectName, pinnedVersion: pinnedVersion, toolchain: toolchain) }
+			.flatMap(.concat) { zipFile in
+				self.unarchiveAndCopyBinaryFrameworks(zipFile: zipFile, projectName: projectName, pinnedVersion: pinnedVersion, toolchain: toolchain)
+ 					.on(failed: { _ in
+						try? FileManager.default.removeItem(at: zipFile)
+					})
+			}
 			.flatMap(.concat) { self.removeItem(at: $0) }
 	}
 


### PR DESCRIPTION
I found a cache-related bug.

I downloaded a zip file of the binary framework using Carthage, but it was failed because the zip file was broken.
So I corrected the zip file, and then I tried to download the framework.
But it occurred the same error.

The error was following:
```
*** xcodebuild output can be found in /var/folders/z3/lyh75tws0hg4nsp2wrg6gxnw0000gq/T/carthage-xcodebuild.OgWAAr.log
*** Downloading binary-only framework test at "file:///Users/<username>/carthage_binary_bug/test.json"
A shell task (/usr/bin/env unzip -uo -qq -d /var/folders/z3/lyh75tws0hg4nsp2wrg6gxnw0000gq/T/carthage-archive.559JOD /Users/<username>/Library/Caches/org.carthage.CarthageKit/binaries/test/1.0.0/test.zip) failed with exit code 9:
[/Users/<username>/Library/Caches/org.carthage.CarthageKit/binaries/test/1.0.0/test.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /Users/<username>/Library/Caches/org.carthage.CarthageKit/binaries/test/1.0.0/test.zip or
        /Users/<username>/Library/Caches/org.carthage.CarthageKit/binaries/test/1.0.0/test.zip.zip, and cannot find /Users/<username>/Library/Caches/org.carthage.CarthageKit/binaries/test/1.0.0/test.zip.ZIP, period.
```

Reproduce:
```
$ git clone https://github.com/tattn/carthage_binary_bug
$ cd carthage_binary_bug
$ vi test.json # modify the path
$ carthage bootstrap # occur the error, because the test.zip is broken.
$ mv test.zip test3.zip
$ mv test2.zip test.zip # replace the broken file with the corrected file.
$ carthage bootstrap # occur the error, but the test.zip is corrected...
```

I changed to remove the broken cache if unarchiving was failed.
If there's a better way to fix it, I'll correct it.