### PR TITLE
avoid breaking lldb when copying the xcframeworks to other machines

### DIFF
--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -134,6 +134,10 @@ public struct BuildArguments {
 		// Disable code signing requirement for all builds
 		// Frameworks get signed in the copy-frameworks action
 		args += [ "CODE_SIGNING_REQUIRED=NO", "CODE_SIGN_IDENTITY=" ]
+        
+        // Avoid breaking lldb when copying the xcframeworks to other machines:
+        // https://github.com/facebook/facebook-ios-sdk/issues/1628
+        args += [ "SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO" ]
 
 		args += [ "CARTHAGE=YES" ]
 

--- a/Source/XCDBLD/BuildArguments.swift
+++ b/Source/XCDBLD/BuildArguments.swift
@@ -134,10 +134,10 @@ public struct BuildArguments {
 		// Disable code signing requirement for all builds
 		// Frameworks get signed in the copy-frameworks action
 		args += [ "CODE_SIGNING_REQUIRED=NO", "CODE_SIGN_IDENTITY=" ]
-        
-        // Avoid breaking lldb when copying the xcframeworks to other machines:
-        // https://github.com/facebook/facebook-ios-sdk/issues/1628
-        args += [ "SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO" ]
+
+		// Avoid breaking lldb when copying the xcframeworks to other machines:
+		// https://github.com/facebook/facebook-ios-sdk/issues/1628
+		args += [ "SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO" ]
 
 		args += [ "CARTHAGE=YES" ]
 


### PR DESCRIPTION
(debugging would also break when deleting the build intermediates from the cache, not just when transferring the xcframeworks to another machine)