### PR TITLE
Add "--valid-simulator-archs" as a workaround for arm simulator issue

### DIFF
--- a/Source/CarthageKit/BuildOptions.swift
+++ b/Source/CarthageKit/BuildOptions.swift
@@ -18,6 +18,8 @@ public struct BuildOptions {
 	public var useBinaries: Bool
 	/// Whether to create an XCFramework instead of lipoing built products.
 	public var useXCFrameworks: Bool
+	/// Explicitly metntion architectures for simulator
+	public var validSimulatorArchs: String?
 
 	public init(
 		configuration: String,
@@ -26,7 +28,8 @@ public struct BuildOptions {
 		derivedDataPath: String? = nil,
 		cacheBuilds: Bool = true,
 		useBinaries: Bool = true,
-		useXCFrameworks: Bool = false
+		useXCFrameworks: Bool = false,
+		validSimulatorArchs: String? = nil
 	) {
 		self.configuration = configuration
 		self.platforms = platforms
@@ -35,5 +38,6 @@ public struct BuildOptions {
 		self.cacheBuilds = cacheBuilds
 		self.useBinaries = useBinaries
 		self.useXCFrameworks = useXCFrameworks
+		self.validSimulatorArchs = validSimulatorArchs
 	}
 }

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -739,7 +739,11 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 					fatalError("Could not find simulator SDK in \(sdks)")
 				}
 
-				return settingsByTarget(build(sdk: deviceSDK, with: buildArgs, in: workingDirectoryURL))
+				let buildForDeviceArgs = buildArgs
+				var buildForSimulatorArgs = buildArgs
+				buildForSimulatorArgs.validArchs = options.validSimulatorArchs
+
+				return settingsByTarget(build(sdk: deviceSDK, with: buildForDeviceArgs, in: workingDirectoryURL))
 					.flatMap(.concat) { settingsEvent -> SignalProducer<TaskEvent<(BuildSettings, BuildSettings)>, CarthageError> in
 						switch settingsEvent {
 						case let .launch(task):
@@ -754,7 +758,7 @@ public func buildScheme( // swiftlint:disable:this function_body_length cyclomat
 						case let .success(deviceSettingsByTarget):
 							return settingsByTarget(
 								build(sdk: simulatorSDK,
-									  with: buildArgs,
+									  with: buildForSimulatorArgs,
 									  in: workingDirectoryURL)
 								)
 								.flatMapTaskEvents(.concat) { (simulatorSettingsByTarget: [String: BuildSettings]) -> SignalProducer<(BuildSettings, BuildSettings), CarthageError> in

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -53,6 +53,10 @@ public struct BuildArguments {
 	/// the native architecture.
 	public var onlyActiveArchitecture: Bool?
 
+	/// The build setting whether the product should exclude some particular archs.
+	/// Primarily used for excluding arm64 architecture from iOS Simulator target
+	public var validArchs: String?
+
 	/// The build setting whether full bitcode should be embedded in the binary.
 	public var bitcodeGenerationMode: BitcodeGenerationMode?
 
@@ -129,6 +133,10 @@ public struct BuildArguments {
 			} else {
 				args += [ "ONLY_ACTIVE_ARCH=NO" ]
 			}
+		}
+
+		if let validArchs = validArchs {
+			args += ["VALID_ARCHS=\(validArchs)"]
 		}
 
 		// Disable code signing requirement for all builds

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -25,6 +25,7 @@ extension BuildOptions: OptionsProtocol {
 			<*> mode <| Option(key: "cache-builds", defaultValue: false, usage: "use cached builds when possible")
 			<*> mode <| Option(key: "use-binaries", defaultValue: true, usage: "don't use downloaded binaries when possible")
 			<*> mode <| Option(key: "use-xcframeworks", defaultValue: false, usage: "create xcframework bundles instead of one framework per platform (requires Xcode 12+)")
+			<*> mode <| Option<String?>(key: "valid-simulator-archs", defaultValue: nil, usage: "explicitly list architectures valid for simulator")
 	}
 }
 

--- a/Tests/CarthageKitTests/ArchiveSpec.swift
+++ b/Tests/CarthageKitTests/ArchiveSpec.swift
@@ -35,7 +35,7 @@ class ArchiveSpec: QuickSpec {
 			let archiveURL = temporaryURL.appendingPathComponent("archive.zip", isDirectory: false)
 
 			beforeEach {
-				expect { try FileManager.default.createDirectory(atPath: temporaryURL.path, withIntermediateDirectories: true, attributes: nil) }.notTo(throwError())
+				expect(expression: {try FileManager.default.createDirectory(atPath: temporaryURL.path, withIntermediateDirectories: true, attributes: nil) }).notTo(throwError())
 				expect(FileManager.default.changeCurrentDirectoryPath(temporaryURL.path)) == true
 				return
 			}
@@ -48,13 +48,13 @@ class ArchiveSpec: QuickSpec {
 
 			it("should zip relative paths into an archive") {
 				let subdirPath = "subdir"
-				expect { try FileManager.default.createDirectory(atPath: subdirPath, withIntermediateDirectories: true) }.notTo(throwError())
+				expect(expression: { try FileManager.default.createDirectory(atPath: subdirPath, withIntermediateDirectories: true) }).notTo(throwError())
 
 				let innerFilePath = (subdirPath as NSString).appendingPathComponent("inner")
-				expect { try "foobar".write(toFile: innerFilePath, atomically: true, encoding: .utf8) }.notTo(throwError())
+				expect(expression: { try "foobar".write(toFile: innerFilePath, atomically: true, encoding: .utf8) }).notTo(throwError())
 
 				let outerFilePath = "outer"
-				expect { try "foobar".write(toFile: outerFilePath, atomically: true, encoding: .utf8) }.notTo(throwError())
+				expect(expression: { try "foobar".write(toFile: outerFilePath, atomically: true, encoding: .utf8) }).notTo(throwError())
 
 				let result = zip(paths: [ innerFilePath, outerFilePath ], into: archiveURL, workingDirectory: temporaryURL.path).wait()
 				expect(result.error).to(beNil())
@@ -81,11 +81,11 @@ class ArchiveSpec: QuickSpec {
 
 			it("should preserve symlinks") {
 				let destinationPath = "symlink-destination"
-				expect { try "foobar".write(toFile: destinationPath, atomically: true, encoding: .utf8) }.notTo(throwError())
+				expect(expression: { try "foobar".write(toFile: destinationPath, atomically: true, encoding: .utf8) }).notTo(throwError())
 
 				let symlinkPath = "symlink"
-				expect { try FileManager.default.createSymbolicLink(atPath: symlinkPath, withDestinationPath: destinationPath) }.notTo(throwError())
-				expect { try FileManager.default.destinationOfSymbolicLink(atPath: symlinkPath) } == destinationPath
+				expect(expression: { try FileManager.default.createSymbolicLink(atPath: symlinkPath, withDestinationPath: destinationPath)}).notTo(throwError())
+				expect(expression: { try FileManager.default.destinationOfSymbolicLink(atPath: symlinkPath)}) == destinationPath
 
 				let result = zip(paths: [ symlinkPath, destinationPath ], into: archiveURL, workingDirectory: temporaryURL.path).wait()
 				expect(result.error).to(beNil())
@@ -96,7 +96,7 @@ class ArchiveSpec: QuickSpec {
 
 				let unzippedSymlinkURL = (unzipResult?.value ?? temporaryURL).appendingPathComponent(symlinkPath)
 				expect(FileManager.default.fileExists(atPath: unzippedSymlinkURL.path)) == true
-				expect { try FileManager.default.destinationOfSymbolicLink(atPath: unzippedSymlinkURL.path) } == destinationPath
+				expect(expression: { try FileManager.default.destinationOfSymbolicLink(atPath: unzippedSymlinkURL.path) }) == destinationPath
 			}
 		}
 	}

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -21,7 +21,7 @@ class ProjectSpec: QuickSpec {
 
 			func build(directoryURL url: URL, platforms: Set<SDK>? = nil, cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [String] {
 				let project = Project(directoryURL: url)
-				let result = project.buildCheckedOutDependenciesWithOptions(BuildOptions(configuration: "Debug", platforms: platforms, cacheBuilds: cacheBuilds), dependenciesToBuild: dependenciesToBuild)
+				let result = project.buildCheckedOutDependenciesWithOptions(BuildOptions(configuration: "Debug", platforms: platforms, cacheBuilds: cacheBuilds, validSimulatorArchs: "i386 x86_64"), dependenciesToBuild: dependenciesToBuild)
 					.ignoreTaskData()
 					.on(value: { project, scheme in
 						NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -355,7 +355,9 @@ class ProjectSpec: QuickSpec {
 			let dependency = Dependency.git(GitURL(repositoryURL.absoluteString))
 
 			func initRepository() {
-				expect { try FileManager.default.createDirectory(atPath: repositoryURL.path, withIntermediateDirectories: true) }.notTo(throwError())
+				expect(expression: {
+					try FileManager.default.createDirectory(atPath: repositoryURL.path, withIntermediateDirectories: true)
+				}).notTo(throwError())
 				_ = launchGitTask([ "init" ], repositoryFileURL: repositoryURL).wait()
 			}
 
@@ -385,7 +387,9 @@ class ProjectSpec: QuickSpec {
 			}
 
 			beforeEach {
-				expect { try FileManager.default.createDirectory(atPath: temporaryURL.path, withIntermediateDirectories: true) }.notTo(throwError())
+				expect(expression: {
+					try FileManager.default.createDirectory(atPath: temporaryURL.path, withIntermediateDirectories: true)
+				}).notTo(throwError())
 				initRepository()
 			}
 

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -21,7 +21,9 @@ class XcodeSpec: QuickSpec {
 
 		beforeEach {
 			_ = try? FileManager.default.removeItem(at: buildFolderURL)
-			expect { try FileManager.default.createDirectory(atPath: targetFolderURL.path, withIntermediateDirectories: true) }.notTo(throwError())
+			expect(expression: {
+				try FileManager.default.createDirectory(atPath: targetFolderURL.path, withIntermediateDirectories: true)
+			}).notTo(throwError())
 		}
 
 		afterEach {
@@ -162,7 +164,7 @@ class XcodeSpec: QuickSpec {
 			let version = PinnedVersion("0.1")
 
 			for dependency in dependencies {
-				let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug"))
+				let result = build(dependency: dependency, version: version, directoryURL, withOptions: BuildOptions(configuration: "Debug", validSimulatorArchs: "i386 x86_64"))
 					.ignoreTaskData()
 					.on(value: { project, scheme in // swiftlint:disable:this end_closure
 						NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -172,7 +174,7 @@ class XcodeSpec: QuickSpec {
 				expect(result.error).to(beNil())
 			}
 
-			let result = buildInDirectory(directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
+			let result = buildInDirectory(directoryURL, withOptions: BuildOptions(configuration: "Debug", validSimulatorArchs: "i386 x86_64"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this closure_params_parantheses
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -269,7 +271,7 @@ class XcodeSpec: QuickSpec {
 			let multipleSubprojects = "SampleMultipleSubprojects"
 			let _directoryURL = Bundle(for: type(of: self)).url(forResource: multipleSubprojects, withExtension: nil)!
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug", validSimulatorArchs: "i386 x86_64"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")
@@ -295,7 +297,7 @@ class XcodeSpec: QuickSpec {
 			let dependency = "SchemeDiscoverySampleForCarthage"
 			let _directoryURL = Bundle(for: type(of: self)).url(forResource: "\(dependency)-0.2", withExtension: nil)!
 
-			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug"), rootDirectoryURL: directoryURL)
+			let result = buildInDirectory(_directoryURL, withOptions: BuildOptions(configuration: "Debug", validSimulatorArchs: "i386 x86_64"), rootDirectoryURL: directoryURL)
 				.ignoreTaskData()
 				.on(value: { project, scheme in // swiftlint:disable:this end_closure
 					NSLog("Building scheme \"\(scheme)\" in \(project)")

--- a/Tests/XCDBLDTests/BuildArgumentsSpec.swift
+++ b/Tests/XCDBLDTests/BuildArgumentsSpec.swift
@@ -98,6 +98,12 @@ class BuildArgumentsSpec: QuickSpec {
 					subject.onlyActiveArchitecture = false
 				}
 			}
+
+			describe("specifying validArchs") {
+				itCreatesBuildArguments("includes VALID_ARCHS if given", arguments: ["VALID_ARCHS=x86_64 i386"]) { subject in
+					subject.validArchs = "x86_64 i386"
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
There is a known issue, that `lipo` is unable to build a fat binary when used with Xcode 12 or later. It does happen due to a fact, that the recent xcodebuild supports also modern MacBooks, which are having arm64 CPU. 

There are two known workarounds:
1. Use XCFramework
2. Exclude arm64 architecture when building for iOS simulator

Considering migration to XCFrameworks as a task that takes time, the latter options is widely used as a workaround — corresponding script was introduced as a wrapper for carthage binary.

In thi PR I would like to introduce a useful option for carthage to explicitly specify target architectures for simulator, which might also be used as a workaround for the mentioned issue. The flag allows to list the valid architectures for iOS Simulator target only.

Example:
```
~$ carthage bootstrap --valid-simulator-archs "i386 x86_64"
```

I have also added this option for some test fixtures, to be able to run all tests on my local machine, using Xcode 12.