### PR TITLE
Use -c protocol.version=2 for submodule command

### DIFF
--- a/Source/CarthageKit/Git.swift
+++ b/Source/CarthageKit/Git.swift
@@ -242,7 +242,7 @@ public func cloneSubmoduleInWorkingDirectory(_ submodule: Submodule, _ workingDi
 /// directory.
 private func checkoutSubmodule(_ submodule: Submodule, _ submoduleWorkingDirectoryURL: URL) -> SignalProducer<(), CarthageError> {
 	return launchGitTask([ "checkout", "--quiet", submodule.sha ], repositoryFileURL: submoduleWorkingDirectoryURL)
-		.then(launchGitTask([ "submodule", "--quiet", "update", "--init", "--recursive" ], repositoryFileURL: submoduleWorkingDirectoryURL))
+		.then(launchGitTask([ "-c", "protocol.version=2", "submodule", "--quiet", "update", "--init", "--recursive" ], repositoryFileURL: submoduleWorkingDirectoryURL))
 		.then(SignalProducer<(), CarthageError>.empty)
 }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/6807

I've been trying to debug what caused https://github.com/realm/realm-cocoa/issues/6807 and https://github.com/realm/realm-cocoa/issues/6806 and figured out another way to get around the failure (besides switching to ssh) was to just tell the git client to use protocol version 2.