### PR TITLE
Update `-showBuildSettings` “Found no destinations for the scheme” pattern to permit more before “Found” and after “error” (due to Xcode 16 Beta 6 and beyond.)

### DIFF
--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -65,7 +65,7 @@ public struct BuildSettings {
 			.flatMapError { error in
 				switch error {
 				case let .shellTaskFailed(_, _, standardError):
-					let pattern = "error[:] [^\n]+Found no destinations for the scheme [^\n]+ and action [^\n]+[.]\n"
+					let pattern = "error[:] [^\n]*Found no destinations for the scheme [^\n]+ and action [^\n]+[.]\n"
 					guard Foundation.NSNotFound == NSRegularExpression.rangeOfFirstMatch(pattern: pattern, within: standardError).location else {
 						return SignalProducer.empty
 					}

--- a/Source/CarthageKit/BuildSettings.swift
+++ b/Source/CarthageKit/BuildSettings.swift
@@ -65,7 +65,7 @@ public struct BuildSettings {
 			.flatMapError { error in
 				switch error {
 				case let .shellTaskFailed(_, _, standardError):
-					let pattern = "error[:] Found no destinations for the scheme [^\n]+ and action [^\n]+[.]\n"
+					let pattern = "error[:] [^\n]+Found no destinations for the scheme [^\n]+ and action [^\n]+[.]\n"
 					guard Foundation.NSNotFound == NSRegularExpression.rangeOfFirstMatch(pattern: pattern, within: standardError).location else {
 						return SignalProducer.empty
 					}


### PR DESCRIPTION
The patch added for picking right targets in Xcode16 beta1 https://github.com/Carthage/Carthage/issues/3375 broke due to the change in the error message in Xcode 16 beta6. This modifies the pattern to match the message. Thanks to @apoltix for his suggestion [here](https://github.com/Carthage/Carthage/issues/3375#issuecomment-2317014794).