### PR TITLE
changed concurrent signal to concat, as concurrent ruins the sort order

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -208,7 +208,7 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 	precondition(directoryURL.isFileURL)
 	let locator = ProjectLocator
 			.locate(in: directoryURL)
-			.flatMap(.concurrent(limit: 4)) { project -> SignalProducer<(ProjectLocator, [Scheme]), CarthageError> in
+			.flatMap(.concat) { project -> SignalProducer<(ProjectLocator, [Scheme]), CarthageError> in
 				return project
 					.schemes()
 					.collect()
@@ -222,6 +222,7 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 					.map { (project, $0) }
 			}
 			.replayLazily(upTo: Int.max)
+
 	return locator
 		.collect()
 		// Allow dependencies which have no projects, not to error out with


### PR DESCRIPTION
This is a fix for #3181 

The ProjectLocator.locate() function is sorting projects/workspaces by directory level, however the SignalProducer is then processing those concurrently effectively breaking the sort order.