### PR TITLE
Store static xcframework builds separately

### DIFF
--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -608,7 +608,8 @@ private func mergeBuildProducts(
 /// in `directoryURL`. Sends the xcframework's URL when complete.
 private func mergeIntoXCFramework(in directoryURL: URL, settings: BuildSettings) -> SignalProducer<URL, CarthageError> {
 	let xcframework = SignalProducer(result: settings.productName).map { productName in
-		directoryURL.appendingPathComponent(productName).appendingPathExtension("xcframework")
+		return settings.productDestinationPath(in: directoryURL)
+			.appendingPathComponent(productName).appendingPathExtension("xcframework")
 	}
 	let framework = SignalProducer(result: settings.wrapperURL.map({ $0.resolvingSymlinksInPath() }))
 


### PR DESCRIPTION
Some projects ship two schemes which build the framework separately—once as a dylib, and once as a static object. Users then choose which variant of the framework they want to integrate with. Carthage organizes static framework bundles into a separate directory (`Carthage/Build/<platform>/Static/Foo.framework`) to accommodate projects like these without causing a collision, where both schemes write to the same destination, but this behavior was never matched for XCFrameworks.

In addition to avoiding the path name collisions, this also makes it easier for users to understand which XCFrameworks should be embedded vs. which should only be linked to.

Fixes #3208.