### PR TITLE
Fix xcframework extraction when a project refers to a missing build directory

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -837,9 +837,9 @@ func extractXCFrameworks(in buildDirectory: URL, for settings: BuildSettings) ->
 	let isRelativeToBuildDirectory = { (url: URL) -> Bool in
 		// `url` might not exist (e.g. it's "Carthage/Build/iOS" and an "iOS" directory was never created). In order
 		// for resolvingSymlinksInPath to resolve as much of the path as it can, reduce it to the nearest extant ancestor.
-		guard let extantURL = sequence(first: url, next: { $0.deletingLastPathComponent() })
-						.first(where: { (try? $0.checkResourceIsReachable()) == true }) else {
-			fatalError("No ancestor of \(url.path) is reachable")
+		var extantURL = url
+		while (try? extantURL.checkResourceIsReachable()) == nil {
+			extantURL.deleteLastPathComponent()
 		}
 		return extantURL.resolvingSymlinksInPath().path.starts(with: buildDirectory.resolvingSymlinksInPath().path)
 	}

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -834,8 +834,14 @@ private func resolveSameTargetName(for settings: BuildSettings) -> SignalProduce
 /// Sends the temporary directory or `nil` if there are no xcframeworks to extract. The directory is _not_ deleted
 /// upon disposal, so that asynchronous build actions can use extracted frameworks after the producer has completed.
 func extractXCFrameworks(in buildDirectory: URL, for settings: BuildSettings) -> SignalProducer<URL?, CarthageError> {
-	let isRelativeToBuildDirectory = { (url: URL) in
-		url.resolvingSymlinksInPath().path.starts(with: buildDirectory.resolvingSymlinksInPath().path)
+	let isRelativeToBuildDirectory = { (url: URL) -> Bool in
+		// `url` might not exist (e.g. it's "Carthage/Build/iOS" and an "iOS" directory was never created). In order
+		// for resolvingSymlinksInPath to resolve as much of the path as it can, reduce it to the nearest extant ancestor.
+		guard let extantURL = sequence(first: url, next: { $0.deletingLastPathComponent() })
+						.first(where: { (try? $0.checkResourceIsReachable()) == true }) else {
+			fatalError("No ancestor of \(url.path) is reachable")
+		}
+		return extantURL.resolvingSymlinksInPath().path.starts(with: buildDirectory.resolvingSymlinksInPath().path)
 	}
 	guard let platformTripleOS = settings.platformTripleOS.value,
 				let frameworkSearchPaths = settings.frameworkSearchPaths.value,


### PR DESCRIPTION
Projects with Cartfile dependencies typically contain a FRAMEWORKS_SEARCH_PATH entry like `Carthage/Build/iOS`. With `--use-xcframeworks`, that platform-specific folder ("iOS") might not exist. This makes the [predicate in extractXCFrameworks](https://github.com/Carthage/Carthage/blob/0668de43eb5d323d2e816eaab83677f50a8eeb24/Source/CarthageKit/Xcode.swift#L838) fail, because resolvingSymlinksInPath() has [realpath(3) semantics](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/realpath.3.html) and will not resolve symlinks for a non-existant path.

Fixed by truncating the given URL down to its extant portion. Since we only care about matching the prefix, and since the `Carthage/Build` directory should always exist because [symlinkBuildPathIfNeeded](https://github.com/Carthage/Carthage/blob/0668de43eb5d323d2e816eaab83677f50a8eeb24/Source/CarthageKit/Project.swift#L1243) was called, this should be safe.

Fixes #3122. I tested using the Cartfile in this issue.