### PR TITLE
README: Minor correction re: "unintrusive"

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ If you’re interested in using Carthage as part of another tool, or perhaps ext
 
 [CocoaPods](http://cocoapods.org/) is a long-standing dependency manager for Cocoa. So why was Carthage created?
 
-Firstly, CocoaPods (by default) automatically creates and updates an Xcode workspace for your application and all dependencies. Carthage builds framework binaries using `xcodebuild`, but leaves the responsibility of integrating them up to the user. CocoaPods’ approach is easier to use, while Carthage’s is flexible and unintrusive.
+Firstly, CocoaPods (by default) automatically creates and updates an Xcode workspace for your application and all dependencies. Carthage builds framework binaries using `xcodebuild`, but leaves the responsibility of integrating them up to the user. CocoaPods’ approach is easier to use, while Carthage’s is flexible and unobtrusive.
 
 The goal of CocoaPods is listed in its [README](https://github.com/CocoaPods/CocoaPods/blob/1703a3464674baecf54bd7e766f4b37ed8fc43f7/README.md) as follows:
 


### PR DESCRIPTION
I'm not sure why, but "unintrusive" has always stuck out in my mind as something that people (including me) say, but isn't present in most reference sources as an antonym to the word "intrusive."

This suggested change replaces it in the project README with the word ["unobtrusive"](https://www.lexico.com/definition/unobtrusive). I think this conveys the intended meaning. Another option would be to say ["non-intrusive,"](https://www.merriam-webster.com/dictionary/nonintrusive) (I see it with and without the hyphen), though I'm in favor of the word choice submitted in this PR, myself.

Thanks for the lovely software.  I stumbled across it in the build instructions for https://devutils.app/ & couldn't pass up the opportunity to be pedantic /s

Cheers!