### PR TITLE
buildableSchemesInDirectory: Fix scheme-selection race condition

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -221,6 +221,10 @@ public func buildableSchemesInDirectory( // swiftlint:disable:this function_body
 					}
 					.map { (project, $0) }
 			}
+			.collect()
+			// Send project-scheme pairs in ProjectLocator priority order, not the random order the projects were loaded in.
+			.map { pairs in pairs.sorted(by: { $0.0 < $1.0 }) }
+			.flatten()
 			.replayLazily(upTo: Int.max)
 	return locator
 		.collect()


### PR DESCRIPTION
In #3076, we started loading projects concurrently to speed up scheme selection in repos containing multiple projects. This introduced a race condition where Carthage would consider whichever project loaded _first_ to be the optimal project to build from, instead of using the sorted order of `ProjectLocator` objects.

Fixes #3211 by re-sorting the project-scheme pairs that are emitted in `buildableSchemesInDirectory`.