### PR TITLE
Bump up version to 0.39.0

### DIFF
--- a/Source/CarthageKit/CarthageKitVersion.swift
+++ b/Source/CarthageKit/CarthageKitVersion.swift
@@ -4,5 +4,5 @@ import Foundation
 public struct CarthageKitVersion {
 	public let value: SemanticVersion
 
-	public static let current = CarthageKitVersion(value: SemanticVersion(0, 38, 0))
+	public static let current = CarthageKitVersion(value: SemanticVersion(0, 39, 0))
 }


### PR DESCRIPTION

Bump up the version to 0.39.0 for the next release.
Diff : https://github.com/Carthage/Carthage/compare/0.38.0...a91d086ceaffef65c4a4a761108f3f32c519940c

This version includes #3293. It's important to fix watchOS and tvOS support on Xcode 14.

@Carthage/carthage 
It looks like no one has maintained it recently, So I'd like to release a newer version.
Could anyone who lives take a look at this PR?