### PR TITLE
v0.36.1, everything new _except_ for xcframeworks

### DIFF
--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -4,5 +4,5 @@ import Foundation
 public struct CarthageKitVersion {
 	public let value: SemanticVersion
 
-	public static let current = CarthageKitVersion(value: SemanticVersion(0, 36, 0))
+	public static let current = CarthageKitVersion(value: SemanticVersion(0, 36, 1))
 }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -663,7 +663,11 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 							return SignalProducer(value: .standardError(data))
 
 						case let .success(deviceSettingsByTarget):
-							return settingsByTarget(build(sdk: simulatorSDK, with: buildArgs, in: workingDirectoryURL))
+							return settingsByTarget(
+								build(sdk: simulatorSDK,
+									  with: buildArgs,
+									  in: workingDirectoryURL)
+								)
 								.flatMapTaskEvents(.concat) { (simulatorSettingsByTarget: [String: BuildSettings]) -> SignalProducer<(BuildSettings, BuildSettings), CarthageError> in
 									assert(
 										deviceSettingsByTarget.count == simulatorSettingsByTarget.count,
@@ -734,7 +738,12 @@ private func resolveSameTargetName(for settings: BuildSettings) -> SignalProduce
 
 /// Runs the build for a given sdk and build arguments, optionally performing a clean first
 // swiftlint:disable:next function_body_length
-private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectoryURL: URL) -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> {
+private func build(
+	sdk: SDK,
+	with buildArgs: BuildArguments,
+	in workingDirectoryURL: URL
+) -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> {
+
 	var argsForLoading = buildArgs
 	argsForLoading.sdk = sdk
 
@@ -801,6 +810,12 @@ private func build(sdk: SDK, with buildArgs: BuildArguments, in workingDirectory
 				.flatMap(.concat) { settings -> SignalProducer<TaskEvent<BuildSettings>, CarthageError> in
 					let actions: [String] = {
 						var result: [String] = [xcodebuildAction.rawValue]
+
+						if settings.contains(where: { UInt64($0["XCODE_VERSION_ACTUAL"].recover("")) ?? 0 >= 1230 }) {
+							// Fixes Xcode 12.3 refusing to link against fat binaries
+							// "Building for iOS Simulator, but the linked and embedded framework 'REDACTED.framework' was built for iOS + iOS Simulator."
+							result += [ "VALIDATE_WORKSPACE=NO" ]
+						}
 
 						if xcodebuildAction == .archive {
 							result += [


### PR DESCRIPTION
This is a companion release to #3106. It cherry-picks the VALIDATE_WORKSPACE fix (https://github.com/Carthage/Carthage/commit/388482045d3452b7fc87a926d35181a614710e63) onto 0.36.0. The goal here is to give users something to fall back on if the xcframeworks release causes problems.