### PR TITLE
Support visionOS by using `-destination xros/xrsimulator`. Make additive changes to XCBLD’s SDK.

### DIFF
--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -366,7 +366,7 @@ extension SDK {
 	/// - Note: As last ditch effort, try inside `/Applications/Xcode.app`, which might not exist.
 	/// - Note: Mostly, `xcodebuild -showsdks -json`-based `XCDBLD.SDK`s will be grabbed instead of
 	///         this signal reaching completion.
-	/// - Note: Will, where possible, draw from `SDK.knownIn2019YearSDKs` for 2019-era captialization.
+	/// - Note: Will, where possible, draw from `SDK.knownIn2023YearSDKs` for 2023-era captialization.
 	static let setFromFallbackXcodeprojBuildSettings: SignalProducer<Set<SDK>?, NoError> =
 		Task("/usr/bin/xcrun", arguments: ["--find", "xcodebuild"], environment: Environment.withoutActiveXcodeXCConfigFile)
 			.launch()
@@ -405,13 +405,13 @@ extension SDK {
 extension SDK {
 	/// - See: `SDK.setFromJSONShowSDKs`
 	/// - Note: Fallbacks are `SDK.setFromFallbackXcodeprojBuildSettings` and
-	///         hardcoded `SDK.knownIn2019YearSDKs`.
+	///         hardcoded `SDK.knownIn2023YearSDKs`.
 	static let setsFromJSONShowSDKsWithFallbacks: SignalProducer<Set<SDK>, NoError> =
 		SDK.setFromJSONShowSDKs
 			.concat(SDK.setFromFallbackXcodeprojBuildSettings)
 			.skip(while: { $0 == nil })
 			.take(first: 1)
 			.skipNil()
-			.reduce(into: SDK.knownIn2019YearSDKs) { $0 = $1 }
+			.reduce(into: SDK.knownIn2023YearSDKs) { $0 = $1 }
 			.replayLazily(upTo: 1)
 }

--- a/Source/CarthageKit/Simulator.swift
+++ b/Source/CarthageKit/Simulator.swift
@@ -43,9 +43,9 @@ internal func selectAvailableSimulator(of sdk: SDK, from data: Data) -> Simulato
 		let devices = jsonObject["devices"] else {
 		return nil
 	}
-	let platformName = sdk.platformSimulatorlessFromHeuristic
+
 	func reducePlatformNames(_ result: inout [String: [Simulator]], _ entry: (key: String, value: [Simulator])) {
-		guard let platformVersion = parsePlatformVersion(for: platformName, from: entry.key) else { return }
+		guard let platformVersion = parsePlatformVersion(for: sdk.simulatorJsonKeyUnderDevicesDictQuery, from: entry.key) else { return }
 		guard entry.value.contains(where: { $0.isAvailable }) else { return }
 		result[platformVersion] = entry.value
 	}

--- a/Source/CarthageKit/VersionFile.swift
+++ b/Source/CarthageKit/VersionFile.swift
@@ -541,7 +541,7 @@ public func createVersionFileForCommitish(
 					cachedFramework = CachedFramework(name: frameworkName, container: nil, libraryIdentifier: nil, hash: hash, linking: linking, swiftToolchainVersion: frameworkSwiftVersion)
 				case .xcframework(name: let container, libraryIdentifier: let identifier):
 					let targetOS = identifier.components(separatedBy: "-")[0]
-					platformName = SDK.associatedSetOfKnownIn2019YearSDKs(targetOS).first?.platformSimulatorlessFromHeuristic
+					platformName = SDK.associatedSetOfKnownIn2023YearSDKs(targetOS).first?.platformSimulatorlessFromHeuristic
 					cachedFramework = CachedFramework(name: frameworkName, container: container, libraryIdentifier: identifier, hash: hash, linking: nil, swiftToolchainVersion: frameworkSwiftVersion)
 				}
 				if let platformName = platformName, var frameworks = platformCaches[platformName] {

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -73,7 +73,7 @@ public struct ArchiveCommand: CommandProtocol {
 		return frameworks.flatMap(.merge) { frameworks -> SignalProducer<(), CarthageError> in
 			// TODO: Better warning/planning for compressing up archives with non-known-in-year-2019 platforms.
 			// NOTE: as of current, non-known-in-year-2019 platforms are not compressed and copied by this command.
-			return SignalProducer<SDK, CarthageError>(SDK.knownIn2019YearSDKs)
+			return SignalProducer<SDK, CarthageError>(SDK.knownIn2023YearSDKs)
 				.flatMap(.merge) { platform -> SignalProducer<String, CarthageError> in
 					return SignalProducer(frameworks).map { framework in
 						return (platform.relativePath as NSString).appendingPathComponent(framework)

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -239,7 +239,7 @@ extension BuildPlatform: ArgumentProtocol {
 
 			guard set.isDisjoint(with: ["all"]) else { throw CocoaError(.keyValueValidation) /* because not solely `all` */ }
 
-			let values = try set.lazy.map(SDK.associatedSetOfKnownIn2019YearSDKs).reduce(into: [] as Set<SDK>) {
+			let values = try set.lazy.map(SDK.associatedSetOfKnownIn2023YearSDKs).reduce(into: [] as Set<SDK>) {
 				guard $1.isEmpty == false else { throw CocoaError(.keyValueValidation) }
 				$0.formUnion($1)
 			}


### PR DESCRIPTION
• Move `selectAvailableSimulator` to a new query method `sdk.simulatorJsonKeyUnderDevicesDictQuery`

• Add knownIn2023Year APIs.

• Fix some whitespace that had spaces in a tabs-based file.

This should fix #3344