### PR TITLE
Fix Bad Credentials for public repository

### DIFF
--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -806,7 +806,7 @@ public final class Project { // swiftlint:disable:this type_body_length
 				case .doesNotExist:
 					return .empty
 
-				case let .apiError(_, _, error):
+				case let .apiError(statusCode, _, error) where statusCode != 401:
 					// Log the GitHub API request failure, not to error out,
 					// because that should not be fatal error.
 					self._projectEventsObserver.send(value: .skippedDownloadingBinaries(dependency, error.message))


### PR DESCRIPTION
Sometimes we can get bad credentials error for public repository, in this case carthage should try again with `Client(server: server, isAuthenticated: false)` instead of failure.

The code I'm modifying is initially introduced in this pull request https://github.com/Carthage/Carthage/pull/669 to fix the issue https://github.com/Carthage/Carthage/issues/465.

the CONTRIBUTING is not updated any more, 
```
xcodeproj && \
  open Carthage.xcodeproj
```
this doesn't work, I'm not able to run unit tests.

I can add some unit tests if needed.