### PR TITLE
Fix Makefile to only pass `-static-stdlib` to `swiftc` when the old linker is `xcrun --find ld` returned.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED:=$(shell test -n "$${HOMEBREW_SDKROOT}
 ifeq ($(SWIFTPM_DISABLE_SANDBOX_SHOULD_BE_FLAGGED), should_be_flagged)
 SWIFT_BUILD_FLAGS+= --disable-sandbox
 endif
-SWIFT_STATIC_STDLIB_SHOULD_BE_FLAGGED:=$(shell test -d $$(dirname $$(xcrun --find swift))/../lib/swift_static/macosx && echo should_be_flagged)
+SWIFT_STATIC_STDLIB_SHOULD_BE_FLAGGED:=$(shell test -d $$(dirname $$(xcrun --find swift))/../lib/swift_static/macosx && (./script/strings_of_xcrun_find_ld.zsh | grep --quiet -e '^only one snapshot supported') && echo should_be_flagged)
 ifeq ($(SWIFT_STATIC_STDLIB_SHOULD_BE_FLAGGED), should_be_flagged)
 SWIFT_BUILD_FLAGS+= -Xswiftc -static-stdlib
 endif

--- a/script/copy-fixtures
+++ b/script/copy-fixtures
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/zsh --no-globalrcs --no-rcs
 #
 # Copies fixture projects into the test bundle directly, so they don't have to
 # be added to the Carthage workspace. This avoids confusing Xcode with
 # "subprojects" that are actually just originating from a fixture.
 
-if [[ -z $1 ]]; then
+if [[ -z "$1" ]]; then
     echo "Error: You must pass a destination directory."
     exit 1
 fi

--- a/script/strings_of_xcrun_find_ld.zsh
+++ b/script/strings_of_xcrun_find_ld.zsh
@@ -1,0 +1,8 @@
+#!/bin/zsh --no-globalrcs --no-rcs
+
+# if the new linker is there, then `dirname $(xcrun --find swift))/../lib/swift_static/macosx` should not be respected as the sentinel value it held in pre-«Xcode 15» days.
+# In a subsequent script — the Makefile — we look for '^only one snapshot supported' (which only exists in the old linker) to tell us.
+## See <https://github.com/apple-opensource/ld64/blame/8568ce3517546665f1f9e0f7ba1858889a305454/src/ld/Snapshot.cpp> for the old linker.
+## See <https://github.com/apple-oss-distributions/dyld/> for the new linker.
+
+(/usr/bin/xcrun --find ld | /usr/bin/xargs /usr/bin/strings) || true


### PR DESCRIPTION
_[This does not affect the runtime behavior of Carthage. Just compilation of 'Carthage as a tool itself.']_

If the new linker is there, then `dirname $(xcrun --find swift))/../lib/swift_static/macosx` should not be respected as the sentinel value it held in pre-«Xcode 15» days.

In the Makefile, we look for `'^only one snapshot supported'` (which only exists in the old linker) to tell us the old linker is present.

See <https://github.com/apple-opensource/ld64/blame/8568ce3517546665f1f9e0f7ba1858889a305454/src/ld/Snapshot.cpp> for the old linker. 

See <https://github.com/apple-oss-distributions/dyld/> for the new linker.

Closes <https://github.com/Carthage/Carthage/issues/3348>.