### PR TITLE
Fix issue where Carthage doesn’t build for watchOS or tvOS if bitcode is disabled in Xcode 14

### DIFF
--- a/Source/XCDBLD/XcodeVersion.swift
+++ b/Source/XCDBLD/XcodeVersion.swift
@@ -13,6 +13,10 @@ public struct XcodeVersion {
 		self.buildVersion = buildVersion
 	}
 
+	public var majorVersionNumber: Int? {
+		version.components(separatedBy: ".").first.flatMap(Int.init)
+	}
+
 	internal init?(xcodebuildOutput: String) {
 		let range = NSRange(xcodebuildOutput.startIndex..., in: xcodebuildOutput)
 		guard let match = XcodeVersion.regex.firstMatch(in: xcodebuildOutput, range: range) else {

--- a/Tests/XCDBLDTests/XcodeVersionSpec.swift
+++ b/Tests/XCDBLDTests/XcodeVersionSpec.swift
@@ -28,6 +28,13 @@ class XcodeVersionSpec: QuickSpec {
 					expect(version2?.buildVersion) == "9M189t"
 				}
 			}
+
+			describe("major version") {
+				it("should return correct major version") {
+					let version = XcodeVersion(xcodebuildOutput: "Xcode 8.3.2\nBuild version 8E2002")
+					expect(version?.majorVersionNumber) == 8
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Resolves #3292 