### PR TITLE
Release: v0.38.0

### DIFF
--- a/Documentation/Artifacts.md
+++ b/Documentation/Artifacts.md
@@ -148,12 +148,22 @@ For dependencies that do not have source code available, a binary project specif
 * The version **must** be a semantic version.  Git branches, tags and commits are not valid.
 * The location **must** be an `https` url.
 
+#### Publish an XCFramework build alongside the framework build using an `alt=` query parameter
+
+To support users who build with `--use-xcframework`, create two zips: one containing the framework bundle(s) for your dependency, the other containing xcframework(s). Include "framework" or "xcframework" in the names of the zips, for example:  `MyFramework.framework.zip` and `MyFramework.xcframework.zip`. In your project specification, join the two URLs into one using a query string:
+
+	https://my.domain.com/release/1.0.0/MyFramework.framework.zip?alt=https://my.domain.com/release/1.0.0/MyFramework.xcframework.zip
+
+Starting in version 0.38.0, Carthage extracts any `alt=` URLs from the version specification. When `--use-xcframeworks` is passed, it prefers downloading URLs with "xcframework" in the name.
+
+**For backwards compatibility,** provide the plain frameworks build _first_ (i.e. not as an alt URL), so that older versions of Carthage use it. Carthage versions prior to 0.38.0 fail to download and extract XCFrameworks.
+
 #### Example binary project specification
 
 ```
 {
 	"1.0": "https://my.domain.com/release/1.0.0/framework.zip",
-	"1.0.1": "https://my.domain.com/release/1.0.1/framework.zip"
+	"1.0.1": "https://my.domain.com/release/1.0.1/MyFramework.framework.zip?alt=https://my.domain.com/release/1.0.1/MyFramework.xcframework.zip"
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Carthage can automatically use prebuilt frameworks, instead of building from scr
 To offer prebuilt frameworks for a specific tag, the binaries for _all_ supported platforms should be zipped up together into _one_ archive, and that archive should be attached to a published Release corresponding to that tag. The attachment should include `.framework` in its name (e.g., `ReactiveCocoa.framework.zip`), to indicate to Carthage that it contains binaries. The directory structure of the archive is free form but, __frameworks should only appear once in the archive__ as they will be copied
 to `Carthage/Build/<platform>` based on their name (e.g. `ReactiveCocoa.framework`).
 
+To offer prebuilt XCFrameworks, build with `--use-xcframeworks` and follow the same process to zip up all XCFrameworks into one archive. Include `.xcframework` in the attachment name. Starting in version 0.38.0, Carthage prefers downloading `.xcframework` attachments when `--use-xcframeworks` is passed.
+
 You can perform the archiving operation with carthage itself using:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Carthage builds your dependencies and provides you with binary frameworks, but y
 	- [Share your Xcode schemes](#share-your-xcode-schemes)
 	- [Resolve build failures](#resolve-build-failures)
 	- [Tag stable releases](#tag-stable-releases)
-	- [Archive prebuilt frameworks into one zip file](#archive-prebuilt-frameworks-into-one-zip-file)
+	- [Archive prebuilt frameworks into zip files](#archive-prebuilt-frameworks-into-zip-files)
 		- [Use travis-ci to upload your tagged prebuilt frameworks](#use-travis-ci-to-upload-your-tagged-prebuilt-frameworks)
 	- [Build static frameworks to speed up your app’s launch times](#build-static-frameworks-to-speed-up-your-apps-launch-times)
 	- [Declare your compatibility](#declare-your-compatibility)

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Carthage determines which versions of your framework are available by searching 
 
 Tags without any version number, or with any characters following the version number (e.g., `1.2-alpha-1`) are currently unsupported, and will be ignored.
 
-### Archive prebuilt frameworks into one zip file
+### Archive prebuilt frameworks into zip files
 
 Carthage can automatically use prebuilt frameworks, instead of building from scratch, if they are attached to a [GitHub Release](https://help.github.com/articles/about-releases/) on your project’s repository or via a binary project definition file.
 

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -44,6 +44,9 @@ public struct BinaryProject: Equatable {
 					guard let firstURL = components.url else {
 						return .failure(BinaryJSONError.invalidURL(value))
 					}
+					guard firstURL.scheme == "file" || firstURL.scheme == "https" else {
+						return .failure(BinaryJSONError.nonHTTPSURL(firstURL))
+					}
 					var binaryURLs: [URL] = [firstURL]
 
 					if let extractedURLs = extractedURLs {

--- a/Source/CarthageKit/BinaryProject.swift
+++ b/Source/CarthageKit/BinaryProject.swift
@@ -38,7 +38,7 @@ public struct BinaryProject: Equatable {
 					guard let string = components.string else {
 						return .failure(BinaryJSONError.invalidURL(value))
 					}
-					urlStrings.append(string)
+					urlStrings.insert(string, at: 0)
 					
 					var binaryURLs: [URL] = []
 					for string in urlStrings {

--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -4,5 +4,5 @@ import Foundation
 public struct CarthageKitVersion {
 	public let value: SemanticVersion
 
-	public static let current = CarthageKitVersion(value: SemanticVersion(0, 37, 0))
+	public static let current = CarthageKitVersion(value: SemanticVersion(0, 38, 0))
 }

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -114,10 +114,11 @@ public func binaryAssetPrioritizingReducer(_ asset: Release.Asset) -> (keyName: 
 
 	let priorities: KeyValuePairs = [".xcframework": 10 as UInt8, ".XCFramework": 10, ".XCframework": 10, ".framework": 40]
 
-	return (priorities.lazy.compactMap {
-		var (potentialPatternRange, keyName) = (asset.name.range(of: $0), asset.name)
-		guard let patternRange = potentialPatternRange else { return nil }
+	for (pathExtension, priority) in priorities {
+		var (potentialPatternRange, keyName) = (asset.name.range(of: pathExtension), asset.name)
+		guard let patternRange = potentialPatternRange else { continue }
 		keyName.removeSubrange(patternRange)
-		return (keyName, asset, $1)
-	} as LazyMapSequence).first
+		return (keyName, asset, priority)
+	}
+	return nil
 }

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -108,17 +108,3 @@ public struct Constants {
 		public static let binaryAssetContentTypes = ["application/zip", "application/x-zip-compressed", "application/octet-stream"]
 	}
 }
-
-public func binaryAssetPrioritizingReducer(_ asset: Release.Asset) -> (keyName: String, asset: Release.Asset, priority: UInt8)? {
-	guard Constants.Project.binaryAssetContentTypes.contains(asset.contentType) else { return nil }
-
-	let priorities: KeyValuePairs = [".xcframework": 10 as UInt8, ".XCFramework": 10, ".XCframework": 10, ".framework": 40]
-
-	for (pathExtension, priority) in priorities {
-		var (potentialPatternRange, keyName) = (asset.name.range(of: pathExtension), asset.name)
-		guard let patternRange = potentialPatternRange else { continue }
-		keyName.removeSubrange(patternRange)
-		return (keyName, asset, priority)
-	}
-	return nil
-}

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -98,7 +98,8 @@ public struct Constants {
 
 		/// The text that needs to exist in a GitHub Release asset's name, for it to be
 		/// tried as a binary framework.
-		public static let binaryAssetPattern = ".framework"
+		public static let frameworkBinaryAssetPattern = ".framework"
+		public static let xcframeworkBinaryAssetPattern = ".xcframework"
 
 		/// MIME types allowed for GitHub Release assets, for them to be considered as
 		/// binary frameworks.

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1,5 +1,6 @@
 // swiftlint:disable file_length
 
+import CommonCrypto
 import Foundation
 import Result
 import ReactiveSwift
@@ -1038,8 +1039,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 	/// Downloads the binary only framework file. Sends the URL to each downloaded zip, after it has been moved to a
 	/// less temporary location.
 	private func downloadBinary(dependency: Dependency, version: SemanticVersion, url: URL) -> SignalProducer<URL, CarthageError> {
-		let fileName = url.lastPathComponent
-		let fileURL = fileURLToCachedBinaryDependency(dependency, version, fileName)
+		let fileURL = downloadURLToCachedBinaryDependency(dependency, version, url)
 
 		if FileManager.default.fileExists(atPath: fileURL.path) {
 			return SignalProducer(value: fileURL)
@@ -1334,9 +1334,21 @@ private func fileURLToCachedBinary(_ dependency: Dependency, _ release: Release,
 }
 
 /// Constructs a file URL to where the binary only framework download should be cached
-private func fileURLToCachedBinaryDependency(_ dependency: Dependency, _ semanticVersion: SemanticVersion, _ fileName: String) -> URL {
-	// ~/Library/Caches/org.carthage.CarthageKit/binaries/MyBinaryProjectFramework/2.3.1/MyBinaryProject.framework.zip
-	return Constants.Dependency.assetsURL.appendingPathComponent("\(dependency.name)/\(semanticVersion)/\(fileName)")
+private func downloadURLToCachedBinaryDependency(_ dependency: Dependency, _ semanticVersion: SemanticVersion, _ url: URL) -> URL {
+  var urlString = url.absoluteString
+  var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
+  _ = digest.withUnsafeMutableBytes { buffer in
+    urlString.withUTF8 { data in
+      CC_SHA256(UnsafeRawPointer(data.baseAddress!), CC_LONG(data.count), buffer)
+    }
+  }
+  let hexDigest = digest.map { String(format: "%02hhx", $0) }.joined()
+  let fileName = url.deletingPathExtension().lastPathComponent
+  let fileExtension = url.pathExtension
+
+	// ~/Library/Caches/org.carthage.CarthageKit/binaries/MyBinaryProjectFramework/2.3.1/MyBinaryProject.framework-578d2a1e3a62983f70dfd8d0b04531b77615cc381edd603813657372d40a8fa1.zip
+	return Constants.Dependency.assetsURL
+    .appendingPathComponent("\(dependency.name)/\(semanticVersion)/\(fileName)-\(hexDigest).\(fileExtension)")
 }
 
 /// Caches the downloaded binary at the given URL, moving it to the other URL

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1340,20 +1340,20 @@ private func fileURLToCachedBinary(_ dependency: Dependency, _ release: Release,
 
 /// Constructs a file URL to where the binary only framework download should be cached
 private func downloadURLToCachedBinaryDependency(_ dependency: Dependency, _ semanticVersion: SemanticVersion, _ url: URL) -> URL {
-  var urlString = url.absoluteString
-  var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
-  _ = digest.withUnsafeMutableBytes { buffer in
-    urlString.withUTF8 { data in
-      CC_SHA256(UnsafeRawPointer(data.baseAddress!), CC_LONG(data.count), buffer)
-    }
-  }
-  let hexDigest = digest.map { String(format: "%02hhx", $0) }.joined()
-  let fileName = url.deletingPathExtension().lastPathComponent
-  let fileExtension = url.pathExtension
+	let urlBytes = url.absoluteString.utf8CString
+	var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
+	_ = digest.withUnsafeMutableBytes { buffer in
+		urlBytes.withUnsafeBytes { data in
+			CC_SHA256(data.baseAddress!, CC_LONG(urlBytes.count), buffer)
+		}
+	}
+	let hexDigest = digest.map { String(format: "%02hhx", $0) }.joined()
+	let fileName = url.deletingPathExtension().lastPathComponent
+	let fileExtension = url.pathExtension
 
 	// ~/Library/Caches/org.carthage.CarthageKit/binaries/MyBinaryProjectFramework/2.3.1/MyBinaryProject.framework-578d2a1e3a62983f70dfd8d0b04531b77615cc381edd603813657372d40a8fa1.zip
 	return Constants.Dependency.assetsURL
-    .appendingPathComponent("\(dependency.name)/\(semanticVersion)/\(fileName)-\(hexDigest).\(fileExtension)")
+		.appendingPathComponent("\(dependency.name)/\(semanticVersion)/\(fileName)-\(hexDigest).\(fileExtension)")
 }
 
 /// Caches the downloaded binary at the given URL, moving it to the other URL

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -824,10 +824,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 						guard Constants.Project.binaryAssetContentTypes.contains(asset.contentType) else {
 							return
 						}
-						if asset.name.range(of: Constants.Project.frameworkBinaryAssetPattern) != nil {
-							assetsByPackageType[.framework, default: []].append(asset)
-						} else if asset.name.range(of: Constants.Project.xcframeworkBinaryAssetPattern) != nil {
+						if asset.name.range(of: Constants.Project.xcframeworkBinaryAssetPattern, options: .caseInsensitive) != nil {
 							assetsByPackageType[.xcframework, default: []].append(asset)
+						} else if asset.name.range(of: Constants.Project.frameworkBinaryAssetPattern, options: .caseInsensitive) != nil {
+							assetsByPackageType[.framework, default: []].append(asset)
 						}
 					}
 					.flatMap(.concat) { assetsByPackageType -> SignalProducer<Release.Asset, CarthageError> in

--- a/Source/carthage/Extensions.swift
+++ b/Source/carthage/Extensions.swift
@@ -95,15 +95,15 @@ internal struct ProjectEventSink {
 
 		case let .downloadingBinaries(dependency, release):
 			carthage.println(formatting.bullets + "Downloading " + formatting.projectName(dependency.name)
-				+ ".framework binary at " + formatting.quote(release))
+				+ " binary at " + formatting.quote(release))
 
 		case let .skippedDownloadingBinaries(dependency, message):
 			carthage.println(formatting.bullets + "Skipped downloading " + formatting.projectName(dependency.name)
-				+ ".framework binary due to the error:\n\t" + formatting.quote(message))
+				+ " binary due to the error:\n\t" + formatting.quote(message))
 
 		case let .skippedInstallingBinaries(dependency, error):
 			let output = """
-			\(formatting.bullets) Skipped installing \(formatting.projectName(dependency.name)).framework binary due to the error:
+			\(formatting.bullets) Skipped installing \(formatting.projectName(dependency.name)) binary due to the error:
 				\(formatting.quote(String(describing: error)))
 
 			    Falling back to building from the source

--- a/Tests/CarthageKitTests/BinaryProjectSpec.swift
+++ b/Tests/CarthageKitTests/BinaryProjectSpec.swift
@@ -11,15 +11,24 @@ class BinaryProjectSpec: QuickSpec {
 				let jsonData = (
 					"{" +
 					"\"1.0\": \"https://my.domain.com/release/1.0.0/framework.zip\"," +
-					"\"1.0.1\": \"https://my.domain.com/release/1.0.1/framework.zip\"" +
+					"\"1.0.1\": \"https://my.domain.com/release/1.0.1/framework.zip?alt=https://my.domain.com/release/1.0.1/xcframework.zip&alt=https://my.domain.com/some/other/alternate.zip\"," +
+					"\"1.0.2\": \"https://my.domain.com/release/1.0.2/framework.zip?alt=https%3A%2F%2Fmy.domain.com%2Frelease%2F1.0.2%2Fxcframework.zip\"" +
 					"}"
 					).data(using: .utf8)!
 
 				let actualBinaryProject = BinaryProject.from(jsonData: jsonData).value
 
 				let expectedBinaryProject = BinaryProject(versions: [
-					PinnedVersion("1.0"): URL(string: "https://my.domain.com/release/1.0.0/framework.zip")!,
-					PinnedVersion("1.0.1"): URL(string: "https://my.domain.com/release/1.0.1/framework.zip")!,
+					PinnedVersion("1.0"): [URL(string: "https://my.domain.com/release/1.0.0/framework.zip")!],
+					PinnedVersion("1.0.1"): [
+						URL(string: "https://my.domain.com/release/1.0.1/framework.zip")!,
+						URL(string: "https://my.domain.com/release/1.0.1/xcframework.zip")!,
+						URL(string: "https://my.domain.com/some/other/alternate.zip")!,
+					],
+					PinnedVersion("1.0.2"): [
+						URL(string: "https://my.domain.com/release/1.0.1/framework.zip")!,
+						URL(string: "https://my.domain.com/release/1.0.1/xcframework.zip")!
+					],
 				])
 
 				expect(actualBinaryProject) == expectedBinaryProject
@@ -79,7 +88,7 @@ class BinaryProjectSpec: QuickSpec {
 				let actualBinaryProject = BinaryProject.from(jsonData: jsonData).value
 
 				let expectedBinaryProject = BinaryProject(versions: [
-					PinnedVersion("1.0"): URL(string: "file:///my/domain/com/framework.zip")!,
+					PinnedVersion("1.0"): [URL(string: "file:///my/domain/com/framework.zip")!],
 				])
 
 				expect(actualBinaryProject) == expectedBinaryProject

--- a/Tests/CarthageKitTests/BinaryProjectSpec.swift
+++ b/Tests/CarthageKitTests/BinaryProjectSpec.swift
@@ -26,8 +26,8 @@ class BinaryProjectSpec: QuickSpec {
 						URL(string: "https://my.domain.com/some/other/alternate.zip")!,
 					],
 					PinnedVersion("1.0.2"): [
-						URL(string: "https://my.domain.com/release/1.0.1/framework.zip")!,
-						URL(string: "https://my.domain.com/release/1.0.1/xcframework.zip")!
+						URL(string: "https://my.domain.com/release/1.0.2/framework.zip")!,
+						URL(string: "https://my.domain.com/release/1.0.2/xcframework.zip")!
 					],
 				])
 

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -456,8 +456,8 @@ class ProjectSpec: QuickSpec {
 				let actualDefinition = project.downloadBinaryFrameworkDefinition(binary: binary).first()?.value
 
 				let expectedBinaryProject = BinaryProject(versions: [
-					PinnedVersion("1.0"): URL(string: "https://my.domain.com/release/1.0.0/framework.zip")!,
-					PinnedVersion("1.0.1"): URL(string: "https://my.domain.com/release/1.0.1/framework.zip")!,
+					PinnedVersion("1.0"): [URL(string: "https://my.domain.com/release/1.0.0/framework.zip")!],
+					PinnedVersion("1.0.1"): [URL(string: "https://my.domain.com/release/1.0.1/framework.zip")!],
 				])
 				expect(actualDefinition) == expectedBinaryProject
 			}


### PR DESCRIPTION
Bumps version to 0.38.0

Small behavior change that came up while working on release notes for #3123: Currently, Carthage will only download prebuilt assets whose names contain `.framework`. Now, it'll also download assets whose names  `.xcframework`. If a release has both framework and xcframework assets, it'll choose which set to download based the --use-xcframeworks flag.