### PR TITLE
Update createTemporaryDirectoryWithTemplate to create temp dirs on th…

### DIFF
--- a/Source/CarthageKit/Archive.swift
+++ b/Source/CarthageKit/Archive.swift
@@ -56,7 +56,7 @@ private let archiveTemplate = "carthage-archive.XXXXXX"
 /// Unzips the archive at the given file URL into a temporary directory, then
 /// sends the file URL to that directory.
 private func unzip(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
-	return FileManager.default.reactive.createTemporaryDirectoryWithTemplate(archiveTemplate)
+	return FileManager.default.reactive.createTemporaryDirectoryWithTemplate(archiveTemplate, destinationURL: fileURL)
 		.flatMap(.merge) { directoryURL in
 			return unzip(archive: fileURL, to: directoryURL)
 				.then(SignalProducer<URL, CarthageError>(value: directoryURL))
@@ -66,7 +66,7 @@ private func unzip(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
 /// Untars an archive at the given file URL into a temporary directory, 
 /// then sends the file URL to that directory.
 private func untar(archive fileURL: URL) -> SignalProducer<URL, CarthageError> {
-	return FileManager.default.reactive.createTemporaryDirectoryWithTemplate(archiveTemplate)
+	return FileManager.default.reactive.createTemporaryDirectoryWithTemplate(archiveTemplate, destinationURL: fileURL)
 		.flatMap(.merge) { directoryURL in
 			return untar(archive: fileURL, to: directoryURL)
 				.then(SignalProducer<URL, CarthageError>(value: directoryURL))

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -1052,7 +1052,7 @@ private func stripBinary(_ binaryURL: URL, keepingArchitectures: [String]) -> Si
 
   let fileManager = FileManager.default.reactive
   
-  let createTempDir: SignalProducer<URL, CarthageError> = fileManager.createTemporaryDirectoryWithTemplate("carthage-lipo-XXXXXX")
+  let createTempDir: SignalProducer<URL, CarthageError> = fileManager.createTemporaryDirectoryWithTemplate("carthage-lipo-XXXXXX", destinationURL: binaryURL)
   
   let copyItem: (URL, URL) -> SignalProducer<URL, CarthageError> = { source, dest in
     fileManager.copyItem(source, into: dest)


### PR DESCRIPTION
Pull request #3025 fixed an issue with installing frameworks while avoiding cross-device link errors. 

It seems that in complex projects, this is insufficient, as a copy-frameworks command with many input frameworks will sometimes still fail with errors such as 

```
copyItem failed: Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"
file:///var/folders/lq/yvbxlp_j64xfh9km1md802x00000gn/T/carthage-lipo-MIM7DX/SimpleKeychain.framework
file:///projects/build/dave/dmpremier-gvncjwnlubknpkfmnxmiipekxcnu/Build/Products/Debug-iphonesimulator/dha.app/Frameworks/SimpleKeychain.framework/
```

In this case, the source file in the temporary directory under `/var/folders` seems to disappear before the `copyItem` method gets called. It isn't always the same file that disappears; re-running the copy-frameworks command sometimes works and sometimes fails with a different file, which suggests that there is some kind of race condition if the install has to fall back to `copyItem` instead of `replaceItem`.

This patch creates a temporary directory that is on the same filesystem as the destination URL, thus ensuring that there is never an issue with cross-device links. 
