### PR TITLE
prevent re-downloading module stable binaries

### DIFF
--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -204,7 +204,7 @@ public struct VersionFile: Codable {
 				} else {
 					return frameworkSwiftVersion(frameworkURL)
 						.map { swiftVersion -> Bool in
-							return swiftVersion == localSwiftVersion
+							return swiftVersion == localSwiftVersion || isModuleStableAPI(localSwiftVersion, swiftVersion, frameworkURL)
 						}
 						.flatMapError { _ in SignalProducer<Bool, CarthageError>(value: false) }
 				}


### PR DESCRIPTION
Carthage will flag cached binary frameworks as invalid if they are built with a different version of the Swift, even if both the binary  and the local version of Swift are module stable. This was likely just missed when module stability support was added in https://github.com/Carthage/Carthage/pull/2902.

A simple example to show the issue (this assumes you are running Xcode 11.6, or any version of Swift that **isnt** 5.2.2):

```
echo "binary \"https://zendesk.jfrog.io/zendesk/libs-releases-local/ios/zendesk/ChatSDK/ChatSDK.json\" == 2.7.0" > Cartfile
carthage bootstrap --platform iOS --cache-builds
carthage bootstrap --platform iOS --cache-builds
```

Looking at the console output of the second run of `carthage bootstrap` shows that the cache has been marked as invalid and is subsequently downloaded again:

```
*** xcodebuild output can be found in /var/folders/wz/gfmnqb3x78sgz5vww3w2mrjh0000gn/T/carthage-xcodebuild.FwywtL.log
*** Invalid cache found for ChatSDK, rebuilding with all downstream dependencies
*** Downloading binary-only framework ChatSDK at "https://zendesk.jfrog.io/zendesk/libs-releases-local/ios/zendesk/ChatSDK/ChatSDK.json"
```

Since the binary was built with Swift 5.2.2 and the local version of Swift is 5.2.4 the existing code flags the cache as invalid.