### PR TITLE
Update README to reflect the build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There are multiple options for installing Carthage:
 
 * **MacPorts:** You can use [MacPorts](https://www.macports.org/) and install the `carthage` tool on your system simply by running `sudo port selfupdate` and `sudo port install carthage`. (note: if you previously installed the binary version of Carthage, you should delete `/Library/Frameworks/CarthageKit.framework`).
 
-* **From source:** If you’d like to run the latest development version (which may be highly unstable or incompatible), simply clone the `master` branch of the repository, then run `make install`. Requires Xcode 9.4 (Swift 4.1).
+* **From source:** If you’d like to run the latest development version (which may be highly unstable or incompatible), simply clone the `master` branch of the repository, then run `make install`. Requires Xcode 10.0 (Swift 4.2).
 
 ## Adding frameworks to an application
 


### PR DESCRIPTION
I notice that Carthage 0.35.0 does not build with Xcode 9.4.1:
```
error: package at '/opt/local/var/macports/build/_Users_travis_build_macports_macports-ports_devel_carthage/carthage/work/Carthage-0.35.0' requires a minimum Swift tools version of 4.2.0 (currently 4.1.0)
```

My guess is the requirement was raised by #2797, and that the README should reflect this new requirement. Not sure if similar changes should be made elsewhere.