### PR TITLE
Add Github action for M1 workaround to docs

### DIFF
--- a/Documentation/Xcode12Workaround.md
+++ b/Documentation/Xcode12Workaround.md
@@ -55,3 +55,7 @@ echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_
 export XCODE_XCCONFIG_FILE="$xcconfig"
 carthage "$@"
 ```
+
+### Github action
+
+To simplify you GitHub actions flow, you can use [dedicated Github action](https://github.com/marketplace/actions/carthage-workaround) that will use the script above.


### PR DESCRIPTION
Until I migrate my project to use XCFrameworks, I created a Github Action, that uses the workaround script so it is simple to use on GitHub. This might be useful for more Carthage users so it would be good to be mentioned in docs.