### PR TITLE
Binary projects: Fall back to an xcframework when nothing else is available

### DIFF
--- a/IntegrationTests/binary.bats
+++ b/IntegrationTests/binary.bats
@@ -4,7 +4,7 @@ setup() {
     cd $BATS_TMPDIR
     rm -rf BinaryTest
     mkdir BinaryTest && cd BinaryTest
-    echo 'binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"' > Cartfile
+    echo 'binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" == 7.4.0' > Cartfile
 }
 
 teardown() {

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -1712,9 +1712,9 @@ extension URL: AssetNameConvertible {
 
 	// Binary dependencies must pick an XCFramework if it's the only asset available. Otherwise, Carthage will download
 	// nothing unless --use-xcframeworks is passed.
-	static var skipsUnwantedXCFrameworks: Bool { false }
+	static var skipsUnwantedXCFrameworks: Bool { return false }
 }
 extension Release.Asset: AssetNameConvertible {
 	// GitHub releases should skip downloading and fall back to building from source if only an XCFramework is available.
-	static var skipsUnwantedXCFrameworks: Bool { true }
+	static var skipsUnwantedXCFrameworks: Bool { return true }
 }


### PR DESCRIPTION
The logic introduced in #3152 attempts to avoid downloading an xcframework when a user didn't ask for one. This is acceptable for GitHub Releases, where a source fallback is available, but not for xcframework-only binary projects. Projects which only advertise an XCFramework appear to succeed but download nothing when built without `--use-xcframeworks`:

```
carthage build Foo 
*** xcodebuild output can be found in /var/folders/qt/83cpf99j101_gkm4n6d67x68z90dks/T/carthage-xcodebuild.QLjLO8.log
*** Downloading binary-only framework MarketingCloudSDK at "https://example.com/Foo.json"
```

(Notice that there's no `*** Downloading Foo binary at "x.y.z"` event indicating that an actual binary was downloaded.)

Fixed by causing binaryAssetFilter to behave differently for binary project URLs, and select unwanted xcframework releases as a last resort.