### PR TITLE
Fix endianness typo in MachHeader unused computed property internal to CarthageKit.

### DIFF
--- a/Source/CarthageKit/MachHeader.swift
+++ b/Source/CarthageKit/MachHeader.swift
@@ -33,7 +33,7 @@ struct MachHeader {
 		return !is64BitHeader
 	}
 
-	var endianess: Endianness {
+	var endianness: Endianness {
 		return magic == MH_CIGAM_64 || magic == MH_CIGAM ? .big : .little
 	}
 }


### PR DESCRIPTION
Fix typo: endianess -> endianness