### PR TITLE
Download multiple GitHub assets and organize static framework assets

### DIFF
--- a/IntegrationTests/build.bats
+++ b/IntegrationTests/build.bats
@@ -5,6 +5,7 @@ setup() {
 }
 
 teardown() {
+    rm -f Cartfile Cartfile.resolved
     cd $BATS_TEST_DIRNAME
 }
 
@@ -16,4 +17,17 @@ EOF
     run carthage bootstrap --platform ios
     [ "$status" -eq 0 ]
     [ -e Carthage/Build/iOS/MMMarkdown.framework ]
+}
+
+@test "carthage build downloads multiple github release assets" {
+    cat >| Cartfile <<-EOF
+github "ReactiveX/RxSwift" == 6.1.0
+EOF
+    run carthage bootstrap --platform ios --use-xcframeworks
+    [ "$status" -eq 0 ]
+    [ -e Carthage/Build/RxTest.xcframework ]
+    [ -e Carthage/Build/RxSwift.xcframework ]
+    [ -e Carthage/Build/RxCocoaRuntime.xcframework ]
+    [ -e Carthage/Build/RxCocoa.xcframework ]
+    [ -e Carthage/Build/RxBlocking.xcframework ]
 }


### PR DESCRIPTION
AFAICT, we have never supported downloading more than one GitHub release asset. @ikesyo mentioned changing the restriction years ago (https://github.com/Carthage/Carthage/pull/1005#issuecomment-165670401) but I can't find a point where it was discussed beyond this mention.

While Carthage _does_ parse multiple github release assets, it [picks the first one and discards the others](https://github.com/Carthage/Carthage/blob/9a3d1799ba8f8b9e2d4514cfa53a2cca6064136e/Source/CarthageKit/Project.swift#L780). I think this behavior is kinda confusing and unintuitive, and there are some projects whose binary downloads are broken because of it:

- RxSwift since v6.0.0: https://github.com/ReactiveX/RxSwift/releases/tag/6.0.0
- Adjust: https://github.com/adjust/ios_sdk/releases/tag/v4.29.2

This change causes Carthage to download and extract all the framework assets it finds on a GitHub release.

Additionally, this change causes Carthage to correctly place static frameworks from binary packages in the `Static/` directory, like it does for locally-built static frameworks. This will break existing projects which integrate static frameworks from binary packages, but the remediation is easy—they'll just need to update the framework's path in Xcode.

