### PR TITLE
Locate schemes concurrently

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -195,7 +195,7 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 	precondition(directoryURL.isFileURL)
 	let locator = ProjectLocator
 			.locate(in: directoryURL)
-			.flatMap(.concat) { project -> SignalProducer<(ProjectLocator, [Scheme]), CarthageError> in
+			.flatMap(.concurrent(limit: 4)) { project -> SignalProducer<(ProjectLocator, [Scheme]), CarthageError> in
 				return project
 					.schemes()
 					.collect()


### PR DESCRIPTION
In large repos (repos with many xcode projects in them, or repos with deeply nested directories), `buildableSchemesInDirectory` can become noticeably slow.

This change makes the directory enumerator stop descending when we filter out a URL, and calls `xcodebuild -list` concurrently using the same pattern that Carthage uses further down.