### PR TITLE
Update command line tool build script to build both arm64 and x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ PREFIX?=/usr/local
 INTERNAL_PACKAGE=CarthageApp.pkg
 OUTPUT_PACKAGE=Carthage.pkg
 
-CARTHAGE_EXECUTABLE=./.build/release/carthage
+CARTHAGE_EXECUTABLE=./.build/apple/Products/release/carthage
 BINARIES_FOLDER=$(PREFIX)/bin
 
-SWIFT_BUILD_FLAGS=--configuration release -Xswiftc -suppress-warnings
+SWIFT_BUILD_FLAGS=--configuration release -Xswiftc -suppress-warnings --arch arm64 --arch x86_64
 
 SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED:=$(shell test -n "$${HOMEBREW_SDKROOT}" && echo should_be_flagged)
 ifeq ($(SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED), should_be_flagged)


### PR DESCRIPTION
Previously the `carthage` command line tool would be built to run on whatever architecture the local builder machine had, this PR changes to building a fat binary with both arm64 and x86_64

Fixes #3245