### PR TITLE
Use modern Alamofire version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Carthage builds your dependencies and provides you with binary frameworks, but y
 1. List the desired dependencies in the [Cartfile][], for example:
 
 	```
-	github "Alamofire/Alamofire" ~> 5.4
+	github "Alamofire/Alamofire" ~> 5.5
 	```
 
 1. Run `carthage update --use-xcframeworks`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Carthage builds your dependencies and provides you with binary frameworks, but y
 1. List the desired dependencies in the [Cartfile][], for example:
 
 	```
-	github "Alamofire/Alamofire" ~> 4.7.2
+	github "Alamofire/Alamofire" ~> 5.4
 	```
 
 1. Run `carthage update --use-xcframeworks`


### PR DESCRIPTION
Thanks for the mention, but Alamofire 4 is no longer recommended, so this PR update the README to use Alamofire 5 in the example.